### PR TITLE
Disable all CI targets which do not run any tests

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -27,11 +27,11 @@ matrix:
     - env: T=devel/freebsd/12.1/1
     - env: T=devel/linux/centos6/1
     - env: T=devel/linux/centos7/1
-    - env: T=devel/linux/centos8/1
+    #- env: T=devel/linux/centos8/1
     - env: T=devel/linux/fedora31/1
     - env: T=devel/linux/fedora32/1
-    - env: T=devel/linux/opensuse15py2/1
-    - env: T=devel/linux/opensuse15/1
+    #- env: T=devel/linux/opensuse15py2/1
+    #- env: T=devel/linux/opensuse15/1
     - env: T=devel/linux/ubuntu1604/1
     - env: T=devel/linux/ubuntu1804/1
 


### PR DESCRIPTION
##### SUMMARY
In the nightly CI runs, the `centos8`, `opensuse15py2` and `opensuse15` targets always fail since no tests are run for them at all.

The obvious fix is to disable these targets. This improves the CI resource footprint of this repo as well :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
