### PR TITLE
[Backport from community.general] postgresql_set: fix a boolean default

### DIFF
--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -289,7 +289,7 @@ def main():
         name=dict(type='str', required=True),
         db=dict(type='str', aliases=['login_db']),
         value=dict(type='str'),
-        reset=dict(type='bool'),
+        reset=dict(type='bool', default=False),
         session_role=dict(type='str'),
         trust_input=dict(type='bool', default=True),
     )


### PR DESCRIPTION
##### SUMMARY
postgresql_set: fix a boolean default
Backport of https://github.com/ansible-collections/community.general/pull/1343 so **no review needed**

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/postgresql_set.py`