### PR TITLE
postgresql_query: add explanation how to pass undefined variables as NULLs to positional_args

### DIFF
--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -27,7 +27,6 @@ options:
     description:
     - List of values to be passed as positional arguments to the query.
       When the value is a list, it will be converted to PostgreSQL array.
-    - To pass NULL value, use C(null).
     - Mutually exclusive with I(named_args).
     type: list
     elements: raw
@@ -35,7 +34,6 @@ options:
     description:
     - Dictionary of key-value arguments to pass to the query.
       When the value is a list, it will be converted to PostgreSQL array.
-    - To pass NULL value, use C(null).
     - Mutually exclusive with I(positional_args).
     type: dict
   path_to_script:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -177,6 +177,10 @@ EXAMPLES = r'''
 # be undefined and you wish to set it as NULL, the constructions like
 # "{{ my_var if (my_var is defined) else none | default(none) }}"
 # will not work as expected substituting an empty string instead of NULL.
+# If possible, we suggest to use Ansible's DEFAULT_JINJA2_NATIVE configuration
+# (https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native).
+# Enabling it fixes this problem. If you cannot enable it, the following workaround
+# can be used.
 # You should precheck such a value and define it as NULL when undefined.
 # For example:
 - name: When undefined, set to NULL

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -172,6 +172,24 @@ EXAMPLES = r'''
     search_path:
     - app1
     - public
+
+# If you use a variable in positional_args / named_args that can
+# be undefined and you wish to set it as NULL, the constructions like
+# "{{ my_var if (my_var is defined) else none | default(none) }}"
+# will not work as expected substituting an empty string instead of NULL.
+# You should precheck such a value and define it as NULL when undefined.
+# For example:
+- name: When undefined, set to NULL
+  set_fact:
+    my_var: NULL
+    when: my_var is undefined
+
+# Then:
+- name: Insert a value using positional arguments
+  community.postgresql.postgresql_query:
+    query: INSERT INTO test_table (col1) VALUES (%s)
+    positional_args:
+    - '{{ my_var }}'
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -182,7 +182,7 @@ EXAMPLES = r'''
 - name: When undefined, set to NULL
   set_fact:
     my_var: NULL
-    when: my_var is undefined
+  when: my_var is undefined
 
 # Then:
 - name: Insert a value using positional arguments

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -27,6 +27,7 @@ options:
     description:
     - List of values to be passed as positional arguments to the query.
       When the value is a list, it will be converted to PostgreSQL array.
+    - To pass NULL value, use C(null).
     - Mutually exclusive with I(named_args).
     type: list
     elements: raw
@@ -34,6 +35,7 @@ options:
     description:
     - Dictionary of key-value arguments to pass to the query.
       When the value is a list, it will be converted to PostgreSQL array.
+    - To pass NULL value, use C(null).
     - Mutually exclusive with I(positional_args).
     type: dict
   path_to_script:

--- a/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
+++ b/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
@@ -243,14 +243,14 @@
     query: INSERT INTO test_table (id, story) VALUES (%s, %s)
     positional_args:
     - 4
-    - NULL
+    - fourth
   register: result
   ignore_errors: true
 
 - assert:
     that:
     - result is changed
-    - result.query == "INSERT INTO test_table (id, story) VALUES (4, NULL)"
+    - result.query == "INSERT INTO test_table (id, story) VALUES (4, 'fourth')" or result.query == "INSERT INTO test_table (id, story) VALUES (4, E'fourth')"
     - result.rowcount == 1
     - result.statusmessage == 'INSERT 0 1'
     - result.query_result == {}

--- a/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
+++ b/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
@@ -243,14 +243,14 @@
     query: INSERT INTO test_table (id, story) VALUES (%s, %s)
     positional_args:
     - 4
-    - fourth
+    - null
   register: result
   ignore_errors: true
 
 - assert:
     that:
     - result is changed
-    - result.query == "INSERT INTO test_table (id, story) VALUES (4, 'fourth')" or result.query == "INSERT INTO test_table (id, story) VALUES (4, E'fourth')"
+    - result.query == "INSERT INTO test_table (id, story) VALUES (4, NULL)"
     - result.rowcount == 1
     - result.statusmessage == 'INSERT 0 1'
     - result.query_result == {}

--- a/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
+++ b/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
@@ -243,7 +243,7 @@
     query: INSERT INTO test_table (id, story) VALUES (%s, %s)
     positional_args:
     - 4
-    - null
+    - NULL
   register: result
   ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/31

postgresql_query: add explanation how to pass undefined variables as NULLs to positional_args

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
postgresql_query