### PR TITLE
AZP Coverage support for Ansible 2.9

### DIFF
--- a/.azure-pipelines/scripts/aggregate-coverage.sh
+++ b/.azure-pipelines/scripts/aggregate-coverage.sh
@@ -12,4 +12,9 @@ mkdir "${agent_temp_directory}/coverage/"
 options=(--venv --venv-system-site-packages --color -v)
 
 ansible-test coverage combine --export "${agent_temp_directory}/coverage/" "${options[@]}"
-ansible-test coverage analyze targets generate "${agent_temp_directory}/coverage/coverage-analyze-targets.json" "${options[@]}"
+
+if ansible-test coverage analyze targets generate --help >/dev/null 2>&1; then
+    # Only analyze coverage if the installed version of ansible-test supports it.
+    # Doing so allows this script to work unmodified for multiple Ansible versions.
+    ansible-test coverage analyze targets generate "${agent_temp_directory}/coverage/coverage-analyze-targets.json" "${options[@]}"
+fi

--- a/.azure-pipelines/scripts/report-coverage.sh
+++ b/.azure-pipelines/scripts/report-coverage.sh
@@ -5,6 +5,11 @@ set -o pipefail -eu
 
 PATH="${PWD}/bin:${PATH}"
 
-pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+if ! ansible-test --help >/dev/null 2>&1; then
+    # Install the devel version of ansible-test for generating code coverage reports.
+    # This is only used by Ansible Collections, which are typically tested against multiple Ansible versions (in separate jobs).
+    # Since a version of ansible-test is required that can work the output from multiple older releases, the devel version is used.
+    pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+fi
 
 ansible-test coverage xml --stub --venv --venv-system-site-packages --color -v


### PR DESCRIPTION
Pull in latest changes from shippable-migration-tool
ci_complete ci_coverage
