### PR TITLE
postgresql_ping, postgresql_info: fix crash related to PgSQL version parsing

### DIFF
--- a/changelogs/fragments/43-modules_fix_version_parsing.yml
+++ b/changelogs/fragments/43-modules_fix_version_parsing.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- postgresql_ping - fix crash caused by wrong PgSQL version parsing (https://github.com/ansible-collections/community.postgresql/issues/40).
+- postgresql_info - fix crash caused by wrong PgSQL version parsing (https://github.com/ansible-collections/community.postgresql/issues/40).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -928,7 +928,7 @@ class PgClusterInfo(object):
         raw = raw.split()[1].split('.')
         self.pg_info["version"] = dict(
             major=int(raw[0]),
-            minor=int(raw[1]),
+            minor=int(raw[1].rstrip(',')),
         )
 
     def get_recovery_state(self):

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -117,7 +117,7 @@ class PgPing(object):
             raw = raw.split()[1].split('.')
             self.version = dict(
                 major=int(raw[0]),
-                minor=int(raw[1]),
+                minor=int(raw[1].rstrip(',')),
             )
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/40

```
>>> raw = 'PostgreSQL 11.6, compiled by Visual C++ build 1800, 64-bit'
>>> raw = raw.split()[1].split('.')
>>> raw
['11', '6,']
>>> int(raw[1].rstrip(','))
6
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request