### PR TITLE
galaxy.yml: change authors field

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@ name: postgresql
 version: 1.1.0
 readme: README.md
 authors:
-  - PostgreSQL Working Group (https://github.com/ansible/community/wiki/PostgreSQL)
+  - Ansible PostgreSQL community
 description: null
 license_file: COPYING
 tags:


### PR DESCRIPTION
##### SUMMARY
Relates to https://8d4b759adbbe5195b96a-922c46b17cda87fc3b2e008fd8af57f8.ssl.cf1.rackcdn.com/51/3496099e4bd5c1f0cca6a158db1591e5035c3a99/third-party-check/ansible-galaxy-importer/ea0512c/job-output.html

```
2021-02-01 08:38:16.028465 | centos-8 | ERROR: The import failed for the following reason: Invalid collection metadata. Each author in 'authors' list must not be greater than 64 characters
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml