### PR TITLE
postgresql_query: add warning to set as_single_query explicitly

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -90,10 +90,10 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: Fedora 31
-              test: fedora31
             - name: Fedora 32
               test: fedora32
+            - name: Fedora 33
+              test: fedora33
             - name: Ubuntu 16.04
               test: ubuntu1604
             - name: Ubuntu 18.04

--- a/changelogs/fragments/54-postgresql_query_add_warning_as_single_query.yml
+++ b/changelogs/fragments/54-postgresql_query_add_warning_as_single_query.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_query - add a warning to set ``as_single_query`` option explicitly (https://github.com/ansible-collections/community.postgresql/pull/54).

--- a/changelogs/fragments/54-postgresql_query_add_warning_as_single_query.yml
+++ b/changelogs/fragments/54-postgresql_query_add_warning_as_single_query.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
 - postgresql_query - add a warning to set ``as_single_query`` option explicitly (https://github.com/ansible-collections/community.postgresql/pull/54).

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -96,7 +96,7 @@ options:
     - Used only when I(path_to_script) is specified, otherwise ignored.
     - If set to C(no), the script can contain only semicolon-separated queries.
       (see the I(path_to_script) option documentation).
-    - The default value is C(False).
+    - The default value is C(no).
     type: bool
     version_added: '1.1.0'
 seealso:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -377,7 +377,8 @@ def main():
 
     if path_to_script and as_single_query is None:
         module.warn('You use the "path_to_script" option with the "as_single_query" '
-                    'option unset. To avoid crashes, please read the documentation '
+                    'option unset. The default is False. '
+                    'To avoid crashes, please read the documentation '
                     'and define the "as_single_query" option explicitly')
 
     if not trust_input:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -378,9 +378,9 @@ def main():
 
     if path_to_script and as_single_query is None:
         module.warn('You use the "path_to_script" option with the "as_single_query" '
-                    'option unset. The default is False. '
+                    'option unset. The default is false. '
                     'To avoid crashes, please read the documentation '
-                    'and define the "as_single_query" option explicitly')
+                    'and define the "as_single_query" option explicitly.')
 
     if not trust_input:
         # Check input for potentially dangerous elements:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -96,6 +96,7 @@ options:
     - Used only when I(path_to_script) is specified, otherwise ignored.
     - If set to C(no), the script can contain only semicolon-separated queries.
       (see the I(path_to_script) option documentation).
+    - The default value is C(False).
     type: bool
     version_added: '1.1.0'
 seealso:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -94,8 +94,9 @@ options:
     - Whether the state is reported as changed or not
       is determined by the last statement of the file.
     - Used only when I(path_to_script) is specified, otherwise ignored.
+    - If set to C(no), the script can contain only semicolon-separated queries.
+      (see the I(path_to_script) option documentation).
     type: bool
-    default: no
     version_added: '1.1.0'
 seealso:
 - module: community.postgresql.postgresql_db
@@ -354,7 +355,7 @@ def main():
         encoding=dict(type='str'),
         trust_input=dict(type='bool', default=True),
         search_path=dict(type='list', elements='str'),
-        as_single_query=dict(type='bool', default=False),
+        as_single_query=dict(type='bool'),
     )
 
     module = AnsibleModule(
@@ -373,6 +374,11 @@ def main():
     trust_input = module.params["trust_input"]
     search_path = module.params["search_path"]
     as_single_query = module.params["as_single_query"]
+
+    if path_to_script and as_single_query is None:
+        module.warn('You use the "path_to_script" option with the "as_single_query" '
+                    'option unset. To avoid crashes, please read the documentation '
+                    'and define the "as_single_query" option explicitly')
 
     if not trust_input:
         # Check input for potentially dangerous elements:


### PR DESCRIPTION
##### SUMMARY
Related to https://github.com/ansible-collections/community.general/pull/886

Related Issues:
11:50 AM issue 1 https://github.com/ansible-collections/community.postgresql/issues/34
11:50 AM issue 2 https://github.com/ansible-collections/community.postgresql/issues/50

Introduction of query_all_results https://github.com/ansible-collections/community.general/pull/886
caused introduction of `as_single_query` option https://github.com/ansible-collections/community.postgresql/pull/37
To save backwards compatibility, the default value of the option was defined as `no`.

So, would be cool to notify users to set the option explicitly.

**the current behavior has NOT changed**