### PR TITLE
Fix fail_on_role check

### DIFF
--- a/changelogs/fragments/82-fix-fail-on-role.yml
+++ b/changelogs/fragments/82-fix-fail-on-role.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - postgresql_privs - fix ``fail_on_role`` check (https://github.com/ansible-collections/community.postgresql/pull/82).

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -1121,13 +1121,11 @@ def main():
             roles = p.roles.split(',')
 
             if len(roles) == 1 and not role_exists(module, conn.cursor, roles[0]):
-                module.exit_json(changed=False)
-
                 if fail_on_role:
                     module.fail_json(msg="Role '%s' does not exist" % roles[0].strip())
-
                 else:
                     module.warn("Role '%s' does not exist, nothing to do" % roles[0].strip())
+                module.exit_json(changed=False, queries=executed_queries)
 
         # check if target_roles is set with type: default_privs
         if p.target_roles and not p.type == 'default_privs':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This fixes the issue where the check is never reached because
the module is unconditionally exited, before, if the specified
role doesn't exist.

Which was effectively as if `fail_on_role` is always set to 'no'
plus the silencing of the warning. Which, of course, is quite a trap
and conflicts with the documentation, as well.

For symmetry and better troubleshooting that result now also includes
the executed queries (like the other call site).


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

postgresql_privs


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

How to reproduce the original issue: try to grant some privilege to a non-existing role.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
