### PR TITLE
Disambiguate login_user and login_password wording

### DIFF
--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -12,12 +12,12 @@ class ModuleDocFragment(object):
 options:
   login_user:
     description:
-      - The username used to authenticate with.
+      - The username this module should use to establish its PostgreSQL session.
     type: str
     default: postgres
   login_password:
     description:
-      - The password used to authenticate with.
+      - The password this module should use to establish its PostgreSQL session.
     type: str
   login_host:
     description:


### PR DESCRIPTION
##### SUMMARY
It's easy to confuse `login_password` with `password` on in the postgresql_user module.

I have changed the wording to make it clearer that the  `login_user` and `login_password` variables are used by the module to establish a session.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.postgresql.postgresql_user

##### ADDITIONAL INFORMATION
`login_password` appears higher in the `community.postgresql.postgresql_user` documentation than `password` so it is an easy mistake to make.  In my case, the module executed without errors or warnings so this could save people time spent troubleshooting their authentication failures.