### PR TITLE
Need a force (bool) option for postgresql_db. Otherwise fails to drop a db with state=absent only

### DIFF
--- a/changelogs/fragments/drop_db_with_force.yml
+++ b/changelogs/fragments/drop_db_with_force.yml
@@ -1,0 +1,3 @@
+postgresql_db name=mydb state=absent fails to remove mydb database if it has active connections.
+
+Added a force option (boolean) to remove active connections first and then remove the database.

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -320,7 +320,7 @@ def db_exists(cursor, db):
 def db_dropconns(cursor, db):
     if cursor.connection.server_version >= 90200:
         """ Drop DB connections in Postgres 9.2 and above """
-        query_terminate = ("SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity"
+        query_terminate = ("SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity "
                            "WHERE pg_stat_activity.datname=%(db)s AND pid <> pg_backend_pid()")
     else:
         """ Drop DB connections in Postgres 9.1 and below """

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -326,11 +326,8 @@ def db_dropconns(cursor, db):
         """ Drop DB connections in Postgres 9.1 and below """
         query_terminate = ("SELECT pg_terminate_backend(pg_stat_activity.procpid) FROM pg_stat_activity"
                            "WHERE pg_stat_activity.datname=%(db)s AND procpid <> pg_backend_pid()")
-    if cursor.connection.server_version < 13000:
-        query_block = ("UPDATE pg_database SET datallowconn = false WHERE datname=%(db)s")
-        query = query_block + ';' + query_terminate
-    else:
-        query = ("DROP DATABASE %(db)s  WITH (FORCE)")
+    query_block = ("UPDATE pg_database SET datallowconn = false WHERE datname=%(db)s")
+    query = query_block + ';' + query_terminate
 
     cursor.execute(query, {'db': db})
 

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -629,7 +629,7 @@ def main():
         tablespace=dict(type='path', default=''),
         dump_extra_args=dict(type='str', default=None),
         trust_input=dict(type='bool', default=True),
-        force=dict(type='bool', default=False)
+        force=dict(type='bool', default=False),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -337,7 +337,7 @@ def db_delete(cursor, db, force=False):
         query = 'DROP DATABASE %(db)s'
         if force:
             if cursor.connection.server_version >= 130000:
-                query = ("DROP DATABASE %(db)s  WITH (FORCE)")
+                query = ('DROP DATABASE "%s" WITH (FORCE)' % db)
             else:
                 db_dropconns(cursor, db)
         executed_commands.append(query)

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -327,7 +327,7 @@ def db_dropconns(cursor, db):
         query_terminate = ("SELECT pg_terminate_backend(pg_stat_activity.procpid) FROM pg_stat_activity "
                            "WHERE pg_stat_activity.datname=%(db)s AND procpid <> pg_backend_pid()")
     query_block = ("UPDATE pg_database SET datallowconn = false WHERE datname=%(db)s")
-    query = query_block + ';' + query_terminate
+    query = query_block + '; ' + query_terminate
 
     cursor.execute(query, {'db': db})
 

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -334,7 +334,7 @@ def db_dropconns(cursor, db):
 
 def db_delete(cursor, db, force=False):
     if db_exists(cursor, db):
-        query = 'DROP DATABASE "%(db)s"'
+        query = 'DROP DATABASE %(db)s'
         if force:
             if cursor.connection.server_version >= 130000:
                 query = ("DROP DATABASE %(db)s  WITH (FORCE)")

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -341,7 +341,7 @@ def db_delete(cursor, db, force=False):
             else:
                 db_dropconns(cursor, db)
         executed_commands.append(query)
-        cursor.execute(query, {'db': db})
+        cursor.execute(query)
         return True
     else:
         return False

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -324,7 +324,7 @@ def db_dropconns(cursor, db):
                            "WHERE pg_stat_activity.datname=%(db)s AND pid <> pg_backend_pid()")
     else:
         """ Drop DB connections in Postgres 9.1 and below """
-        query_terminate = ("SELECT pg_terminate_backend(pg_stat_activity.procpid) FROM pg_stat_activity"
+        query_terminate = ("SELECT pg_terminate_backend(pg_stat_activity.procpid) FROM pg_stat_activity "
                            "WHERE pg_stat_activity.datname=%(db)s AND procpid <> pg_backend_pid()")
     query_block = ("UPDATE pg_database SET datallowconn = false WHERE datname=%(db)s")
     query = query_block + ';' + query_terminate

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -334,7 +334,7 @@ def db_dropconns(cursor, db):
 
 def db_delete(cursor, db, force=False):
     if db_exists(cursor, db):
-        query = 'DROP DATABASE %(db)s'
+        query = 'DROP DATABASE "%s"' % db
         if force:
             if cursor.connection.server_version >= 130000:
                 query = ('DROP DATABASE "%s" WITH (FORCE)' % db)

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -337,9 +337,12 @@ def db_dropconns(cursor, db):
 
 def db_delete(cursor, db, force=False):
     if db_exists(cursor, db):
-        if force:
-            db_dropconns(cursor, db)
         query = 'DROP DATABASE "%s"' % db
+        if force:
+            if cursor.connection.server_version >= 13000:
+                query = ("DROP DATABASE %(db)s  WITH (FORCE)")
+            else:
+                db_dropconns(cursor, db)
         executed_commands.append(query)
         cursor.execute(query)
         return True

--- a/tests/integration/targets/postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/postgresql_db/tasks/main.yml
@@ -42,3 +42,6 @@
   vars:
     file: dbdata.tar
     test_fixture: admin
+
+# Simple test to create and then drop with force
+- import_tasks: manage_database.yml

--- a/tests/integration/targets/postgresql_db/tasks/manage_database.yml
+++ b/tests/integration/targets/postgresql_db/tasks/manage_database.yml
@@ -7,4 +7,3 @@
     name: mydb
     state: absent
     force: yes
-

--- a/tests/integration/targets/postgresql_db/tasks/manage_database.yml
+++ b/tests/integration/targets/postgresql_db/tasks/manage_database.yml
@@ -1,0 +1,10 @@
+- name: Create a simple database mydb
+  postgresql_db:
+    name: mydb
+
+- name: Drop the database with force
+  postgresql_db:
+    name: mydb
+    state: absent
+    force: yes
+

--- a/tests/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/tests/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -46,6 +46,7 @@
   become: yes
   postgresql_db:
     state: absent
+    force: yes
     name: "{{ db_name }}"
     login_user: "{{ pg_user }}"
   register: result
@@ -71,6 +72,7 @@
   become: yes
   postgresql_db:
     state: absent
+    force: yes
     name: "{{ db_name }}"
     login_user: "{{ pg_user }}"
   register: result

--- a/tests/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/tests/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -46,7 +46,6 @@
   become: yes
   postgresql_db:
     state: absent
-    force: yes
     name: "{{ db_name }}"
     login_user: "{{ pg_user }}"
   register: result
@@ -72,7 +71,6 @@
   become: yes
   postgresql_db:
     state: absent
-    force: yes
     name: "{{ db_name }}"
     login_user: "{{ pg_user }}"
   register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes https://github.com/ansible-collections/community.postgresql/issues/109

Added a `force` (boolean) option with `state=absent`. Need to drop active connections first to be able to drop a database.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task, or feature below -->
postgresql_db needs a force option with state=absent or it will fail to drop a database with active connections

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

1. When database does not exists, do nothing.
2. When database exists and has active connections, and force is True, it will drop the database
3. When database exists and has active connections, and force is False, it will fail to drop the database
4. When database exists and has no active connections, and force is False, it will drop the database
5. When database exists and has no active connections, and force is True, it will drop the database


<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
postgresql_db:
    name: mydb
    state: absent
    force: yes
```
`force:` is the new feature request. Without it a DB will not be removed with active connections
`force:` _default_ value is **False** and added to the documentation
