### PR TITLE
pg_hba.conf: add parameter to keep rule-specific comments next to the rule

### DIFF
--- a/changelogs/fragments/134-postgresql_pg_hba-rule-specific-comments.yml
+++ b/changelogs/fragments/134-postgresql_pg_hba-rule-specific-comments.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - postgresql_pg_hba - Add the parameters ``keep_comments_at_rules`` and ``comment``. (https://github.com/ansible-collections/community.postgresql/issues/134).
+  - postgresql_pg_hba - Add the parameters ``keep_comments_at_rules`` and ``comment`` (https://github.com/ansible-collections/community.postgresql/issues/134).

--- a/changelogs/fragments/134-postgresql_pg_hba-rule-specific-comments.yml
+++ b/changelogs/fragments/134-postgresql_pg_hba-rule-specific-comments.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - postgresql_pg_hba - Add the parameters ``keep_comments_at_rules`` and ``comment``. (https://github.com/ansible-collections/community.postgresql/issues/134).

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -51,6 +51,10 @@ options:
       - Type of the rule. If not set, C(postgresql_pg_hba) will only return contents.
     type: str
     choices: [ local, host, hostnossl, hostssl ]
+  comment:
+    description:
+      - A comment that will be placed in the same line behind the rule. See also parameter I(keep_comments_at_rules).
+    type: str
   databases:
     description:
       - Databases this line applies to.
@@ -692,6 +696,7 @@ def main():
         backup=dict(type='bool', default=False),
         backup_file=dict(type='str'),
         contype=dict(type='str', default=None, choices=PG_HBA_TYPES),
+        comment=dict(type='str', default=None),
         create=dict(type='bool', default=False),
         databases=dict(type='str', default='all'),
         dest=dict(type='path', required=True),
@@ -730,6 +735,7 @@ def main():
     state = module.params["state"]
     users = module.params["users"]
     keep_comments_at_rules = module.params["keep_comments_at_rules"]
+    comment = module.params["comment"]
 
     ret = {'msgs': []}
     try:
@@ -741,7 +747,7 @@ def main():
         try:
             for database in databases.split(','):
                 for user in users.split(','):
-                    rule = PgHbaRule(contype, database, user, source, netmask, method, options)
+                    rule = PgHbaRule(contype, database, user, source, netmask, method, options, comment=comment)
                     if state == "present":
                         ret['msgs'].append('Adding')
                         pg_hba.add_rule(rule)

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -161,6 +161,17 @@ EXAMPLES = '''
     users: mary
     databases: mydb
     state: absent
+
+- name: Grant some_user access to some_db, comment that and keep other rule-specific comments attached to their rules
+  community.postgresql.postgresql_pg_hba:
+    dest: /var/lib/postgres/data/pg_hba.conf
+    contype: host
+    users: some_user
+    databases: some_db
+    method: md5
+    source: ::/0
+    keep_comments_at_rules: true
+    comment: "this rule is an example"
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -131,7 +131,9 @@ seealso:
 requirements:
     - ipaddress
 
-author: Sebastiaan Mannem (@sebasmannem)
+author:
+- Sebastiaan Mannem (@sebasmannem)
+- Felix Hamme (@betanummeric)
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -91,10 +91,10 @@ options:
     choices: [ sdu, sud, dsu, dus, usd, uds ]
   keep_comments_at_rules:
     description:
-     - If true, comments that stand together with a rule in one line are kept behind that line.
-     - If false, such comments are moved to the beginning of the file, like all other comments.
-     type: bool
-     default: false
+      - If true, comments that stand together with a rule in one line are kept behind that line.
+      - If false, such comments are moved to the beginning of the file, like all other comments.
+    type: bool
+    default: false
   state:
     description:
       - The lines will be added/modified when C(state=present) and removed when C(state=absent).

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -53,8 +53,9 @@ options:
     choices: [ local, host, hostnossl, hostssl ]
   comment:
     description:
-      - A comment that will be placed in the same line behind the rule. See also parameter I(keep_comments_at_rules).
+      - A comment that will be placed in the same line behind the rule. See also the I(keep_comments_at_rules) parameter.
     type: str
+    version_added: '1.5.0'
   databases:
     description:
       - Databases this line applies to.
@@ -91,10 +92,11 @@ options:
     choices: [ sdu, sud, dsu, dus, usd, uds ]
   keep_comments_at_rules:
     description:
-      - If true, comments that stand together with a rule in one line are kept behind that line.
-      - If false, such comments are moved to the beginning of the file, like all other comments.
+      - If C(true), comments that stand together with a rule in one line are kept behind that line.
+      - If C(false), such comments are moved to the beginning of the file, like all other comments.
     type: bool
     default: false
+    version_added: '1.5.0'
   state:
     description:
       - The lines will be added/modified when C(state=present) and removed when C(state=absent).

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -181,3 +181,62 @@
     - 'pg_hba_fail_src_all_with_netmask is failed'
     - 'not netmask_sameas_prefix_check is changed'
     - 'pg_hba_options is changed'
+
+- name: Create a rule with the comment 'comment1'
+  postgresql_pg_hba:
+    contype: host
+    dest: /tmp/pg_hba2.conf
+    create: true
+    method: md5
+    address: "2001:db8::1/128"
+    order: sud
+    state: present
+    comment: "comment1"
+
+- name: read pgh_hba2.conf
+  set_fact:
+    content: "{{ lookup('file', '/tmp/pg_hba2.conf') }}"
+- debug:
+    var: content
+- assert:
+    that:
+      - '"\nhost\tall\tall\t2001:db8::1/128\tmd5\t#comment1" == content'
+
+- name: Create a rule with the comment 'comment2'
+  postgresql_pg_hba:
+    contype: host
+    dest: /tmp/pg_hba2.conf
+    method: md5
+    address: "2001:db8::2/128"
+    order: sud
+    state: present
+    comment: "comment2"
+
+- name: read pgh_hba2.conf
+  set_fact:
+    content: "{{ lookup('file', '/tmp/pg_hba2.conf') }}"
+- debug:
+    var: content
+- assert:
+    that:
+      - '"#comment1\nhost\tall\tall\t2001:db8::1/128\tmd5\nhost\tall\tall\t2001:db8::2/128\tmd5\t#comment2" == content'
+
+- name: Create a rule with the comment 'comment3' and keep_comments_at_rules
+  postgresql_pg_hba:
+    contype: host
+    dest: /tmp/pg_hba2.conf
+    method: md5
+    address: "2001:db8::3/128"
+    order: sud
+    state: present
+    comment: "comment3"
+    keep_comments_at_rules: true
+
+- name: read pgh_hba2.conf
+  set_fact:
+    content: "{{ lookup('file', '/tmp/pg_hba2.conf') }}"
+- debug:
+    var: content
+- assert:
+    that:
+      - '"#comment1\nhost\tall\tall\t2001:db8::1/128\tmd5\nhost\tall\tall\t2001:db8::2/128\tmd5\t#comment2\nhost\tall\tall\t2001:db8::3/128\tmd5\t#comment3" == content'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #134

Currently, the module community.postgresql.postgresql_pg_hba would move those comments to the beginning of the file, which removes the comment-to-rule relation. To optionally preserve that and to optionally add such comments, I propose to introduce two new parameters to the module:

- _keep_comments_at_rules_ (bool, default=false)
    - If true, comments that stand together with a rule in one line are kept behind that line.
    - If false, such comments are moved to the beginning of the file, like all other comments.
- _comment_ (string, optional)
    - A comment that will be placed in the same line behind the rule.

If not set, the behavior of the module remains like before.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_pg_hba

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
example use in a playbook:
```yaml
- name: manage pg_hba.conf
  community.postgresql.postgresql_pg_hba:
    address: "{{ address }}"
    contype: host
    create: yes
    databases: "{{ database }}"
    dest: "{{ data_dir }}/pg_hba.conf"
    method: md5
    owner: postgres
    state: present
    users: "{{ username }}"
    keep_comments_at_rules: true
    comment: "this rule is for {{ reason }}"
```

I am new to this project. If I missed something, please let me know.