### PR TITLE
postgresql_info: fix crash when extension version is 0.

### DIFF
--- a/changelogs/fragments/138-postgresql_info_fix_ver_handling.yml
+++ b/changelogs/fragments/138-postgresql_info_fix_ver_handling.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- postgresql_info - Fix extension version handling when it has 0 value (https://github.com/ansible-collections/community.postgresql/issues/137).
+- postgresql_ext - Fix extension version handling when it has 0 value (https://github.com/ansible-collections/community.postgresql/pull/138).
+
+minor_changes:
+- postgresql_info - Add the ``raw`` return value for extension version (https://github.com/ansible-collections/community.postgresql/pull/138).

--- a/changelogs/fragments/138-postgresql_info_fix_ver_handling.yml
+++ b/changelogs/fragments/138-postgresql_info_fix_ver_handling.yml
@@ -1,6 +1,6 @@
 bugfixes:
 - postgresql_info - Fix extension version handling when it has 0 value (https://github.com/ansible-collections/community.postgresql/issues/137).
-- postgresql_ext - Fix extension version handling when it has 0 value (https://github.com/ansible-collections/community.postgresql/pull/138).
+- postgresql_ext - Fix extension version handling when it has 0 value (https://github.com/ansible-collections/community.postgresql/issues/136).
 
 minor_changes:
 - postgresql_info - Add the ``raw`` return value for extension version (https://github.com/ansible-collections/community.postgresql/pull/138).

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -276,7 +276,7 @@ def ext_get_versions(cursor, ext):
     query = ("SELECT extversion FROM pg_catalog.pg_extension "
              "WHERE extname = %(ext)s")
 
-    current_version = '0'
+    current_version = None
     cursor.execute(query, {'ext': ext})
     res = cursor.fetchone()
     if res:
@@ -290,7 +290,7 @@ def ext_get_versions(cursor, ext):
 
     available_versions = parse_ext_versions(current_version, res)
 
-    if current_version == '0':
+    if current_version is None:
         current_version = False
 
     return (current_version, available_versions)
@@ -314,8 +314,12 @@ def parse_ext_versions(current_version, ext_ver_list):
             continue
 
         try:
-            if LooseVersion(line['version']) > LooseVersion(current_version):
-                available_versions.append(line['version'])
+            if current_version is None:
+                if LooseVersion(line['version']) >= LooseVersion('0'):
+                    available_versions.append(line['version'])
+            else:
+                if LooseVersion(line['version']) > LooseVersion(current_version):
+                    available_versions.append(line['version'])
         except Exception:
             # When a version cannot be compared, skip it
             # (there's a note in the documentation)

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -197,7 +197,7 @@ databases:
           type: dict
           sample:
           - { "plpgsql": { "description": "PL/pgSQL procedural language",
-            "extversion": { "major": 1, "minor": 0 } } }
+            "extversion": { "major": 1, "minor": 0, "raw": '1.0' } } }
           contains:
             extdescription:
               description: Extension description.
@@ -219,6 +219,11 @@ databases:
                   returned: always
                   type: int
                   sample: 0
+                raw:
+                  description: Extension full version.
+                  returned: always
+                  type: str
+                  sample: '1.0'
             nspname:
               description: Namespace where the extension is.
               returned: always
@@ -746,12 +751,17 @@ class PgClusterInfo(object):
         res = self.__exec_sql(query)
         ext_dict = {}
         for i in res:
+            ext_ver_raw = i[1]
             ext_ver = i[1].split('.')
+
+            if len(ext_ver) < 2:
+                ext_ver.append(None)
 
             ext_dict[i[0]] = dict(
                 extversion=dict(
                     major=int(ext_ver[0]),
-                    minor=int(ext_ver[1]),
+                    minor=int(ext_ver[1]) if ext_ver[1] else None,
+                    raw=ext_ver_raw,
                 ),
                 nspname=i[2],
                 description=i[3],

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -347,6 +347,53 @@
       that:
       - result is changed
 
+  # https://github.com/ansible-collections/community.postgresql/issues/137
+  - name: Drop extension
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      state: absent
+
+  - name: Non standard version
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: 0
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 0
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '0'
+
+  - name: Upgrade extension to the latest
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: latest
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 3
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == 0
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3.0'
+
   # Cleanup:
   - name: postgresql_ext_version - drop the extension
     <<: *task_parameters

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--0.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--0.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''0'')::text';

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -217,6 +217,7 @@
     dest: /usr/share/postgresql/{{ pg_ver }}/extension/{{ item }}
     mode: '0444'
   with_items:
+  - dummy--0.sql
   - dummy--1.0.sql
   - dummy--2.0.sql
   - dummy--3.0.sql
@@ -228,6 +229,7 @@
     mode: '0444'
     state: touch
   with_items:
+  - dummy--0--1.0.sql
   - dummy--1.0--2.0.sql
   - dummy--2.0--3.0.sql
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-collections/community.postgresql/issues/137
Fixes https://github.com/ansible-collections/community.postgresql/issues/136

postgresql_info:
- fix crash when extension version is 0.
- add raw ret value for extensions

postgresql_ext (i put it in this PR because it needs for integration tests):
- fix extension of version 0 handling

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/postgresql_ext.py
plugins/modules/postgresql_info.py