### PR TITLE
correct version value in postgresql_slot

### DIFF
--- a/changelogs/fragments/120-postgresql_correct_server_version_check.yml
+++ b/changelogs/fragments/120-postgresql_correct_server_version_check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_slot - Correct the server_version check for PG 9.6 (https://github.com/ansible-collections/community.postgresql/issue/120)

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -191,8 +191,8 @@ class PgSlot(object):
             return None
 
         if kind == 'physical':
-            # Check server version (needs for immedately_reserverd needs 9.6+):
-            if self.cursor.connection.server_version < 96000:
+            # Check server version (immediately_reserved needs 9.6+):
+            if self.cursor.connection.server_version < 90600:
                 query = "SELECT pg_create_physical_replication_slot(%(name)s)"
 
             else:


### PR DESCRIPTION
##### SUMMARY

The check in postgresql_slot which determines if the PG server is 9.6+
has a typo in the version. It was using 96000 when the value should be
90600.

Also corrected the spelling in the comment that is part of said version
check.

Fixes #120

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

potgresql_slot

##### ADDITIONAL INFORMATION

```
(postgres@[local]:5432/postgres[45017]) # show server_version_num ;
┌────────────────────┐
│ server_version_num │
├────────────────────┤
│ 90600              │
└────────────────────┘
(1 row)
```

As you can see, the correct version string is `90600` not `96000`