### PR TITLE
Exclude some distributions from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -97,8 +97,6 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: CentOS 8
@@ -119,8 +117,6 @@ stages:
         parameters:
           testFormat: 2.11/linux/{0}/1
           targets:
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: Fedora 32
@@ -139,8 +135,6 @@ stages:
         parameters:
           testFormat: 2.10/linux/{0}/1
           targets:
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: Fedora 31
@@ -159,8 +153,6 @@ stages:
         parameters:
           testFormat: 2.9/linux/{0}/1
           targets:
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: Fedora 31

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -99,14 +99,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
-            - name: Fedora 33
-              test: fedora33
             - name: Fedora 34
               test: fedora34
-            - name: Ubuntu 18.04
-              test: ubuntu1804
             - name: Ubuntu 20.04
               test: ubuntu2004
   - stage: Docker_2_11
@@ -119,12 +113,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 32
-              test: fedora32
-            - name: Fedora 33
-              test: fedora33
-            - name: Ubuntu 18.04
-              test: ubuntu1804
             - name: Ubuntu 20.04
               test: ubuntu2004
   - stage: Docker_2_10
@@ -137,14 +125,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 31
-              test: fedora31
-            - name: Fedora 32
-              test: fedora32
-            - name: Ubuntu 16.04
-              test: ubuntu1604
-            - name: Ubuntu 18.04
-              test: ubuntu1804
   - stage: Docker_2_9
     displayName: Docker 2.9
     dependsOn: []
@@ -155,12 +135,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 31
-              test: fedora31
-            - name: Ubuntu 16.04
-              test: ubuntu1604
-            - name: Ubuntu 18.04
-              test: ubuntu1804
 
 ### Remote
   - stage: Remote_devel
@@ -171,8 +145,6 @@ stages:
         parameters:
           testFormat: devel/{0}/1
           targets:
-            - name: RHEL 7.9
-              test: rhel/7.9
             - name: RHEL 8.4
               test: rhel/8.4
   - stage: Remote_2_11
@@ -183,8 +155,6 @@ stages:
         parameters:
           testFormat: 2.11/{0}/1
           targets:
-            - name: RHEL 7.9
-              test: rhel/7.9
             - name: RHEL 8.3
               test: rhel/8.3
   - stage: Remote_2_10

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -193,7 +193,12 @@
     state: present
     comment: "comment1"
 
-- name: read pgh_hba2.conf
+- name: Fetch the file
+  fetch:
+    src: /tmp/pg_hba2.conf
+    dest: /tmp/pg_hba2.conf
+    flat: yes
+- name: Read pg_hba2.conf
   set_fact:
     content: "{{ lookup('file', '/tmp/pg_hba2.conf') }}"
 - debug:
@@ -212,7 +217,12 @@
     state: present
     comment: "comment2"
 
-- name: read pgh_hba2.conf
+- name: Fetch the file
+  fetch:
+    src: /tmp/pg_hba2.conf
+    dest: /tmp/pg_hba2.conf
+    flat: yes
+- name: Read pg_hba2.conf
   set_fact:
     content: "{{ lookup('file', '/tmp/pg_hba2.conf') }}"
 - debug:
@@ -232,7 +242,12 @@
     comment: "comment3"
     keep_comments_at_rules: true
 
-- name: read pgh_hba2.conf
+- name: Fetch the file
+  fetch:
+    src: /tmp/pg_hba2.conf
+    dest: /tmp/pg_hba2.conf
+    flat: yes
+- name: Read pg_hba2.conf
   set_fact:
     content: "{{ lookup('file', '/tmp/pg_hba2.conf') }}"
 - debug:


### PR DESCRIPTION
##### SUMMARY
Exclude some distributions from CI where PostgreSQL version is too old or where the same version is present in other distros

CentOS 6: `8.4.20` (excluded)
CentOS 7: `9.2.24`
CentOS 8: `10.17` (excluded)

Fedora 31 `11.8`(excluded)
Fedora 32 `12.6` (excluded)
Fedora 33 `12.7` (excluded)
Fedora 34 `13.4`

Ubuntu 16.04: `9.5` (excluded)
Ubuntu 18.04: `10.18` (excluded)
Ubuntu 20.04: `12.8`

RHEL 7.9: `9.2` (excluded)
RHEL 8.3: `10.17`
RHEL 8.4: `10.17`

After this PR we will test against:
- 9.2 (i think this is a good low border)
- 10
- 12
- 13


##### ISSUE TYPE
Testing