### PR TITLE
postgresql_privs: Additional information when something goes wrong.

### DIFF
--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+from ansible.module_utils._text import to_native
 
 
 # Input patterns for is_input_dangerous function:
@@ -167,22 +168,25 @@ def check_input(module, *args):
     dangerous_elements = []
 
     for elem in needs_to_check:
-        if isinstance(elem, str):
-            if is_input_dangerous(elem):
-                dangerous_elements.append(elem)
+        try:
+            if isinstance(elem, str):
+                if is_input_dangerous(elem):
+                    dangerous_elements.append(elem)
 
-        elif isinstance(elem, list):
-            for e in elem:
-                if is_input_dangerous(e):
-                    dangerous_elements.append(e)
+            elif isinstance(elem, list):
+                for e in elem:
+                    if is_input_dangerous(e):
+                        dangerous_elements.append(e)
 
-        elif elem is None or isinstance(elem, bool):
-            pass
+            elif elem is None or isinstance(elem, bool):
+                pass
 
-        else:
-            elem = str(elem)
-            if is_input_dangerous(elem):
-                dangerous_elements.append(elem)
+            else:
+                elem = str(elem)
+                if is_input_dangerous(elem):
+                    dangerous_elements.append(elem)
+        except ValueError as e:
+            module.fail_json(msg=to_native(e))
 
     if dangerous_elements:
         module.fail_json(msg="Passed input '%s' is "

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -53,14 +53,14 @@ options:
     description:
     - Comma separated list of database objects to set privileges on.
     - If I(type) is C(table), C(partition table), C(sequence), C(function) or C(procedure),
-      the special valueC(ALL_IN_SCHEMA) can be provided instead to specify all
-      database objects of type I(type) in the schema specified via I(schema).
+      the special value C(ALL_IN_SCHEMA) can be provided instead to specify all
+      database objects of I(type) in the schema specified via I(schema).
       (This also works with PostgreSQL < 9.0.) (C(ALL_IN_SCHEMA) is available
        for C(function) and C(partition table) since Ansible 2.8).
     - C(procedure) is supported since PostgreSQL 11 and M(community.postgresql) collection 1.3.0.
     - If I(type) is C(database), this parameter can be omitted, in which case
       privileges are set for the database specified via I(database).
-    - If I(type) is I(function) or I(procedure), colons (":") in object names will be
+    - If I(type) is C(function) or C(procedure), colons (":") in object names will be
       replaced with commas (needed to specify signatures, see examples).
     type: str
     aliases:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In issue #132 ( #133 ) it was reported that when there is an incorrect entry of the parameter `objs` ( or `obj`), it does not arise a more detail message about what is happening.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* plugin/modules/postgresql_privs.py

<!--- ##### ADDITIONAL INFORMATION -->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

