### PR TITLE
Better handling of extension versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ The PostgreSQL modules rely on the [Psycopg2](https://www.psycopg.org/docs/) Pos
 - 2.11
 - devel
 
+Our AZP CI includes testing with the following docker images / PostgreSQL versions:
+
+- CentOS 7: 9.2
+- RHEL 8.3 / 8.4: 10
+- Fedora 34: 13
+- Ubuntu 20.04: 14
+
 ## Included content
 
 - **Info modules**:

--- a/changelogs/fragments/163-better_handling_of_postgresql_extensions.yml
+++ b/changelogs/fragments/163-better_handling_of_postgresql_extensions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_ext - Handle postgresql extension updates through path validation instead of version comparison (https://github.com/ansible-collections/community.postgresql/issues/129).

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -72,7 +72,8 @@ options:
     description:
       - Extension version to add or update to. Has effect with I(state=present) only.
       - If not specified, the latest extension version will be created.
-      - Downgrading is only supported if the extension provides a downgrade path otherwise the extension must be removed and a lower version of the extension must be made available.
+      - Downgrading is only supported if the extension provides a downgrade path otherwise
+        the extension must be removed and a lower version of the extension must be made available.
       - Set I(version=latest) to always update the extension to the latest available version.
     type: str
   trust_input:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -148,14 +148,13 @@ EXAMPLES = r'''
     cascade: yes
     state: absent
 
-- name: Create extension foo of version 1.2 or update it to that version if it's already
-  created and a valid update path exists community.postgresql.postgresql_ext:
+- name: Create extension foo of version 1.2 or update it to that version if it's already created and a valid update path exists
+  community.postgresql.postgresql_ext:
     db: acme
     name: foo
     version: 1.2
 
-- name: Create the latest available version of extension foo. If already installed,
-  update it to the latest version
+- name: Create the latest available version of extension foo. If already installed, update it to the latest version
   community.postgresql.postgresql_ext:
     db: acme
     name: foo

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -198,8 +198,20 @@ executed_queries = []
 #
 
 
-def ext_delete(cursor, ext, curr_version, cascade):
-    if curr_version:
+def ext_delete(cursor, ext, current_version, cascade):
+    """Remove the extension from the database
+
+    Return True if success.
+
+    Args:
+      cursor (cursor) -- cursor object of psycopg2 library
+      ext (str) -- extension name
+      current_version (str) -- installed version of the extension.
+        Value obtained from ext_get_versions and used to
+        determine if the extension was installed.
+      cascade (boolean) -- Pass the CASCADE flag to the DROP commmand
+    """
+    if current_version:
         query = "DROP EXTENSION \"%s\"" % ext
         if cascade:
             query += " CASCADE"
@@ -234,6 +246,17 @@ def ext_update_version(cursor, ext, version):
 
 
 def ext_create(cursor, ext, schema, cascade, version):
+    """
+    Create the extension objects inside the database
+
+    Return True if success.
+
+    Args:
+      cursor (cursor) -- cursor object of psycopg2 library
+      ext (str) -- extension name
+      schema (str) -- target schema for extension objects
+      version (str) -- extension version
+    """
     query = "CREATE EXTENSION \"%s\"" % ext
     params = {}
 
@@ -252,7 +275,9 @@ def ext_create(cursor, ext, schema, cascade, version):
 
 def ext_get_versions(cursor, ext):
     """
-    Get the current created extension version and available versions.
+    Get the currently created extension version if it is installed
+    in the database and versions that are available if it is
+    installed on the system.
 
     Return tuple (current_version, [list of available versions]).
 
@@ -296,7 +321,18 @@ def ext_get_versions(cursor, ext):
 
 def ext_valid_update_path(cursor, ext, current_version, version):
     """
-        Value of 'latest' is always a valid path.
+    Check to see if the installed extension version has a valid update
+    path to the given version. A version of 'latest' is always a valid path.
+
+    Return True if a valid path exists. Otherwise return False.
+
+    Args:
+      cursor (cursor) -- cursor object of psycopg2 library
+      ext (str) -- extension name
+      current_version (str) -- installed version of the extension.
+      version (str) -- target extension version to update to.
+        A value of 'latest' is always a valid path and will result
+        in the extension update command always being run.
     """
 
     valid_path = False
@@ -401,7 +437,7 @@ def main():
             # If version is not passed:
             else:
                 # Extension exists, attempt to update to latest version defined in extension control file
-                # ALTER EXTENSION is actually run, so 'changed' is technically true even if nothing updated
+                # ALTER EXTENSION is actually run, so 'changed' will be true even if nothing updated
                 if curr_version and version == 'latest':
                     if module.check_mode:
                         changed = True

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -438,7 +438,7 @@ def main():
 
             # If version is not passed:
             else:
-                ## Extension exists, no request to update so no change
+                # Extension exists, no request to update so no change
                 if curr_version:
                     changed = False
                 else:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -174,7 +174,6 @@ import traceback
 
 try:
     from psycopg2.extras import DictCursor
-    from psycopg2 import sql
 except ImportError:
     # psycopg2 is checked by connect_to_db()
     # from ansible.module_utils.postgres
@@ -201,9 +200,9 @@ executed_queries = []
 
 def ext_delete(cursor, ext, curr_version, cascade):
     if curr_version:
-        query = sql.SQL("DROP EXTENSION {extension}").format(extension=sql.Identifier(ext))
+        query = "DROP EXTENSION \"%s\"" % ext
         if cascade:
-            query += sql.SQL(" CASCADE")
+            query += " CASCADE"
         cursor.execute(query)
         executed_queries.append(cursor.mogrify(query))
         return True
@@ -221,11 +220,11 @@ def ext_update_version(cursor, ext, version):
       ext (str) -- extension name
       version (str) -- extension version
     """
-    query = sql.SQL("ALTER EXTENSION {extension} UPDATE").format(extension=sql.Identifier(ext))
+    query = "ALTER EXTENSION \"%s\" UPDATE" % ext
     params = {}
 
     if version != 'latest':
-        query += sql.SQL(" TO %(ver)s")
+        query += " TO %(ver)s"
         params['ver'] = version
 
     cursor.execute(query, params)
@@ -235,16 +234,16 @@ def ext_update_version(cursor, ext, version):
 
 
 def ext_create(cursor, ext, schema, cascade, version):
-    query = sql.SQL("CREATE EXTENSION {extension}").format(extension=sql.Identifier(ext))
+    query = "CREATE EXTENSION \"%s\"" % ext
     params = {}
 
     if schema:
-        query += sql.SQL(" WITH SCHEMA {ext_schema}").format(ext_schema=sql.Identifier(schema))
+        query += " WITH SCHEMA \"%s\"" % schema
     if version != 'latest':
-        query += sql.SQL(" VERSION %(ver)s")
+        query += " VERSION %(ver)s"
         params['ver'] = version
     if cascade:
-        query += sql.SQL(" CASCADE")
+        query += " CASCADE"
 
     cursor.execute(query, params)
     executed_queries.append(cursor.mogrify(query, params))

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -147,13 +147,14 @@ EXAMPLES = r'''
     cascade: yes
     state: absent
 
-- name: Create extension foo of version 1.2 or update it to that version if it's already created and a valid update path exists
-  community.postgresql.postgresql_ext:
+- name: Create extension foo of version 1.2 or update it to that version if it's already
+  created and a valid update path exists community.postgresql.postgresql_ext:
     db: acme
     name: foo
     version: 1.2
 
-- name: Create the latest available version of extension foo. If already installed, update it to the latest version
+- name: Create the latest available version of extension foo. If already installed,
+  update it to the latest version
   community.postgresql.postgresql_ext:
     db: acme
     name: foo
@@ -302,8 +303,8 @@ def ext_valid_update_path(cursor, ext, current_version, version):
     params = {}
     if version != 'latest':
         query = ("SELECT path FROM pg_extension_update_paths(%(ext)s)"
-                  "WHERE source = %(cv)s"
-                  "AND target = %(ver)s")
+                 "WHERE source = %(cv)s"
+                 "AND target = %(ver)s")
 
         params['ext'] = ext
         params['cv'] = current_version
@@ -311,11 +312,11 @@ def ext_valid_update_path(cursor, ext, current_version, version):
 
         cursor.execute(query, params)
         res = cursor.fetchone()
-        if res != None:
+        if res is not None:
             valid_path = True
     else:
         valid_path = True
-    
+
     return (valid_path)
 
 
@@ -407,7 +408,7 @@ def main():
                         changed = ext_update_version(cursor, ext, version)
                 # Extension exists, no request to update so no change
                 elif curr_version:
-                      changed = False
+                    changed = False
                 else:
                     # If the ext doesn't exist and is available:
                     if available_versions:
@@ -419,7 +420,6 @@ def main():
                     # If the ext doesn't exist and is not available:
                     else:
                         module.fail_json(msg="Extension %s is not available" % ext)
-
 
         elif state == "absent":
             if curr_version:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -154,7 +154,7 @@ EXAMPLES = r'''
     name: foo
     version: 1.2
 
-- name: Create latest available version of extension foo. If already installed, update it to the latest version
+- name: Create the latest available version of extension foo. If already installed, update it to the latest version
   community.postgresql.postgresql_ext:
     db: acme
     name: foo

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -72,8 +72,7 @@ options:
     description:
       - Extension version to add or update to. Has effect with I(state=present) only.
       - If not specified, the latest extension version will be created.
-      - Version downgrade is only supported if extension provides a downgrade path.
-        Otherwise extension must be removed and lower version of extension must be made available.
+      - Downgrading is only supported if the extension provides a downgrade path otherwise the extension must be removed and a lower version of the extension must be made available.
       - Set I(version=latest) to always update the extension to the latest available version.
     type: str
   trust_input:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -412,6 +412,8 @@ def main():
                     # Given version already installed
                     if curr_version == version:
                         changed = False
+                    # Attempt to update to given version or latest version defined in extension control file
+                    # ALTER EXTENSION is actually run if valid, so 'changed' will be true even if nothing updated
                     else:
                         valid_update_path = ext_valid_update_path(cursor, ext, curr_version, version)
                         if valid_update_path:
@@ -436,15 +438,8 @@ def main():
 
             # If version is not passed:
             else:
-                # Extension exists, attempt to update to latest version defined in extension control file
-                # ALTER EXTENSION is actually run, so 'changed' will be true even if nothing updated
-                if curr_version and version == 'latest':
-                    if module.check_mode:
-                        changed = True
-                    else:
-                        changed = ext_update_version(cursor, ext, version)
-                # Extension exists, no request to update so no change
-                elif curr_version:
+                ## Extension exists, no request to update so no change
+                if curr_version:
                     changed = False
                 else:
                     # If the ext doesn't exist and is available:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -201,8 +201,7 @@ executed_queries = []
 
 def ext_delete(cursor, ext, curr_version, cascade):
     if curr_version:
-        query = sql.SQL("DROP EXTENSION {extension}").format(
-                extension=sql.Identifier(ext))
+        query = sql.SQL("DROP EXTENSION {extension}").format(extension=sql.Identifier(ext))
         if cascade:
             query += sql.SQL(" CASCADE")
         cursor.execute(query)
@@ -222,12 +221,11 @@ def ext_update_version(cursor, ext, version):
       ext (str) -- extension name
       version (str) -- extension version
     """
-    query = sql.SQL("ALTER EXTENSION {extension} UPDATE").format(
-            extension=sql.Identifier(ext))
+    query = sql.SQL("ALTER EXTENSION {extension} UPDATE").format(extension=sql.Identifier(ext))
     params = {}
 
     if version != 'latest':
-        query += sql.SQL( " TO %(ver)s")
+        query += sql.SQL(" TO %(ver)s")
         params['ver'] = version
 
     cursor.execute(query, params)
@@ -237,13 +235,11 @@ def ext_update_version(cursor, ext, version):
 
 
 def ext_create(cursor, ext, schema, cascade, version):
-    query = sql.SQL("CREATE EXTENSION {extension}").format(
-            extension=sql.Identifier(ext))
+    query = sql.SQL("CREATE EXTENSION {extension}").format(extension=sql.Identifier(ext))
     params = {}
 
     if schema:
-        query += sql.SQL(" WITH SCHEMA {ext_schema}").format(
-        ext_schema=sql.Identifier(schema))
+        query += sql.SQL(" WITH SCHEMA {ext_schema}").format(ext_schema=sql.Identifier(schema))
     if version != 'latest':
         query += sql.SQL(" VERSION %(ver)s")
         params['ver'] = version

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -153,7 +153,7 @@
   - assert:
       that:
       - result is changed
-      - result.queries == ["ALTER EXTENSION \"{{ test_ext }}\" UPDATE TO '2.0'"]
+      - result.queries == ["SELECT path FROM pg_extension_update_paths('dummy') WHERE source = '1.0' AND target = '2.0'", "ALTER EXTENSION \"{{ test_ext }}\" UPDATE TO '2.0'"]
 
   - name: postgresql_ext_version - check, the version must be 2.0
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -211,7 +211,7 @@
       that:
       - result.rowcount == 1
 
-  - name: postgresql_ext_version - try to update the extension to the latest version again
+  - name: postgresql_ext_version - try to update the extension to the latest version again which always runs an update.
     <<: *task_parameters
     postgresql_ext:
       <<: *pg_parameters
@@ -222,7 +222,17 @@
 
   - assert:
       that:
-      - result is not changed
+      - result is changed
+
+  - name: postgresql_ext_version - check that version number did not change even though update ran
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '3.0'"
+
+  - assert:
+      that:
+      - result.rowcount == 1
 
   - name: postgresql_ext_version - try to downgrade the extension version, must fail
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -153,7 +153,7 @@
   - assert:
       that:
       - result is changed
-      - result.queries == ["SELECT path FROM pg_extension_update_paths('dummy') WHERE source = '1.0' AND target = '2.0'", "ALTER EXTENSION \"{{ test_ext }}\" UPDATE TO '2.0'"]
+      - result.queries == ["ALTER EXTENSION \"{{ test_ext }}\" UPDATE TO '2.0'"]
 
   - name: postgresql_ext_version - check, the version must be 2.0
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -199,7 +199,7 @@
   - assert:
       that:
       - result is changed
-      - result.queries == ["ALTER EXTENSION \"{{ test_ext }}\" UPDATE TO '3.0'"]
+      - result.queries == ["ALTER EXTENSION \"{{ test_ext }}\" UPDATE"]
 
   - name: postgresql_ext_version - check
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -327,7 +327,7 @@
       that:
       - result.rowcount == 1
 
-  - name: postgresql_ext_version - try to install non-existent version
+  - name: postgresql_ext_version - try to install non-existent extension
     <<: *task_parameters
     postgresql_ext:
       <<: *pg_parameters
@@ -338,7 +338,7 @@
   - assert:
       that:
       - result.failed == true
-      - result.msg == "Extension non_existent is not installed"
+      - result.msg == "Extension non_existent is not available"
 
   ######################################################################
   # https://github.com/ansible-collections/community.general/issues/1095


### PR DESCRIPTION
##### SUMMARY
This PR is a bugfix and enhancement for better handling PostgreSQL extensions. The issues surrounding the current handling of extension versions are outlined in the related Issue #129.

Tried to keep it so that there is no change to the current interface or options that the user has to worry about with this update. Only change that the user may see is that a version of "latest" will now always ensure the latest version of an extension is installed whenever the play is run. It did not always do that in all cases before.

The module no longer cares about the actual "version number" of any extension since an extension version is a completely arbitrary string value. What determines which version is "greater" or "less than" another is simply the update paths that the extension author provides, so all version comparison operations have been removed.

For extension updates, this changes the handling of them to simply check if there is a valid update path between the currently installed version and the given target version. This allows supporting of "downgrades" as well if the extension author provides such a method.

Giving a value of "latest" for the extension version works pretty much the same as before, but now it will always attempt to perform an extension update if that value is given. This better supports major version upgrades of PostgreSQL to also include updates to extensions as well if a newer version of the extension is available at that time. For example, when upgrading to PG 13, the version of pg_stat_statements changed to 1.8 to add new columns. If the user had the version of "latest" in their ansible inventory, it would upgrade pg_stat_statements as well as PG if making use of this module.

I'm still not quite familiar with how to get the testing environment for ansible modules set up yet, so I haven't provided updated tests for these changes. I'm attempting to get it figured out, but if someone else could assist with that, that would be great.

I've so far tested these changes with ansible 2.9 and 2.11 myself either by updating the python module manually or by using a custom collections path to the playbook.

Fixes: #129 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
postgresql_ext


