### PR TITLE
Add GHA CI for ansible-test sanity

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -1,0 +1,22 @@
+---
+name: Sanity
+on:
+  pull_request:
+    paths:
+    - 'plugins/**'
+    - '.github/workflows/ansible-test-sanity.yml'
+  push:
+    paths:
+    - 'plugins/**'
+    - '.github/workflows/ansible-test-sanity.yml'
+  schedule:
+  # Every day at 3:14
+  - cron:  '14 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  sanity:
+    uses: data-bene/ansible-collection-gh-workflow/.github/workflows/workflow.yml@release/v1
+    with:
+      fail-fast: false
+      testing-type: sanity

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   sanity:
-    uses: data-bene/ansible-collection-gh-workflow/.github/workflows/workflow.yml@release/v1
+    uses: data-bene/ansible-collection-gh-workflow/.github/workflows/workflow-sanity.yml@release/v1
     with:
       fail-fast: false
-      testing-type: sanity

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -17,5 +17,3 @@ on:
 jobs:
   sanity:
     uses: data-bene/ansible-collection-gh-workflow/.github/workflows/workflow-sanity.yml@release/v1
-    with:
-      fail-fast: false


### PR DESCRIPTION
Edited on https://github.com/ansible-collections/community.postgresql/pull/165#issuecomment-980460927

##### SUMMARY

Setup `ansible-test sanity` with GHA.

Uses upstream projects:

* Action: https://github.com/ansible-community/ansible-test-gh-action
* Action: https://github.com/Data-Bene/ansible-test-versions-gh-action
* Action: https://github.com/dorny/paths-filter
* Worflow: https://github.com/Data-Bene/ansible-collection-gh-workflow

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### COMPONENT NAME

GHA workflow

<!--- Write the short name of the module, plugin, task or feature below -->

