### PR TITLE
bugfix: postgres_info.py now shows the info of each specific database

### DIFF
--- a/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
+++ b/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgres_info - Specific info (namespaces, extensions, languages) of each database was not being shown properly. Instead, the info from the DB that was connected was always being shown.
+- postgres_info - Specific info (namespaces, extensions, languages) of each database was not being shown properly. Instead, the info from the DB that was connected was always being shown (https://github.com/ansible-collections/community.postgresql/issues/172).

--- a/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
+++ b/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
@@ -1,3 +1,2 @@
 bugfixes:
 - postgres_info - Specific info (namespaces, extensions, languages) of each database was not being shown properly. Instead, the info from the DB that was connected was always being shown.
-

--- a/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
+++ b/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
@@ -1,0 +1,3 @@
+bugfixes:
+    - postgres_info - Specific info (namespaces, extensions, languages) of each database was not being shown properly. Instead, the info from the DB that was connected was always being shown.
+

--- a/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
+++ b/changelogs/fragments/173-postgres_info_now_shows_the_info_of_each_specific_database.yml
@@ -1,3 +1,3 @@
 bugfixes:
-    - postgres_info - Specific info (namespaces, extensions, languages) of each database was not being shown properly. Instead, the info from the DB that was connected was always being shown.
+- postgres_info - Specific info (namespaces, extensions, languages) of each database was not being shown properly. Instead, the info from the DB that was connected was always being shown.
 

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -566,7 +566,7 @@ class PgDbConn(object):
         if self.db_conn is not None:
             self.db_conn.close()
 
-        # the lines below seem redudant but they are actually needed for connect to work as expected
+        # the lines below seem redundant but they are actually needed for connect to work as expected
         self.module.params['db'] = dbname
         self.module.params['database'] = dbname
         self.module.params['login_db'] = dbname

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -564,7 +564,7 @@ class PgDbConn(object):
             dbname (string): Database name to connect to.
         """
         if self.db_conn is not None:
-        self.db_conn.close()
+          self.db_conn.close()
 
         # the lines below seem redudant but they are actually needed for connect to work as expected
         self.module.params['db'] = dbname

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -553,8 +553,8 @@ class PgDbConn(object):
         conn_params = get_conn_params(self.module, self.module.params, warn_db_default=False)
         self.db_conn = connect_to_db(self.module, conn_params, fail_on_conn=fail_on_conn)
         if self.db_conn is None:
-          # only happens if fail_on_conn is False and there actually was an issue connecting to the DB
-          return None
+            # only happens if fail_on_conn is False and there actually was an issue connecting to the DB
+            return None
         return self.db_conn.cursor(cursor_factory=DictCursor)
 
     def reconnect(self, dbname):
@@ -564,7 +564,7 @@ class PgDbConn(object):
             dbname (string): Database name to connect to.
         """
         if self.db_conn is not None:
-          self.db_conn.close()
+            self.db_conn.close()
 
         # the lines below seem redudant but they are actually needed for connect to work as expected
         self.module.params['db'] = dbname
@@ -1020,12 +1020,12 @@ class PgClusterInfo(object):
         for datname in db_dict:
             self.cursor = self.db_obj.reconnect(datname)
             if self.cursor is None:
-              # that means we don't have permission to access these database
-              db_dict[datname]['namespaces'] = {}
-              db_dict[datname]['extensions'] = {}
-              db_dict[datname]['languages'] = {}
-              db_dict[datname]['error'] = "could not connect to the database (probably permission issue)"
-              continue
+                # that means we don't have permission to access these database
+                db_dict[datname]['namespaces'] = {}
+                db_dict[datname]['extensions'] = {}
+                db_dict[datname]['languages'] = {}
+                db_dict[datname]['error'] = "could not connect to the database (probably permission issue)"
+                continue
             db_dict[datname]['namespaces'] = self.get_namespaces()
             db_dict[datname]['extensions'] = self.get_ext_info()
             db_dict[datname]['languages'] = self.get_lang_info()

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -1024,7 +1024,7 @@ class PgClusterInfo(object):
                 db_dict[datname]['namespaces'] = {}
                 db_dict[datname]['extensions'] = {}
                 db_dict[datname]['languages'] = {}
-                db_dict[datname]['error'] = "could not connect to the database (probably permission issue)"
+                db_dict[datname]['error'] = "Could not connect to the database."
                 continue
             db_dict[datname]['namespaces'] = self.get_namespaces()
             db_dict[datname]['extensions'] = self.get_ext_info()

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -53,6 +53,48 @@
       name: session_superuser
       role_attr_flags: SUPERUSER
 
+  - name: postgresql_info - create extra DBs for testing
+    <<: *task_parameters
+    postgresql_db:
+      login_user: '{{ pg_user }}'
+      maintenance_db: postgres
+      login_port: '{{ replica_port }}'
+      name: "{{ item }}"
+    loop:
+      - db1
+      - db2
+
+  - name: postgresql_info - create extra schemas for testing
+    <<: *task_parameters
+    postgresql_schema:
+      login_user: '{{ pg_user }}'
+      login_port: '{{ replica_port }}'
+      db:   '{{ item[0] }}'
+      name: "{{ item[1] }}"
+    loop:
+      - [ "db1", "db1_schema1"]
+      - [ "db1", "db1_schema2"]
+      - [ "db2", "db2_schema1"]
+      - [ "db2", "db2_schema2"]
+
+  - name: postgresql_table - create extra tables for testing
+    <<: *task_parameters
+    postgresql_table:
+      login_user: '{{ pg_user }}'
+      login_port: '{{ replica_port }}'
+      db:   '{{ item[0] }}'
+      name: "{{ item[1] }}.{{ item[2] }}"
+      columns: waste_id int
+    loop:
+      - [ "db1", "db1_schema1", "db1_schema1_table1"]
+      - [ "db1", "db1_schema1", "db1_schema1_table2"]
+      - [ "db1", "db1_schema2", "db1_schema2_table1"]
+      - [ "db1", "db1_schema2", "db1_schema2_table2"]
+      - [ "db2", "db2_schema1", "db2_schema1_table1"]
+      - [ "db2", "db2_schema1", "db2_schema1_table2"]
+      - [ "db2", "db2_schema2", "db2_schema2_table1"]
+      - [ "db2", "db2_schema2", "db2_schema2_table2"]
+
   - name: postgresql_info - test return values and session_role param
     <<: *task_parameters
     postgresql_info:
@@ -71,6 +113,12 @@
       - result.databases.{{ db_default }}.extensions
       - result.databases.{{ test_db }}.subscriptions.{{ test_subscription }}
       - result.databases.{{ test_db }}.subscriptions.{{ test_subscription2 }}
+
+      - result.databases.db1.namespaces.db1_schema1
+      - result.databases.db1.namespaces.db1_schema2
+      - result.databases.db2.namespaces.db2_schema1
+      - result.databases.db2.namespaces.db2_schema2
+
       - result.settings
       - result.tablespaces
       - result.roles


### PR DESCRIPTION
##### SUMMARY
fixes #172

The reason `postgres_info.py` was gathering data on every database was because of a bug in `PgDbConn.reconnect()`, which is fixed here.

I also changed the main loop that iterate among all DBs to ignore DBs which it can't access because in AWS RDS not all DBs are accessible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgres_info.py

