### PR TITLE
postgresql_ping: return conn error message

### DIFF
--- a/changelogs/fragments/177-postgresql_ping_add_conn_err_msg_ret_val.yml
+++ b/changelogs/fragments/177-postgresql_ping_add_conn_err_msg_ret_val.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- postgresql_ping - Add the conn_err_msg return value (https://github.com/ansible-collections/community.postgresql/pull/177).
+- postgresql_ping - add the ``conn_err_msg`` return value (https://github.com/ansible-collections/community.postgresql/pull/177).

--- a/changelogs/fragments/177-postgresql_ping_add_conn_err_msg_ret_val.yml
+++ b/changelogs/fragments/177-postgresql_ping_add_conn_err_msg_ret_val.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_ping - Add the conn_err_msg return value (https://github.com/ansible-collections/community.postgresql/pull/177).

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -54,7 +54,7 @@ def ensure_required_libs(module):
 def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
     """Connect to a PostgreSQL database.
 
-    Return a dict containing a psycopg2 connection object and error message / None.
+    Return a tuple containing a psycopg2 connection object and error message / None.
 
     Args:
         module (AnsibleModule) -- object of ansible.module_utils.basic.AnsibleModule class

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -54,7 +54,7 @@ def ensure_required_libs(module):
 def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
     """Connect to a PostgreSQL database.
 
-    Return psycopg2 connection object.
+    Return a dict containing a psycopg2 connection object and error message / None.
 
     Args:
         module (AnsibleModule) -- object of ansible.module_utils.basic.AnsibleModule class
@@ -67,6 +67,7 @@ def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
     ensure_required_libs(module)
 
     db_connection = None
+    conn_err = None
     try:
         db_connection = psycopg2.connect(**conn_params)
         if autocommit:
@@ -91,20 +92,19 @@ def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
             module.fail_json(msg='Postgresql server must be at least '
                                  'version 8.4 to support sslrootcert')
 
-        if fail_on_conn:
-            module.fail_json(msg="unable to connect to database: %s" % to_native(e))
-        else:
-            module.warn("PostgreSQL server is unavailable: %s" % to_native(e))
-            db_connection = None
+        conn_err = to_native(e)
 
     except Exception as e:
+        conn_err = to_native(e)
+
+    if conn_err is not None:
         if fail_on_conn:
-            module.fail_json(msg="unable to connect to database: %s" % to_native(e))
+            module.fail_json(msg="unable to connect to database: %s" % conn_err)
         else:
-            module.warn("PostgreSQL server is unavailable: %s" % to_native(e))
+            module.warn("PostgreSQL server is unavailable: %s" % conn_err)
             db_connection = None
 
-    return db_connection
+    return db_connection, conn_err
 
 
 def exec_sql(obj, query, query_params=None, return_bool=False, add_to_executed=True, dont_exec=False):

--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -379,7 +379,7 @@ def main():
 
     # Connect to DB and make cursor object:
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=False)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     ##############

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -398,7 +398,7 @@ def main():
         module.warn("Parameter version is ignored when state=absent")
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     try:

--- a/plugins/modules/postgresql_idx.py
+++ b/plugins/modules/postgresql_idx.py
@@ -518,7 +518,7 @@ def main():
         module.fail_json(msg="cascade parameter used only with state=absent")
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     # Set defaults:

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -551,7 +551,7 @@ class PgDbConn(object):
         Note: connection parameters are passed by self.module object.
         """
         conn_params = get_conn_params(self.module, self.module.params, warn_db_default=False)
-        self.db_conn = connect_to_db(self.module, conn_params, fail_on_conn=fail_on_conn)
+        self.db_conn = dummy, connect_to_db(self.module, conn_params, fail_on_conn=fail_on_conn)
         if self.db_conn is None:
             # only happens if fail_on_conn is False and there actually was an issue connecting to the DB
             return None

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -551,7 +551,7 @@ class PgDbConn(object):
         Note: connection parameters are passed by self.module object.
         """
         conn_params = get_conn_params(self.module, self.module.params, warn_db_default=False)
-        self.db_conn = dummy, connect_to_db(self.module, conn_params, fail_on_conn=fail_on_conn)
+        self.db_conn, dummy = connect_to_db(self.module, conn_params, fail_on_conn=fail_on_conn)
         if self.db_conn is None:
             # only happens if fail_on_conn is False and there actually was an issue connecting to the DB
             return None

--- a/plugins/modules/postgresql_lang.py
+++ b/plugins/modules/postgresql_lang.py
@@ -309,7 +309,7 @@ def main():
         check_input(module, lang, session_role, owner)
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=False)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor()
 
     changed = False

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -185,7 +185,7 @@ def main():
         check_input(module, groups, target_roles, session_role)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
-    db_connection = connect_to_db(module, conn_params, autocommit=False)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     ##############

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -420,7 +420,7 @@ def main():
         check_input(module, new_owner, obj_name, reassign_owned_by, session_role)
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=False)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     ##############

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -83,6 +83,11 @@ server_version:
   returned: always
   type: dict
   sample: { major: 13, minor: 2, full: '13.2', raw: 'PostgreSQL 13.2 on x86_64-pc-linux-gnu' }
+conn_err_msg:
+  description: Connection error message.
+  returned: always
+  type: str
+  sample: ''
 '''
 
 try:
@@ -177,10 +182,13 @@ def main():
         changed=False,
         is_available=False,
         server_version=dict(),
+        conn_err_msg='',
     )
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
-    db_connection = connect_to_db(module, conn_params, fail_on_conn=False)
+    db_connection, err = connect_to_db(module, conn_params, fail_on_conn=False)
+    if err:
+        result['conn_err_msg'] = err
 
     if db_connection is not None:
         cursor = db_connection.cursor(cursor_factory=DictCursor)

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -88,6 +88,7 @@ conn_err_msg:
   returned: always
   type: str
   sample: ''
+  version_added: 1.7.0
 '''
 
 try:

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -636,7 +636,7 @@ def main():
     # Connect to DB and make cursor object:
     conn_params = get_conn_params(module, module.params)
     # We check publication state without DML queries execution, so set autocommit:
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     # Check version:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -413,7 +413,7 @@ def main():
         query_list.append(query)
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=autocommit)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=autocommit)
     if encoding is not None:
         db_connection.set_client_encoding(encoding)
     cursor = db_connection.cursor(cursor_factory=DictCursor)

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -256,7 +256,7 @@ def main():
     changed = False
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     try:

--- a/plugins/modules/postgresql_sequence.py
+++ b/plugins/modules/postgresql_sequence.py
@@ -534,7 +534,7 @@ def main():
     autocommit = not module.check_mode
     # Connect to DB and make cursor object:
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=autocommit)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=autocommit)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     ##############

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -366,7 +366,7 @@ def main():
         module.fail_json(msg="%s: at least one of value or reset param must be specified" % name)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     kw = {}
@@ -456,7 +456,7 @@ def main():
 
     # Reconnect and recheck current value:
     if context in ('sighup', 'superuser-backend', 'backend', 'superuser', 'user'):
-        db_connection = connect_to_db(module, conn_params, autocommit=True)
+        db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
         cursor = db_connection.cursor(cursor_factory=DictCursor)
 
         res = param_get(cursor, module, name)

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -269,7 +269,7 @@ def main():
         warn_db_default = False
 
     conn_params = get_conn_params(module, module.params, warn_db_default=warn_db_default)
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     ##################################

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -646,7 +646,7 @@ def main():
     # Connect to DB and make cursor object:
     pg_conn_params = get_conn_params(module, module.params)
     # We check subscription state without DML queries execution, so set autocommit:
-    db_connection = connect_to_db(module, pg_conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, pg_conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     # Check version:

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -531,7 +531,7 @@ def main():
         module.fail_json(msg="%s: including param needs like param specified" % table)
 
     conn_params = get_conn_params(module, module.params)
-    db_connection = connect_to_db(module, conn_params, autocommit=False)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     if storage_params:

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -428,7 +428,7 @@ def main():
                     rename_to, session_role, settings_list)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
-    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     # Change autocommit to False if check_mode:

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -933,7 +933,7 @@ def main():
                     role_attr_flags, groups, comment, session_role)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
-    db_connection = connect_to_db(module, conn_params)
+    db_connection, dummy = connect_to_db(module, conn_params)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     try:

--- a/plugins/modules/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/postgresql_user_obj_stat_info.py
@@ -315,7 +315,7 @@ def main():
     # Connect to DB and make cursor object:
     pg_conn_params = get_conn_params(module, module.params)
     # We don't need to commit anything, so, set it to False:
-    db_connection = connect_to_db(module, pg_conn_params, autocommit=False)
+    db_connection, dummy = connect_to_db(module, pg_conn_params, autocommit=False)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     ############################

--- a/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
@@ -66,6 +66,7 @@
 - assert:
     that: 
     - result.is_available == true
+    - result.conn_err_msg == ''
   when:
   - ansible_os_family == 'Debian'
   - postgres_version_resp.stdout is version('9.4', '>=')
@@ -85,3 +86,18 @@
     that:
     - result is failed
     - result.msg is search('is potentially dangerous')
+
+# Check conn_err_msg return value
+- name: Try to connect to non-existent DB
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_ping:
+    db: blahblah
+    login_user: "{{ pg_user }}"
+  register: result
+
+- name: Check conn_err_msg return value
+  assert:
+    that:
+    - result is succeeded
+    - result.conn_err_msg is search("database \"blahblah\" does not exist")

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -222,7 +222,7 @@ class TestConnectToDb():
         monkeypatch.setattr(pg, 'psycopg2', m_psycopg2)
 
         conn_params = pg.get_conn_params(m_ansible_module, m_ansible_module.params)
-        db_connection = pg.connect_to_db(m_ansible_module, conn_params)
+        db_connection, dummy = pg.connect_to_db(m_ansible_module, conn_params)
         cursor = db_connection.cursor()
         # if errors, db_connection returned as None:
         assert type(db_connection) == DbConnection
@@ -238,7 +238,7 @@ class TestConnectToDb():
 
         m_ansible_module.params['session_role'] = 'test_role'
         conn_params = pg.get_conn_params(m_ansible_module, m_ansible_module.params)
-        db_connection = pg.connect_to_db(m_ansible_module, conn_params)
+        db_connection, dummy = pg.connect_to_db(m_ansible_module, conn_params)
         cursor = db_connection.cursor()
         # if errors, db_connection returned as None:
         assert type(db_connection) == DbConnection
@@ -257,7 +257,7 @@ class TestConnectToDb():
         m_ansible_module.params['login_user'] = 'Exception'  # causes Exception
 
         conn_params = pg.get_conn_params(m_ansible_module, m_ansible_module.params)
-        db_connection = pg.connect_to_db(m_ansible_module, conn_params, fail_on_conn=True)
+        db_connection, dummy = pg.connect_to_db(m_ansible_module, conn_params, fail_on_conn=True)
 
         assert 'unable to connect to database' in m_ansible_module.err_msg
         assert db_connection is None
@@ -272,7 +272,7 @@ class TestConnectToDb():
         m_ansible_module.params['login_user'] = 'Exception'  # causes Exception
 
         conn_params = pg.get_conn_params(m_ansible_module, m_ansible_module.params)
-        db_connection = pg.connect_to_db(m_ansible_module, conn_params, fail_on_conn=False)
+        db_connection, dummy = pg.connect_to_db(m_ansible_module, conn_params, fail_on_conn=False)
 
         assert m_ansible_module.err_msg == ''
         assert 'PostgreSQL server is unavailable' in m_ansible_module.warn_msg
@@ -288,7 +288,7 @@ class TestConnectToDb():
         monkeypatch.setattr(pg, 'psycopg2', m_psycopg2)
 
         conn_params = pg.get_conn_params(m_ansible_module, m_ansible_module.params)
-        db_connection = pg.connect_to_db(m_ansible_module, conn_params, autocommit=True)
+        db_connection, dummy = pg.connect_to_db(m_ansible_module, conn_params, autocommit=True)
         cursor = db_connection.cursor()
 
         # if errors, db_connection returned as None:
@@ -301,7 +301,7 @@ class TestConnectToDb():
         monkeypatch.setattr(pg, 'psycopg2', m_psycopg2)
 
         conn_params = pg.get_conn_params(m_ansible_module, m_ansible_module.params)
-        db_connection = pg.connect_to_db(m_ansible_module, conn_params, autocommit=True)
+        db_connection, dummy = pg.connect_to_db(m_ansible_module, conn_params, autocommit=True)
         cursor = db_connection.cursor()
 
         # if errors, db_connection returned as None:


### PR DESCRIPTION
##### SUMMARY

Relates to https://github.com/ansible-collections/community.postgresql/issues/174

@tcraxs @ @klando @MichaelDBA @hunleyd @marcosdiez , needs your opinion on this:
1. Can this ret val be useful? I.e. to be able to use it inside playbooks (now we can see what's wrong only in warnings).
2. If you think this value is useful, should we return it always (i.e. as an empty string when the connection has succeeded) or only when an error occurres?
3. Any other thoughts?

@marcosdiez maybe we could use the related change in `connect_to_db` to fill up messages in https://github.com/ansible-collections/community.postgresql/pull/173

See the integration tests i added to `tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml` to see how it can be used.
```
# Check conn_err_msg return value
- name: Try to connect to non-existent DB
  become_user: "{{ pg_user }}"
  become: yes
  postgresql_ping:
    db: blahblah
    login_user: "{{ pg_user }}"
  register: result

- name: Check conn_err_msg return value
  assert:
    that:
    - result is succeeded
    - result.conn_err_msg is search("database \"blahblah\" does not exist")
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql_ping