### PR TITLE
Prepare for distutils.version being removed in Python 3.12

### DIFF
--- a/changelogs/fragments/178-prepare_for_distutils_be_removed.yml
+++ b/changelogs/fragments/178-prepare_for_distutils_be_removed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Collection core functions - use vendored version of ``distutils.version`` included in ansible-core 2.12 if available. This avoids breakage when ``distutils`` is removed from the standard library of Python 3.12. Note that ansible-core 2.11, ansible-base 2.10 and Ansible 2.9 are right now not compatible with Python 3.12, hence this fix does not target these ansible-core/-base/2.9 versions (https://github.com/ansible-collections/community.postgresql/pull/178)."

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -22,7 +22,7 @@ except ImportError:
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
-from distutils.version import LooseVersion
+from ansible_collections.community.postgresql.plugins.module_utils.version import LooseVersion
 
 
 def postgres_common_argument_spec():

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -3,7 +3,7 @@
 # Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""Provide Version object to compare version numbers."""
+"""Provide version object to compare version numbers."""
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Provide Version object to compare version numbers."""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.six import raise_from
+
+try:
+    from ansible.module_utils.compat.version import LooseVersion
+except ImportError:
+    try:
+        from distutils.version import LooseVersion
+    except ImportError as exc:
+        msg = ('To use this plugin or module with ansible-core < 2.11, '
+               'you need to use Python < 3.12 with distutils.version present')
+        raise_from(ImportError(msg), exc)


### PR DESCRIPTION
##### SUMMARY
Prepare for distutils.version being removed in Python 3.12

Relates to https://github.com/ansible-collections/overview/issues/45#issuecomment-999911221

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request