### PR TITLE
postgresql_script: new module

### DIFF
--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -40,7 +40,7 @@ options:
   path:
     description:
     - Path to a SQL script on the target machine.
-    - To upload dumps or to execute other complex scripts, the preferable way
+    - To upload dumps, the preferable way
       is to use the M(community.postgresql.postgresql_db) module with I(state=restore).
     type: path
   session_role:

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -44,10 +44,10 @@ options:
     type: path
   session_role:
     description:
-    - Switch to session_role after connecting. The specified session_role must
-      be a role that the current login_user is a member of.
+    - Switch to C(session_role) after connecting. The specified role must
+      be a role that the current C(login_user) is a member of.
     - Permissions checking for SQL commands is carried out as though
-      the session_role were the one that had logged in originally.
+      the C(session_role) were the one that had logged in originally.
     type: str
   db:
     description:

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: postgresql_script
+
+short_description: Run PostgreSQL statements from a file
+
+description:
+- Runs arbitrary PostgreSQL statements from a file.
+- Does not run against backup files.
+  Use M(community.postgresql.postgresql_db) with I(state=restore)
+  to run queries on files made by pg_dump/pg_dumpall utilities.
+
+version_added: '2.1.0'
+
+options:
+  positional_args:
+    description:
+    - List of values to substitute variable placeholders within the file content.
+    - When the value is a list, it will be converted to PostgreSQL array.
+    - Mutually exclusive with I(named_args).
+    type: list
+    elements: raw
+  named_args:
+    description:
+    - Dictionary of key-value arguments to substitute
+      variable placeholders within the file content.
+    - When the value is a list, it will be converted to PostgreSQL array.
+    - Mutually exclusive with I(positional_args).
+    type: dict
+  path:
+    description:
+    - Path to a SQL script on the target machine.
+    - To upload dumps or to execute other complex scripts, the preferable way
+      is to use the M(community.postgresql.postgresql_db) module with I(state=restore).
+    type: path
+  session_role:
+    description:
+    - Switch to session_role after connecting. The specified session_role must
+      be a role that the current login_user is a member of.
+    - Permissions checking for SQL commands is carried out as though
+      the session_role were the one that had logged in originally.
+    type: str
+  db:
+    description:
+    - Name of database to connect to and run queries against.
+    type: str
+    aliases:
+    - login_db
+  encoding:
+    description:
+    - Set the client encoding for the current session (e.g. C(UTF-8)).
+    - The default is the encoding defined by the database.
+    type: str
+  trust_input:
+    description:
+    - If C(no), check whether a value of I(session_role) is potentially dangerous.
+    - It makes sense to use C(no) only when SQL injections
+      via I(session_role) are possible.
+    type: bool
+    default: yes
+  search_path:
+    description:
+    - List of schema names to look in.
+    type: list
+    elements: str
+
+seealso:
+- module: community.postgresql.postgresql_db
+- module: community.postgresql.postgresql_query
+- name: PostgreSQL Schema reference
+  description: Complete reference of the PostgreSQL schema documentation.
+  link: https://www.postgresql.org/docs/current/ddl-schemas.html
+
+author:
+- Douglas J Hunley (@hunleyd)
+- A. Hart (@jtelcontar)
+- Daniel Scharon (@DanScharon)
+- Andrew Klychkov (@Andersson007)
+
+extends_documentation_fragment:
+- community.postgresql.postgres
+
+notes:
+- Does not support C(check_mode).
+'''
+
+EXAMPLES = r'''
+# Assuming that the file contains
+# SELECT * FROM id_talbe WHERE id = %s,
+# '%s' will be substituted with 1
+- name: Run query from SQL script using UTF-8 client encoding for session and positional args
+  community.postgresql.postgresql_script:
+    db: test_db
+    path: /var/lib/pgsql/test.sql
+    positional_args:
+      - 1
+    encoding: UTF-8
+
+# Assuming that the file contains
+# SELECT * FROM test WHERE id = %(id_val)s AND story = %(story_val)s,
+# %-values will be substituted with 1 and 'test'
+- name: Select query to test_db with named_args
+  community.postgresql.postgresql_script:
+    db: test_db
+    path: /var/lib/pgsql/test.sql
+    named_args:
+      id_val: 1
+      story_val: test
+
+# Pass list and string vars as positional_args
+- name: Set vars
+  ansible.builtin.set_fact:
+    my_list:
+    - 1
+    - 2
+    - 3
+    my_arr: '{1, 2, 3}'
+
+# Assuming that the the file contains
+# SELECT * FROM test_array_table WHERE arr_col1 = %s AND arr_col2 = %s
+- name: Passing positional_args as arrays
+  community.postgresql.postgresql_script:
+    path: /var/lib/pgsql/test.sql
+    positional_args:
+    - '{{ my_list }}'
+    - '{{ my_arr|string }}'
+
+# Assuming that the the file contains
+# SELECT * FROM test_table,
+# look into app1 schema first, then,
+# if the schema doesn't exist or the table hasn't been found there,
+# try to find it in the schema public
+- name: Select from test using search_path
+  community.postgresql.postgresql_script:
+    path: /var/lib/pgsql/test.sql
+    search_path:
+    - app1
+    - public
+
+# If you use a variable in positional_args/named_args that can
+# be undefined and you wish to set it as NULL, the constructions like
+# "{{ my_var if (my_var is defined) else none | default(none) }}"
+# will not work as expected substituting an empty string instead of NULL.
+# If possible, we suggest to use Ansible's DEFAULT_JINJA2_NATIVE configuration
+# (https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native).
+# Enabling it fixes this problem. If you cannot enable it, the following workaround
+# can be used.
+# You should precheck such a value and define it as NULL when undefined.
+# For example:
+- name: When undefined, set to NULL
+  set_fact:
+    my_var: NULL
+  when: my_var is undefined
+
+# Then, assuming that the file contains
+# INSERT INTO test_table (col1) VALUES (%s)
+- name: Insert a value using positional arguments
+  community.postgresql.postgresql_script:
+    path: /var/lib/pgsql/test.sql
+    positional_args:
+    - '{{ my_var }}'
+'''
+
+RETURN = r'''
+query:
+    description:
+    - Executed query.
+    - When the C(positional_args) or C(named_args) options are used,
+      the query contains all variables that were substituted
+      inside the database connector.
+    returned: always
+    type: str
+    sample: 'SELECT * FROM bar'
+statusmessage:
+    description:
+    - Attribute containing the message returned by the database connector
+      after executing the script content.
+    - When there are several statements in the script, returns a message
+      related to the last statement.
+    returned: always
+    type: str
+    sample: 'INSERT 0 1'
+query_result:
+    description:
+    - List of dictionaries in the column:value form representing returned rows.
+    - When there are several statements in the script,
+      returns result of the last statement.
+    returned: always
+    type: list
+    elements: dict
+    sample: [{"Column": "Value1"},{"Column": "Value2"}]
+rowcount:
+    description:
+    - Number of produced or affected rows.
+    - When there are several statements in the script,
+      returns a number of rows affected by the last statement.
+    returned: changed
+    type: int
+    sample: 5
+'''
+
+try:
+    from psycopg2 import ProgrammingError as Psycopg2ProgrammingError
+    from psycopg2.extras import DictCursor
+except ImportError:
+    # it is needed for checking 'no result to fetch' in main(),
+    # psycopg2 availability will be checked by connect_to_db() into
+    # ansible.module_utils.postgres
+    pass
+
+import datetime
+import decimal
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.postgresql.plugins.module_utils.database import (
+    check_input,
+)
+from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
+    connect_to_db,
+    get_conn_params,
+    postgres_common_argument_spec,
+)
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
+
+
+# ===========================================
+# Module execution.
+#
+
+def list_to_pg_array(elem):
+    """Convert the passed list to PostgreSQL array
+    represented as a string.
+
+    Args:
+        elem (list): List that needs to be converted.
+
+    Returns:
+        elem (str): String representation of PostgreSQL array.
+    """
+    elem = str(elem).strip('[]')
+    elem = '{' + elem + '}'
+    return elem
+
+
+def convert_elements_to_pg_arrays(obj):
+    """Convert list elements of the passed object
+    to PostgreSQL arrays represented as strings.
+
+    Args:
+        obj (dict or list): Object whose elements need to be converted.
+
+    Returns:
+        obj (dict or list): Object with converted elements.
+    """
+    if isinstance(obj, dict):
+        for (key, elem) in iteritems(obj):
+            if isinstance(elem, list):
+                obj[key] = list_to_pg_array(elem)
+
+    elif isinstance(obj, list):
+        for i, elem in enumerate(obj):
+            if isinstance(elem, list):
+                obj[i] = list_to_pg_array(elem)
+
+    return obj
+
+
+def set_search_path(cursor, search_path):
+    """Set session's search_path.
+
+    Args:
+        cursor (Psycopg2 cursor): Database cursor object.
+        search_path (str): String containing comma-separated schema names.
+    """
+    cursor.execute('SET search_path TO %s' % search_path)
+
+
+def main():
+    argument_spec = postgres_common_argument_spec()
+    argument_spec.update(
+        path=dict(type='path'),
+        db=dict(type='str', aliases=['login_db']),
+        positional_args=dict(type='list', elements='raw'),
+        named_args=dict(type='dict'),
+        session_role=dict(type='str'),
+        encoding=dict(type='str'),
+        trust_input=dict(type='bool', default=True),
+        search_path=dict(type='list', elements='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=(('positional_args', 'named_args'),),
+        supports_check_mode=False,
+    )
+
+    path = module.params["path"]
+    positional_args = module.params["positional_args"]
+    named_args = module.params["named_args"]
+    encoding = module.params["encoding"]
+    session_role = module.params["session_role"]
+    trust_input = module.params["trust_input"]
+    search_path = module.params["search_path"]
+
+    if not trust_input:
+        # Check input for potentially dangerous elements:
+        check_input(module, session_role)
+
+    try:
+        with open(path, 'rb') as f:
+            script_content = to_native(f.read())
+
+    except Exception as e:
+        module.fail_json(msg="Cannot read file '%s' : %s" % (path, to_native(e)))
+
+    conn_params = get_conn_params(module, module.params)
+    db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
+    if encoding is not None:
+        db_connection.set_client_encoding(encoding)
+    cursor = db_connection.cursor(cursor_factory=DictCursor)
+
+    if search_path:
+        set_search_path(cursor, '%s' % ','.join([x.strip(' ') for x in search_path]))
+
+    # Prepare args:
+    if positional_args:
+        args = positional_args
+    elif named_args:
+        args = named_args
+    else:
+        args = None
+
+    # Convert elements of type list to strings
+    # representing PG arrays
+    if args:
+        args = convert_elements_to_pg_arrays(args)
+
+    # Set defaults:
+    changed = False
+
+    rowcount = 0
+    statusmessage = ''
+
+    # Execute script content:
+    try:
+        cursor.execute(script_content, args)
+    except Exception as e:
+        cursor.close()
+        db_connection.close()
+        module.fail_json(msg="Cannot execute SQL '%s' %s: %s" % (script_content, args, to_native(e)))
+
+    statusmessage = cursor.statusmessage
+
+    if cursor.rowcount > 0:
+        rowcount = cursor.rowcount
+
+    query_result = []
+    try:
+        for row in cursor.fetchall():
+            # Ansible engine does not support decimals.
+            # An explicit conversion is required on the module's side
+            row = dict(row)
+            for (key, val) in iteritems(row):
+                if isinstance(val, decimal.Decimal):
+                    row[key] = float(val)
+
+                elif isinstance(val, datetime.timedelta):
+                    row[key] = str(val)
+
+            query_result.append(row)
+
+    except Psycopg2ProgrammingError as e:
+        if to_native(e) == "no results to fetch":
+            query_result = {}
+
+    except Exception as e:
+        module.fail_json(msg="Cannot fetch rows from cursor: %s" % to_native(e))
+
+    kw = dict(
+        changed=changed,
+        query=cursor.query,
+        statusmessage=statusmessage,
+        query_result=query_result,
+        rowcount=rowcount,
+    )
+
+    cursor.close()
+    db_connection.close()
+
+    module.exit_json(**kw)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -70,7 +70,7 @@ options:
     default: yes
   search_path:
     description:
-    - List of schema names to look in.
+    - Overrides the list of schemas to search for db objects in.
     type: list
     elements: str
 

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -147,28 +147,28 @@ EXAMPLES = r'''
     - app1
     - public
 
-# If you use a variable in positional_args/named_args that can
-# be undefined and you wish to set it as NULL, the constructions like
-# "{{ my_var if (my_var is defined) else none | default(none) }}"
-# will not work as expected substituting an empty string instead of NULL.
-# If possible, we suggest to use Ansible's DEFAULT_JINJA2_NATIVE configuration
-# (https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native).
-# Enabling it fixes this problem. If you cannot enable it, the following workaround
-# can be used.
-# You should precheck such a value and define it as NULL when undefined.
-# For example:
-- name: When undefined, set to NULL
-  set_fact:
-    my_var: NULL
-  when: my_var is undefined
-
-# Then, assuming that the file contains
-# INSERT INTO test_table (col1) VALUES (%s)
-- name: Insert a value using positional arguments
-  community.postgresql.postgresql_script:
-    path: /var/lib/pgsql/test.sql
-    positional_args:
-    - '{{ my_var }}'
+- block:
+    # If you use a variable in positional_args/named_args that can
+    # be undefined and you wish to set it as NULL, constructions like
+    # "{{ my_var if (my_var is defined) else none | default(none) }}"
+    # will not work as expected substituting an empty string instead of NULL.
+    # If possible, we suggest using Ansible's DEFAULT_JINJA2_NATIVE configuration
+    # (https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native).
+    # Enabling it fixes this problem. If you cannot enable it, the following workaround
+    # can be used.
+    # You should precheck such a value and define it as NULL when undefined.
+    # For example:
+    - name: When undefined, set to NULL
+      set_fact:
+        my_var: NULL
+      when: my_var is undefined
+    # Then, assuming that the file contains
+    # INSERT INTO test_table (col1) VALUES (%s)
+    - name: Insert a value using positional arguments
+      community.postgresql.postgresql_script:
+        path: /var/lib/pgsql/test.sql
+        positional_args:
+          - '{{ my_var }}'
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -117,23 +117,23 @@ EXAMPLES = r'''
       id_val: 1
       story_val: test
 
-# Pass list and string vars as positional_args
-- name: Set vars
-  ansible.builtin.set_fact:
-    my_list:
-    - 1
-    - 2
-    - 3
-    my_arr: '{1, 2, 3}'
-
-# Assuming that the the file contains
-# SELECT * FROM test_array_table WHERE arr_col1 = %s AND arr_col2 = %s
-- name: Passing positional_args as arrays
-  community.postgresql.postgresql_script:
-    path: /var/lib/pgsql/test.sql
-    positional_args:
-    - '{{ my_list }}'
-    - '{{ my_arr|string }}'
+- block:
+  # Assuming that the the file contains
+  # SELECT * FROM test_array_table WHERE arr_col1 = %s AND arr_col2 = %s
+  # Pass list and string vars as positional_args
+  - name: Set vars
+    ansible.builtin.set_fact:
+      my_list:
+      - 1
+      - 2
+      - 3
+      my_arr: '{1, 2, 3}'
+  - name: Passing positional_args as arrays
+    community.postgresql.postgresql_script:
+      path: /var/lib/pgsql/test.sql
+      positional_args:
+        - '{{ my_list }}'
+        - '{{ my_arr|string }}'
 
 # Assuming that the the file contains
 # SELECT * FROM test_table,

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -162,6 +162,7 @@ EXAMPLES = r'''
       set_fact:
         my_var: NULL
       when: my_var is undefined
+
     # Then, assuming that the file contains
     # INSERT INTO test_table (col1) VALUES (%s)
     - name: Insert a value using positional arguments

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -15,6 +15,7 @@ short_description: Run PostgreSQL statements from a file
 
 description:
 - Runs arbitrary PostgreSQL statements from a file.
+- The module always reports that the state has changed.
 - Does not run against backup files.
   Use M(community.postgresql.postgresql_db) with I(state=restore)
   to run queries on files made by pg_dump/pg_dumpall utilities.
@@ -345,12 +346,6 @@ def main():
     if args:
         args = convert_elements_to_pg_arrays(args)
 
-    # Set defaults:
-    changed = False
-
-    rowcount = 0
-    statusmessage = ''
-
     # Execute script content:
     try:
         cursor.execute(script_content, args)
@@ -361,8 +356,7 @@ def main():
 
     statusmessage = cursor.statusmessage
 
-    if cursor.rowcount > 0:
-        rowcount = cursor.rowcount
+    rowcount = cursor.rowcount
 
     query_result = []
     try:
@@ -387,7 +381,7 @@ def main():
         module.fail_json(msg="Cannot fetch rows from cursor: %s" % to_native(e))
 
     kw = dict(
-        changed=changed,
+        changed=True,
         query=cursor.query,
         statusmessage=statusmessage,
         query_result=query_result,

--- a/tests/integration/targets/postgresql_script/aliases
+++ b/tests/integration/targets/postgresql_script/aliases
@@ -1,0 +1,2 @@
+destructive
+shippable/posix/group1

--- a/tests/integration/targets/postgresql_script/defaults/main.yml
+++ b/tests/integration/targets/postgresql_script/defaults/main.yml
@@ -1,0 +1,1 @@
+db_default: postgres

--- a/tests/integration/targets/postgresql_script/files/test0.sql
+++ b/tests/integration/targets/postgresql_script/files/test0.sql
@@ -1,0 +1,4 @@
+SELECT version();
+
+SELECT story FROM test_table
+  WHERE id = %s OR story = 'Данные';

--- a/tests/integration/targets/postgresql_script/files/test1.sql
+++ b/tests/integration/targets/postgresql_script/files/test1.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION add(integer, integer) RETURNS integer
+  AS 'select $1 + $2;'
+  LANGUAGE SQL
+  IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+
+SELECT story FROM test_table
+  WHERE id = %s OR story = 'Данные';
+
+SELECT version();

--- a/tests/integration/targets/postgresql_script/files/test10.sql
+++ b/tests/integration/targets/postgresql_script/files/test10.sql
@@ -1,0 +1,1 @@
+SELECT EXTRACT(epoch from make_interval(secs => 3)) AS extract

--- a/tests/integration/targets/postgresql_script/files/test11.sql
+++ b/tests/integration/targets/postgresql_script/files/test11.sql
@@ -1,0 +1,1 @@
+SELECT make_interval(secs => 3)

--- a/tests/integration/targets/postgresql_script/files/test12.sql
+++ b/tests/integration/targets/postgresql_script/files/test12.sql
@@ -1,0 +1,1 @@
+INSERT INTO test2 (id) VALUES (1)

--- a/tests/integration/targets/postgresql_script/files/test2.sql
+++ b/tests/integration/targets/postgresql_script/files/test2.sql
@@ -1,0 +1,1 @@
+ANALYZE test_table

--- a/tests/integration/targets/postgresql_script/files/test3.sql
+++ b/tests/integration/targets/postgresql_script/files/test3.sql
@@ -1,0 +1,4 @@
+SELECT version();
+
+SELECT story FROM test_table
+  WHERE id = %(item)s OR story = 'Данные';

--- a/tests/integration/targets/postgresql_script/files/test4.sql
+++ b/tests/integration/targets/postgresql_script/files/test4.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_array_table (arr_col) VALUES (%s)

--- a/tests/integration/targets/postgresql_script/files/test5.sql
+++ b/tests/integration/targets/postgresql_script/files/test5.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test_array_table WHERE arr_col = %s

--- a/tests/integration/targets/postgresql_script/files/test6.sql
+++ b/tests/integration/targets/postgresql_script/files/test6.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test_array_table WHERE arr_col = %(arr_val)s;

--- a/tests/integration/targets/postgresql_script/files/test7.sql
+++ b/tests/integration/targets/postgresql_script/files/test7.sql
@@ -1,0 +1,1 @@
+INSERT INTO test1 (id) VALUES (1)

--- a/tests/integration/targets/postgresql_script/files/test8.sql
+++ b/tests/integration/targets/postgresql_script/files/test8.sql
@@ -1,0 +1,1 @@
+SELECT id FROM test1

--- a/tests/integration/targets/postgresql_script/files/test9.sql
+++ b/tests/integration/targets/postgresql_script/files/test9.sql
@@ -1,0 +1,1 @@
+SELECT * FROM blabla

--- a/tests/integration/targets/postgresql_script/meta/main.yml
+++ b/tests/integration/targets/postgresql_script/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_postgresql_db

--- a/tests/integration/targets/postgresql_script/tasks/main.yml
+++ b/tests/integration/targets/postgresql_script/tasks/main.yml
@@ -1,0 +1,7 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Initial CI tests of postgresql_query module
+- import_tasks: postgresql_script_initial.yml

--- a/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
+++ b/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
@@ -1,0 +1,314 @@
+
+- vars:
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: yes
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: '{{ db_default }}'
+
+  block:
+
+  - name: Drop test table if exists
+    <<: *task_parameters
+    shell: psql postgres -U "{{ pg_user }}" -t -c "DROP TABLE IF EXISTS test_table;"
+    ignore_errors: true
+
+  - name: Create test table called test_table
+    <<: *task_parameters
+    shell: psql postgres -U "{{ pg_user }}" -t -c "CREATE TABLE test_table (id int, story text);"
+    ignore_errors: true
+
+  - name: Insert some data into test_table
+    <<: *task_parameters
+    shell: psql postgres -U "{{ pg_user }}" -t -c "INSERT INTO test_table (id, story) VALUES (1, 'first'), (2, 'second'), (3, 'third');"
+    ignore_errors: true
+
+  - name: Copy script files
+    become: yes
+    copy:
+      src: '{{ item }}'
+      dest: '~{{ pg_user }}/{{ item }}'
+      owner: '{{ pg_user }}'
+      force: yes
+    loop:
+    - test0.sql
+    - test1.sql
+    - test2.sql
+    - test3.sql
+    - test4.sql
+    - test5.sql
+    - test6.sql
+    - test7.sql
+    - test8.sql
+    - test9.sql
+    - test10.sql
+    - test11.sql
+    - test12.sql
+
+  - name: Analyze test_table
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: '~{{ pg_user }}/test2.sql'
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == 'ANALYZE test_table\n'
+      - result.rowcount != 0
+      - result.statusmessage == 'ANALYZE'
+      - result.query_result == {}
+
+  - name: Run queries from SQL script using positional_args
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test0.sql
+      positional_args:
+      - 1
+      encoding: UTF-8
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "SELECT version();\n\nSELECT story FROM test_table\n  WHERE id = 1 OR story = 'Данные';\n"
+      - result.query_result[0].story == 'first'
+      - result.rowcount == 1
+      - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
+
+  - name: Run queries from SQL script using named_args
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test3.sql
+      named_args:
+        item: 1
+      encoding: UTF-8
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "SELECT version();\n\nSELECT story FROM test_table\n  WHERE id = 1 OR story = 'Данные';\n"
+      - result.query_result[0].story == 'first'
+      - result.rowcount == 1
+      - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
+
+  - name: Create test table for issue 59955
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: test_array_table
+      columns:
+      - arr_col int[]
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - set_fact:
+      my_list:
+      - 1
+      - 2
+      - 3
+      my_arr: '{1, 2, 3}'
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - name: Insert array into test table by positional args
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test4.sql
+      positional_args:
+      - '{{ my_list }}'
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "INSERT INTO test_array_table (arr_col) VALUES ('{1, 2, 3}')\n"
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - name: Select array from test table by passing positional_args
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test5.sql
+      positional_args:
+      - '{{ my_list }}'
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'\n"
+      - result.rowcount == 1
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - name: Select array from test table by passing named_args
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test6.sql
+      named_args:
+        arr_val:
+        - '{{ my_list }}'
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}';\n"
+      - result.rowcount == 1
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - name: Select array from test table by passing positional_args as a string
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test5.sql
+      positional_args:
+      - '{{ my_arr|string }}'
+      trust_input: yes
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'\n"
+      - result.rowcount == 1
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  - name: Test trust_input parameter
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+      path: ~{{ pg_user }}/test5.sql
+      trust_input: no
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')
+
+  - name: Clean up
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: test_array_table
+      state: absent
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  #############################
+  # Check search_path parameter
+
+  - name: Create test schemas
+    <<: *task_parameters
+    postgresql_schema:
+      <<: *pg_parameters
+      name: '{{ item }}'
+    loop:
+    - query_test1
+    - query_test2
+
+  - name: Create test tables
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: '{{ item }}'
+      columns:
+      - id int
+    loop:
+    - 'query_test1.test1'
+    - 'query_test2.test2'
+
+  - name: Insert data
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/{{ item }}.sql
+      search_path:
+      - query_test1
+      - query_test2
+    loop:
+    - test7
+    - test12
+
+  - name: Get data
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test8.sql
+      search_path:
+      - query_test1
+      - query_test2
+
+  - assert:
+      that:
+      - result.rowcount == 1
+
+  - name: Get data, must fail as we don't specify search_path
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test8.sql
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+
+  #############################################################################
+  # Issue https://github.com/ansible-collections/community.postgresql/issues/45
+  - name: Create table containing a decimal value
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: blabla
+      columns:
+      - id int
+      - num decimal
+
+  - name: Insert data
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: INSERT INTO blabla (id, num) VALUES (1, 1::decimal)
+
+  - name: Get data
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test9.sql
+
+  - assert:
+      that:
+      - result.rowcount == 1
+
+  #############################################################################
+  # Issue https://github.com/ansible-collections/community.postgresql/issues/47
+  - name: Get datetime.timedelta value
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test10.sql
+    when: postgres_version_resp.stdout is version('10', '>=')
+
+  - assert:
+      that:
+      - result.rowcount == 1
+      - result.query_result[0]["extract"] == 3 or result.query_result[0]["extract"] == 3.0
+    when: postgres_version_resp.stdout is version('10', '>=')
+
+  - name: Get interval value
+    <<: *task_parameters
+    postgresql_script:
+      <<: *pg_parameters
+      path: ~{{ pg_user }}/test11.sql
+    when: postgres_version_resp.stdout is version('10', '>=')
+
+  - assert:
+      that:
+      - result.rowcount == 1
+      - result.query_result[0]["make_interval"] == "0:00:03"
+    when: postgres_version_resp.stdout is version('10', '>=')

--- a/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
+++ b/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
@@ -1,4 +1,3 @@
-
 - vars:
     task_parameters: &task_parameters
       become_user: '{{ pg_user }}'
@@ -7,9 +6,7 @@
     pg_parameters: &pg_parameters
       login_user: '{{ pg_user }}'
       login_db: '{{ db_default }}'
-
   block:
-
   - name: Drop test table if exists
     <<: *task_parameters
     shell: psql postgres -U "{{ pg_user }}" -t -c "DROP TABLE IF EXISTS test_table;"


### PR DESCRIPTION
##### SUMMARY
postgresql_script: new module - Runs SQL statements from a file.

Relates to the discussion in https://github.com/ansible-collections/community.postgresql/issues/180#issuecomment-1032610020

The rough plan is:
- [ ] Release this module
- [ ] Add a deprecation warning to the `postgresql_query` module about deprecation of the `path_to_script` and `as_single_query` options and related ret values. The warning will ask users to use the `postgresql_script` module
- [ ] Update docs in the `postgresql_query` module
- [ ] Announce the deprecation and removal in the next major release (6 months - 1 year)

In this PR:
- [x] Discuss module's interface
- [x] Cover stuff with CI (and maybe unit tests)
- [ ] Ask folks for manual testing

After releasing
- [ ] Move functions shared between `postgresql_query` and `postgresql_script` to `module_utils/postgres.py` and import them from there.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql_script