### PR TITLE
module_utils: get rid of deprecated alias database for conn param dbname when psycopg2 is 2.7+

### DIFF
--- a/changelogs/fragments/1-postgresq_connection_fix.yml
+++ b/changelogs/fragments/1-postgresq_connection_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- module core functions - get rid of the deprecated psycopg2 connection alias ``database`` in favor of ``dbname`` when psycopg2 is 2.7+ (https://github.com/ansible-collections/community.postgresql/pull/196).

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -184,16 +184,28 @@ def get_conn_params(module, params_dict, warn_db_default=True):
     }
 
     # Might be different in the modules:
-    if params_dict.get('db'):
-        params_map['db'] = 'database'
-    elif params_dict.get('database'):
-        params_map['database'] = 'database'
-    elif params_dict.get('login_db'):
-        params_map['login_db'] = 'database'
+    if LooseVersion(psycopg2.__version__) >= LooseVersion('2.7.0'):
+        if params_dict.get('db'):
+            params_map['db'] = 'dbname'
+        elif params_dict.get('database'):
+            params_map['database'] = 'dbname'
+        elif params_dict.get('login_db'):
+            params_map['login_db'] = 'dbname'
+        else:
+            if warn_db_default:
+                module.warn('Database name has not been passed, '
+                            'used default database to connect to.')
     else:
-        if warn_db_default:
-            module.warn('Database name has not been passed, '
-                        'used default database to connect to.')
+        if params_dict.get('db'):
+            params_map['db'] = 'database'
+        elif params_dict.get('database'):
+            params_map['database'] = 'database'
+        elif params_dict.get('login_db'):
+            params_map['login_db'] = 'database'
+        else:
+            if warn_db_default:
+                module.warn('Database name has not been passed, '
+                            'used default database to connect to.')
 
     kw = dict((params_map[k], v) for (k, v) in iteritems(params_dict)
               if k in params_map and v != '' and v is not None)

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -314,12 +314,14 @@ class TestGetConnParams():
 
     """Namespace for testing get_conn_params() function."""
 
-    def test_get_conn_params_def(self, m_ansible_module):
+    def test_get_conn_params_def(self, m_ansible_module, m_psycopg2, monkeypatch):
         """Test get_conn_params(), warn_db_default kwarg is default."""
+        monkeypatch.setattr(pg, 'psycopg2', m_psycopg2)
         assert pg.get_conn_params(m_ansible_module, INPUT_DICT) == EXPECTED_DICT
         assert m_ansible_module.warn_msg == 'Database name has not been passed, used default database to connect to.'
 
-    def test_get_conn_params_warn_db_def_false(self, m_ansible_module):
+    def test_get_conn_params_warn_db_def_false(self, m_ansible_module, m_psycopg2, monkeypatch):
         """Test get_conn_params(), warn_db_default kwarg is False."""
+        monkeypatch.setattr(pg, 'psycopg2', m_psycopg2)
         assert pg.get_conn_params(m_ansible_module, INPUT_DICT, warn_db_default=False) == EXPECTED_DICT
         assert m_ansible_module.warn_msg == ''


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/194

The `database` conn param was deprecated as a keyword argument in favor of `dbname` since psycopg2 2.7.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request