### PR TITLE
Update changelog.yaml

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -222,7 +222,7 @@ releases:
       bugfixes:
       - module core functions - get rid of the deprecated psycopg2 connection alias
         ``database`` in favor of ``dbname`` when psycopg2 is 2.7+ (https://github.com/ansible-collections/community.postgresql/pull/196).
-      - postgresql_query - cannot handle .sql file with \n at end of file (https://github.com/ansible-collections/community.postgresql/issues/180).
+      - postgresql_query - cannot handle .sql file with \\n at end of file (https://github.com/ansible-collections/community.postgresql/issues/180).
       release_summary: 'This is the bugfix release of the ``community.postgresql``
         collection.
 


### PR DESCRIPTION
Escape the backslash in '\n' (backslash 'n') so that the bugfix comment for release 1.7.1 is correctly being displayed on GitHub.