### PR TITLE
deprecate 'priv' argument in postgresql_user

### DIFF
--- a/changelogs/fragments/0-postgresql_user_depraction_of_privs.yml
+++ b/changelogs/fragments/0-postgresql_user_depraction_of_privs.yml
@@ -1,0 +1,2 @@
+major_changes:
+- postgresql_user - the ``priv`` argument has been deprecated and will be removed in ``community.postgresql 3.0.0``. Please use the ``postgresql_privs`` module to grant/revoke privileges instead (https://github.com/ansible-collections/community.postgresql/issues/212).

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -21,6 +21,7 @@ description:
 - Set I(fail_on_user) to C(no) to make the module ignore failures when trying to remove a user.
   In this case, the module reports if changes happened as usual and separately reports
   whether the user has been removed or not.
+- B(WARNING) The C(priv) option has been B(deprecated) and will be removed in community.postgresql 3.0.0. Please use the I(postgresql_privs) module instead.
 options:
   name:
     description:
@@ -58,6 +59,9 @@ options:
     - fail_on_role
   priv:
     description:
+    - This option has been B(deprecated) and will be removed in
+      community.postgresql 3.0.0. Please use the I(postgresql_privs) module to
+      GRANT/REVOKE permissions instead.
     - "Slash-separated PostgreSQL privileges string: C(priv1/priv2), where
       you can define the user's privileges for the database ( allowed options - 'CREATE',
       'CONNECT', 'TEMPORARY', 'TEMP', 'ALL'. For example C(CONNECT) ) or
@@ -312,12 +316,13 @@ FLAGS_BY_VERSION = {'BYPASSRLS': 90500}
 
 SCRAM_SHA256_REGEX = r'^SCRAM-SHA-256\$(\d+):([A-Za-z0-9+\/=]+)\$([A-Za-z0-9+\/=]+):([A-Za-z0-9+\/=]+)$'
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'ALL')),
                    database=frozenset(
                        ('CREATE', 'CONNECT', 'TEMPORARY', 'TEMP', 'ALL')),
                    )
 
-# map to cope with idiosyncracies of SUPERUSER and LOGIN
+# map to cope with idiosyncrasies of SUPERUSER and LOGIN
 PRIV_TO_AUTHID_COLUMN = dict(SUPERUSER='rolsuper', CREATEROLE='rolcreaterole',
                              CREATEDB='rolcreatedb', INHERIT='rolinherit', LOGIN='rolcanlogin',
                              REPLICATION='rolreplication', BYPASSRLS='rolbypassrls')
@@ -608,6 +613,7 @@ def user_delete(cursor, user):
     return True
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def has_table_privileges(cursor, user, table, privs):
     """
     Return the difference between the privileges that a user already has and
@@ -625,6 +631,7 @@ def has_table_privileges(cursor, user, table, privs):
     return (have_currently, other_current, desired)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def get_table_privileges(cursor, user, table):
     if '.' in table:
         schema, table = table.split('.', 1)
@@ -636,6 +643,7 @@ def get_table_privileges(cursor, user, table):
     return frozenset([x[0] for x in cursor.fetchall()])
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def grant_table_privileges(cursor, user, table, privs):
     # Note: priv escaped by parse_privs
     privs = ', '.join(privs)
@@ -645,6 +653,7 @@ def grant_table_privileges(cursor, user, table, privs):
     cursor.execute(query)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def revoke_table_privileges(cursor, user, table, privs):
     # Note: priv escaped by parse_privs
     privs = ', '.join(privs)
@@ -654,6 +663,7 @@ def revoke_table_privileges(cursor, user, table, privs):
     cursor.execute(query)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def get_database_privileges(cursor, user, db):
     priv_map = {
         'C': 'CREATE',
@@ -674,6 +684,7 @@ def get_database_privileges(cursor, user, db):
     return normalize_privileges(o, 'database')
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def has_database_privileges(cursor, user, db, privs):
     """
     Return the difference between the privileges that a user already has and
@@ -691,6 +702,7 @@ def has_database_privileges(cursor, user, db, privs):
     return (have_currently, other_current, desired)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def grant_database_privileges(cursor, user, db, privs):
     # Note: priv escaped by parse_privs
     privs = ', '.join(privs)
@@ -705,6 +717,7 @@ def grant_database_privileges(cursor, user, db, privs):
     cursor.execute(query)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def revoke_database_privileges(cursor, user, db, privs):
     # Note: priv escaped by parse_privs
     privs = ', '.join(privs)
@@ -719,6 +732,7 @@ def revoke_database_privileges(cursor, user, db, privs):
     cursor.execute(query)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def revoke_privileges(cursor, user, privs):
     if privs is None:
         return False
@@ -740,6 +754,7 @@ def revoke_privileges(cursor, user, privs):
     return changed
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def grant_privileges(cursor, user, privs):
     if privs is None:
         return False
@@ -791,6 +806,7 @@ def parse_role_attrs(role_attr_flags, srv_version):
     return ' '.join(flags)
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def normalize_privileges(privs, type_):
     new_privs = set(privs)
     if 'ALL' in new_privs:
@@ -803,6 +819,7 @@ def normalize_privileges(privs, type_):
     return new_privs
 
 
+# WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
 def parse_privs(privs, db):
     """
     Parse privilege string to determine permissions for database db.
@@ -886,7 +903,7 @@ def main():
         user=dict(type='str', required=True, aliases=['name']),
         password=dict(type='str', default=None, no_log=True),
         state=dict(type='str', default='present', choices=['absent', 'present']),
-        priv=dict(type='str', default=None),
+        priv=dict(type='str', default=None, removed_in_version='3.0.0', removed_from_collection='community.postgreql'),
         db=dict(type='str', default='', aliases=['login_db']),
         fail_on_user=dict(type='bool', default=True, aliases=['fail_on_role']),
         role_attr_flags=dict(type='str', default=''),
@@ -908,8 +925,10 @@ def main():
     password = module.params["password"]
     state = module.params["state"]
     fail_on_user = module.params["fail_on_user"]
+    # WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
     if module.params['db'] == '' and module.params["priv"] is not None:
         module.fail_json(msg="privileges require a database to be specified")
+    # WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
     privs = parse_privs(module.params["priv"], module.params["db"])
     no_password_changes = module.params["no_password_changes"]
     if module.params["encrypted"]:
@@ -963,6 +982,7 @@ def main():
                                  exception=traceback.format_exc())
             except SQLParseError as e:
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+        # WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
         try:
             changed = grant_privileges(cursor, user, privs) or changed
         except SQLParseError as e:
@@ -988,6 +1008,7 @@ def main():
                 changed = True
                 kw['user_removed'] = True
             else:
+                # WARNING: privs are deprecated and will  be removed in community.postgresql 3.0.0
                 try:
                     changed = revoke_privileges(cursor, user, privs)
                     user_removed = user_delete(cursor, user)


### PR DESCRIPTION
##### SUMMARY
Deprecate the `priv` argument of postgresql_user in favor of the postgresql_privs module

fixes #212

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_user
