### PR TITLE
Documentation change for postgresql_owner.py 

### DIFF
--- a/changelogs/fragments/issue_240_doc_change.yml
+++ b/changelogs/fragments/issue_240_doc_change.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- postgresql_owner - Change documentation to specify that ``REASSIGNED OWNED BY`` will impact the entire cluster/instance and not just a single database. 

--- a/changelogs/fragments/issue_240_doc_change.yml
+++ b/changelogs/fragments/issue_240_doc_change.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_owner - Change documentation to specify that ``REASSIGNED OWNED BY`` will impact the entire cluster/instance and not just a single database. 

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -38,7 +38,7 @@ options:
     description:
     - The list of role names. The ownership of all the objects within the current database,
       and of all shared objects (databases, tablespaces), owned by this role(s) will be reassigned to I(owner).
-    - Pay attention - it reassigns all objects owned by this role(s) in the I(db)!
+    - Pay attention - it reassigns all objects owned by this role(s) in the I(instance)!
     - If role(s) exists, always returns changed True.
     - Cannot reassign ownership of objects that are required by the database system.
     - Mutually exclusive with C(obj_type).


### PR DESCRIPTION
##### SUMMARY
Update documentation to reflect what actually happens when `REASSIGNED OWNED BY` is invoked. 


##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
`postgresql_owner`



