### PR TITLE
fix: Cast connparams to allow idempotence (#280)

### DIFF
--- a/changelogs/fragments/285-postgresql_subscription_fix_idempontece.yml
+++ b/changelogs/fragments/285-postgresql_subscription_fix_idempontece.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - postgresql_subscription - Fix idempotence by casting the connparams dict variable
+  - postgresql_subscription - fix idempotence by casting the ``connparams`` dict variable (https://github.com/ansible-collections/community.postgresql/issues/280).

--- a/changelogs/fragments/285-postgresql_subscription_fix_idempontece.yml
+++ b/changelogs/fragments/285-postgresql_subscription_fix_idempontece.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_subscription - Fix idempotence by casting the connparams dict variable

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -331,7 +331,10 @@ class PgSubscription():
         if subscr_info.get('subconninfo'):
             for param in subscr_info['subconninfo'].split(' '):
                 tmp = param.split('=')
-                self.attrs['conninfo'][tmp[0]] = tmp[1]
+                try:
+                    self.attrs['conninfo'][tmp[0]] = int(tmp[1])
+                except ValueError:
+                    self.attrs['conninfo'][tmp[0]] = tmp[1]
 
         return True
 

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -264,7 +264,7 @@ def convert_subscr_params(params_dict):
 
     return ', '.join(params_list)
 
- def cast_connparams(connparams):
+def cast_connparams(connparams):
     """Cast the passed connparams dictionary
 
     Returns:

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -264,6 +264,7 @@ def convert_subscr_params(params_dict):
 
     return ', '.join(params_list)
 
+
 def cast_connparams(connparams):
     """Cast the passed connparams dictionary
 

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -331,10 +331,7 @@ class PgSubscription():
         if subscr_info.get('subconninfo'):
             for param in subscr_info['subconninfo'].split(' '):
                 tmp = param.split('=')
-                try:
-                    self.attrs['conninfo'][tmp[0]] = int(tmp[1])
-                except ValueError:
-                    self.attrs['conninfo'][tmp[0]] = tmp[1]
+                self.attrs['conninfo'][tmp[0]] = tmp[1]
 
         return True
 

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -264,6 +264,20 @@ def convert_subscr_params(params_dict):
 
     return ', '.join(params_list)
 
+ def cast_connparams(connparams):
+    """Cast the passed connparams dictionary
+
+    Returns:
+        Dictionary
+    """
+    for (param, val) in iteritems(connparams):
+        try:
+            connparams[param] = int(val)
+        except ValueError:
+            connparams[param] = val
+
+    return connparams
+
 
 class PgSubscription():
     """Class to work with PostgreSQL subscription.
@@ -368,7 +382,7 @@ class PgSubscription():
         """Update the subscription.
 
         Args:
-            connparams (str): Connection string in libpq style.
+            connparams (dict): Connection dict in libpq style.
             publications (list): Publications on the primary to use.
             subsparams (dict): Dictionary of optional parameters.
 
@@ -683,7 +697,7 @@ def main():
                                           check_mode=module.check_mode)
 
         else:
-            changed = subscription.update(connparams,
+            changed = subscription.update(cast_connparams(connparams),
                                           publications,
                                           subsparams,
                                           check_mode=module.check_mode)

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -265,19 +265,19 @@ def convert_subscr_params(params_dict):
     return ', '.join(params_list)
 
 
-def cast_connparams(connparams):
-    """Cast the passed connparams dictionary
+def cast_connparams(connparams_dict):
+    """Cast the passed connparams_dict dictionary
 
     Returns:
         Dictionary
     """
-    for (param, val) in iteritems(connparams):
+    for (param, val) in iteritems(connparams_dict):
         try:
-            connparams[param] = int(val)
+            connparams_dict[param] = int(val)
         except ValueError:
-            connparams[param] = val
+            connparams_dict[param] = val
 
-    return connparams
+    return connparams_dict
 
 
 class PgSubscription():
@@ -698,7 +698,10 @@ def main():
                                           check_mode=module.check_mode)
 
         else:
-            changed = subscription.update(cast_connparams(connparams),
+            if connparams:
+                connparams = cast_connparams(connparams)
+
+            changed = subscription.update(connparams,
                                           publications,
                                           subsparams,
                                           check_mode=module.check_mode)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #280. `postgresql_subscription` module is not idempotent because the port is cast to `int`  in the following chunk of code( [335](https://github.com/ansible-collections/community.postgresql/blob/639197ead257c1b4c63627d035996790e904cf6e/plugins/modules/postgresql_subscription.py#L335)):

```py
                try:
                    self.attrs['conninfo'][tmp[0]] = int(tmp[1])
                except ValueError:
                    self.attrs['conninfo'][tmp[0]] = tmp[1]
```
On line [385](https://github.com/ansible-collections/community.postgresql/blob/639197ead257c1b4c63627d035996790e904cf6e/plugins/modules/postgresql_subscription.py#L385) the if condition always return false  because variable `connparams` is a dict of string
```py
            if connparams != self.attrs['conninfo']:
                changed = self.__set_conn_params(convert_conn_params(connparams),
                                                 check_mode=check_mode)
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
