### PR TITLE
deprecate groups argument

### DIFF
--- a/changelogs/0-postgresql_user-deprecate-privs-manipulation.yml
+++ b/changelogs/0-postgresql_user-deprecate-privs-manipulation.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - postgresql_user - the ``groups`` argument has been deprecated and will be removed in ``community.postgresql 3.0.0``. Please use the ``postgresql_membership`` module to specify group/role memberships instead (https://github.com/ansible-collections/community.postgresql/issues/277).

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -23,6 +23,8 @@ description:
   whether the user has been removed or not.
 - B(WARNING) The I(priv) option has been B(deprecated) and will be removed in community.postgresql 3.0.0. Please use the
   M(community.postgresql.postgresql_privs) module instead.
+- B(WARNING) The I(groups) option has been B(deprecated) ans will be removed in community.postgresql 3.0.0.
+  Please use the M(community.postgresql.postgresql_membership) module instead.
 options:
   name:
     description:
@@ -139,6 +141,9 @@ options:
     aliases: [ ssl_rootcert ]
   groups:
     description:
+    - This option has been B(deprecated) and will be removed in community.postgresql 3.0.0.
+      Please use the I(postgresql_membership) module to GRANT/REVOKE group/role memberships
+      instead.
     - The list of groups (roles) that you want to grant to the user.
     type: list
     elements: str
@@ -244,6 +249,8 @@ EXAMPLES = r'''
     user: test
     password: ""
 
+# This example uses the `group` argument which is deprecated.
+# You should use the `postgresql_membership` module instead.
 - name: Create user test and grant group user_ro and user_rw to it
   community.postgresql.postgresql_user:
     name: test
@@ -917,6 +924,7 @@ def main():
         expires=dict(type='str', default=None),
         conn_limit=dict(type='int', default=None),
         session_role=dict(type='str'),
+        # WARNING: groups are deprecated and will  be removed in community.postgresql 3.0.0
         groups=dict(type='list', elements='str'),
         comment=dict(type='str', default=None),
         trust_input=dict(type='bool', default=True),
@@ -943,6 +951,7 @@ def main():
     expires = module.params["expires"]
     conn_limit = module.params["conn_limit"]
     role_attr_flags = module.params["role_attr_flags"]
+    # WARNING: groups are deprecated and will  be removed in community.postgresql 3.0.0
     groups = module.params["groups"]
     if groups:
         groups = [e.strip() for e in groups]
@@ -952,6 +961,7 @@ def main():
     trust_input = module.params['trust_input']
     if not trust_input:
         # Check input for potentially dangerous elements:
+        # WARNING: groups are deprecated and will  be removed in community.postgresql 3.0.0
         check_input(module, user, password, privs, expires,
                     role_attr_flags, groups, comment, session_role)
 
@@ -995,6 +1005,7 @@ def main():
         except SQLParseError as e:
             module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
+        # WARNING: groups are deprecated and will  be removed in community.postgresql 3.0.0
         if groups:
             target_roles = []
             target_roles.append(user)


### PR DESCRIPTION
##### SUMMARY

Deprecate the `groups` arugment for eventual removal. End users should
use `postgresql_membership` instead to alter which groups/roles a db
user belongs to.

Spawned from #277 277

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_user

