### PR TITLE
idempotent when password is scram hashed

### DIFF
--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -423,6 +423,11 @@ def user_should_we_change_password(current_role_attrs, user, password, encrypted
         if password == '':
             if current_role_attrs['rolpassword'] is not None:
                 pwchanging = True
+        
+        # If the provided password is a SCRAM hash, compare it directly to the current password
+        elif re.match(SCRAM_SHA256_REGEX, password):
+            if password != current_role_attrs['rolpassword']:
+                pwchanging = True
 
         # SCRAM hashes are represented as a special object, containing hash data:
         # `SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>`

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -423,7 +423,6 @@ def user_should_we_change_password(current_role_attrs, user, password, encrypted
         if password == '':
             if current_role_attrs['rolpassword'] is not None:
                 pwchanging = True
-        
         # If the provided password is a SCRAM hash, compare it directly to the current password
         elif re.match(SCRAM_SHA256_REGEX, password):
             if password != current_role_attrs['rolpassword']:


### PR DESCRIPTION
##### SUMMARY

Add a test to user_should_we_change_password to check if the password parameter is a SCRAM-256 hash, and if it is the same as the stored password.

This is a similar approach to when the provided password is a MD5 hash.

Fixes #301

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
community.postgresql.postgresql_user

