### PR TITLE
postgresql_pg_hba: bulk rule editing

### DIFF
--- a/changelogs/fragments/303-postgresql_pg_hba_add_bulk_rule_arguments.yml
+++ b/changelogs/fragments/303-postgresql_pg_hba_add_bulk_rule_arguments.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - "postgresql_pg_hba - add argument ``rules`` to specify a list of rules using the normal rule-specific argument in each item (https://github.com/ansible-collections/community.postgresql/issues/297)."
+  - >-
+    postgresql_pg_hba - add argument ``rules_behavior`` (choices: conflict (default), combine) to fail when ``rules``
+    and normal rule-specific arguments are given or, when ``combine``, use them as defaults for the ``rules`` items
+    (https://github.com/ansible-collections/community.postgresql/issues/297).
+  - "postgresql_pg_hba - add argument ``overwrite`` (bool, default: false) to remove unmanaged rules (https://github.com/ansible-collections/community.postgresql/issues/297)."

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -90,6 +90,11 @@ options:
     type: str
     default: sdu
     choices: [ sdu, sud, dsu, dus, usd, uds ]
+  overwrite:
+    description:
+      - Remove all existing rules before adding rules. (Like C(state: absent) for all pre-existing rules.)
+    type: bool
+    default: false
   keep_comments_at_rules:
     description:
       - If C(true), comments that stand together with a rule in one line are kept behind that line.
@@ -97,6 +102,23 @@ options:
     type: bool
     default: false
     version_added: '1.5.0'
+  rules:
+    description:
+      - A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once. 
+        Each object can have the following keys (the "rule-specific arguments"), which are treated the same as if they
+        were arguments of this module:
+      - C(address), C(comment), C(contype), C(databases), C(method), C(netmask), C(options), C(state), C(users)
+      - See also C(rules_behavior).
+    type: list
+  rules_behavior:
+    description:
+      - Configure how the C(rules) argument works with the rule-specific arguments outside the C(rules) argument
+        together: If C(conflict), don't. Fail if C(rules) and e.g. C(address) are set. If C(combine), the normal
+        rule-specific arguments are not defining a rule, but are used as defaults for the arguments in the C(rules)
+        argument.
+    type: str
+    choices: [ conflict, combine ]
+    default: conflict
   state:
     description:
       - The lines will be added/modified when C(state=present) and removed when C(state=absent).

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -815,9 +815,10 @@ def main():
             if len(address_keys) > 1:
                 module.fail_json(msg='rule number {} of the "rules" argument ({}) uses ambiguous settings: '
                                      '{} are aliases, only one is allowed'.format(index, address_keys, rule))
-            address = rule[address_keys[0]]
-            del rule[address_keys[0]]
-            rule['address'] = address
+            if len(address_keys) == 1:
+                address = rule[address_keys[0]]
+                del rule[address_keys[0]]
+                rule['address'] = address
 
             for key in rule_keys:
                 if key not in rule:

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -728,7 +728,7 @@ def main():
         keep_comments_at_rules=dict(type='bool', default=False),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         users=dict(type='str', default='all'),
-        rules=dict(type='dict'),
+        rules=dict(type='list'),
         rules_behavior=dict(type='str', default='conflict', choices=['combine', 'conflict']),
         overwrite=dict(type='bool', default=False),
     )

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -92,7 +92,7 @@ options:
     choices: [ sdu, sud, dsu, dus, usd, uds ]
   overwrite:
     description:
-      - Remove all existing rules before adding rules. (Like C(state: absent) for all pre-existing rules.)
+      - "Remove all existing rules before adding rules. (Like C(state: absent) for all pre-existing rules.)"
     type: bool
     default: false
   keep_comments_at_rules:
@@ -104,7 +104,7 @@ options:
     version_added: '1.5.0'
   rules:
     description:
-      - A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once. 
+      - A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once.
         Each object can have the following keys (the "rule-specific arguments"), which are treated the same as if they
         were arguments of this module:
       - C(address), C(comment), C(contype), C(databases), C(method), C(netmask), C(options), C(state), C(users)
@@ -112,7 +112,8 @@ options:
     type: list
   rules_behavior:
     description:
-      - Configure how the C(rules) argument works with the rule-specific arguments outside the C(rules) argument
+      - >-
+        Configure how the C(rules) argument works with the rule-specific arguments outside the C(rules) argument
         together: If C(conflict), don't. Fail if C(rules) and e.g. C(address) are set. If C(combine), the normal
         rule-specific arguments are not defining a rule, but are used as defaults for the arguments in the C(rules)
         argument.
@@ -836,8 +837,8 @@ def main():
             # alias handling
             address_keys = [key for key in rule.keys() if key in ('address', 'source', 'src')]
             if len(address_keys) > 1:
-                module.fail_json(msg='rule number {} of the "rules" argument ({}) uses ambiguous settings: '
-                                     '{} are aliases, only one is allowed'.format(index, address_keys, rule))
+                module.fail_json(msg='rule number {0} of the "rules" argument ({1}) uses ambiguous settings: '
+                                     '{2} are aliases, only one is allowed'.format(index, address_keys, rule))
             if len(address_keys) == 1:
                 address = rule[address_keys[0]]
                 del rule[address_keys[0]]
@@ -864,10 +865,10 @@ def main():
                     pg_hba_rule = PgHbaRule(rule['contype'], database, user, rule['address'], rule['netmask'],
                                             rule['method'], rule['options'], comment=rule['comment'])
                     if rule['state'] == "present":
-                        ret['msgs'].append('Adding rule {}'.format(pg_hba_rule))
+                        ret['msgs'].append('Adding rule {0}'.format(pg_hba_rule))
                         pg_hba.add_rule(pg_hba_rule)
                     else:
-                        ret['msgs'].append('Removing rule {}'.format(pg_hba_rule))
+                        ret['msgs'].append('Removing rule {0}'.format(pg_hba_rule))
                         pg_hba.remove_rule(pg_hba_rule)
         except PgHbaError as error:
             module.fail_json(msg='Error modifying rules:\n{0}'.format(error))

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -116,6 +116,7 @@ options:
       - See I(rules) for the complete list of rule-specific arguments.
       - When set to C(conflict), fail if I(rules) and, for example, I(address) are set.
       - If C(combine), the normal rule-specific arguments are not defining a rule, but are used as defaults for the arguments in the I(rules) argument.
+      - Is used only when I(rules) is specified, ignored otherwise.
     type: str
     choices: [ conflict, combine ]
     default: conflict

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -111,6 +111,7 @@ options:
       - C(address), C(comment), C(contype), C(databases), C(method), C(netmask), C(options), C(state), C(users)
       - See also C(rules_behavior).
     type: list
+    elements: dict
   rules_behavior:
     description:
       - >-

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -104,10 +104,8 @@ options:
     version_added: '1.5.0'
   rules:
     description:
-      - >-
-        A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once.
-        Each object can have the following keys (the "rule-specific arguments"), which are treated the same as if they
-        were arguments of this module:
+      - A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once.
+      - "Each object can have the following keys (the 'rule-specific arguments'), which are treated the same as if they were arguments of this module:"
       - C(address), C(comment), C(contype), C(databases), C(method), C(netmask), C(options), C(state), C(users)
       - See also C(rules_behavior).
     type: list

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -92,7 +92,7 @@ options:
     choices: [ sdu, sud, dsu, dus, usd, uds ]
   overwrite:
     description:
-      - "Remove all existing rules before adding rules. (Like C(state: absent) for all pre-existing rules.)"
+      - Remove all existing rules before adding rules. (Like I(state=absent) for all pre-existing rules.)
     type: bool
     default: false
   keep_comments_at_rules:

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -810,7 +810,7 @@ def main():
     if overwrite:
         pg_hba.clear_rules()
 
-    rule_keys = {
+    rule_keys = [
         'address',
         'comment',
         'contype',
@@ -820,7 +820,7 @@ def main():
         'options',
         'state',
         'users'
-    }
+    ]
     if rules is None:
         single_rule = dict()
         for key in rule_keys:

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -196,6 +196,29 @@ EXAMPLES = '''
     source: ::/0
     keep_comments_at_rules: true
     comment: "this rule is an example"
+
+- name: Replace everything with a new set of rules
+  community.postgresql.postgresql_pg_hba:
+    dest: /var/lib/postgres/data/pg_hba.conf
+    overwrite: true # remove preexisting rules
+
+    # custom defaults
+    rules_behavior: combine
+    contype: hostssl
+    address: 2001:db8::/64
+    comment: added in bulk
+
+    rules:
+    - users: user1
+      databases: db1
+      # contype, address and comment come from custom default
+    - users: user2
+      databases: db2
+      comment: added with love # overwrite custom default for this rule
+      # contype and address come from custom default
+    - users: user3
+      databases: db3
+      # contype, address and comment come from custom default
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -793,7 +793,8 @@ def main():
         rules = new_rules
 
         if rules_behavior == 'conflict':
-            used_rule_keys = [key for key in rule_keys if module.params[key] is not None]
+            # it's ok if the module default is set
+            used_rule_keys = [key for key in rule_keys if module.params[key] != argument_spec[key].get('default', None)]
             if len(used_rule_keys) > 0:
                 module.fail_json(msg='conflict: either argument "rules_behavior" needs to be changed or "rules" must'
                                      ' not be set or {0} must not be set'.format(used_rule_keys))

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -112,9 +112,9 @@ options:
     elements: dict
   rules_behavior:
     description:
-      - Configure how the I(rules) argument works with the rule-specific arguments outside the I(rules) argument
-        together: If C(conflict), don't.
-      - Fail if I(rules) and, for example, I(address) are set.
+      - "Configure how the I(rules) argument works together with the rule-specific arguments outside the I(rules) argument."
+      - See I(rules) for the complete list of rule-specific arguments.
+      - When set to C(conflict), fail if I(rules) and, for example, I(address) are set.
       - If C(combine), the normal rule-specific arguments are not defining a rule, but are used as defaults for the arguments in the I(rules) argument.
     type: str
     choices: [ conflict, combine ]

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -776,7 +776,7 @@ def main():
         keep_comments_at_rules=dict(type='bool', default=False),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         users=dict(type='str', default='all'),
-        rules=dict(type='list'),
+        rules=dict(type='list', elements='dict'),
         rules_behavior=dict(type='str', default='conflict', choices=['combine', 'conflict']),
         overwrite=dict(type='bool', default=False),
     )

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -112,11 +112,10 @@ options:
     elements: dict
   rules_behavior:
     description:
-      - >-
-        Configure how the C(rules) argument works with the rule-specific arguments outside the C(rules) argument
-        together: If C(conflict), don't. Fail if C(rules) and e.g. C(address) are set. If C(combine), the normal
-        rule-specific arguments are not defining a rule, but are used as defaults for the arguments in the C(rules)
-        argument.
+      - Configure how the I(rules) argument works with the rule-specific arguments outside the I(rules) argument
+        together: If C(conflict), don't.
+      - Fail if I(rules) and, for example, I(address) are set.
+      - If C(combine), the normal rule-specific arguments are not defining a rule, but are used as defaults for the arguments in the I(rules) argument.
     type: str
     choices: [ conflict, combine ]
     default: conflict

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -104,7 +104,8 @@ options:
     version_added: '1.5.0'
   rules:
     description:
-      - A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once.
+      - >-
+        A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once.
         Each object can have the following keys (the "rule-specific arguments"), which are treated the same as if they
         were arguments of this module:
       - C(address), C(comment), C(contype), C(databases), C(method), C(netmask), C(options), C(state), C(users)

--- a/tests/integration/targets/postgresql_pg_hba/tasks/main.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/main.yml
@@ -5,3 +5,4 @@
 
 # Initial CI tests of postgresql_pg_hba module
 - import_tasks: postgresql_pg_hba_initial.yml
+- import_tasks: postgresql_pg_hba_bulk_rules.yml

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
@@ -73,6 +73,7 @@
 - name: get jinja2 version
   shell: '/usr/bin/pip --disable-pip-version-check --no-cache-dir show Jinja2 2>/dev/null | grep -oPm 1 "(?<=^Version: )\d+\.\d+"'
   register: jinja2_version
+  ignore_errors: true
 - assert:
     that:
       - result.failed
@@ -80,7 +81,7 @@
       - "result.results|selectattr('changed')|length == 0"
       - "result.results|rejectattr('failed')|length == 0"
       # the 'in' test was added in jinja 2.10
-      - "jinja2_version.stdout|trim is version('2.10', '<') or result.results|selectattr('msg', 'in', 'conflict')|length == 0"
+      - "jinja2_version.rc == 0 and jinja2_version.stdout|trim is version('2.10', '<') or result.results|selectattr('msg', 'in', 'conflict')|length == 0"
 
 - name: test rules with module defaults
   community.postgresql.postgresql_pg_hba:

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
@@ -70,13 +70,17 @@
     - users: testuser
   register: result
   ignore_errors: true
+- name: get jinja2 version
+  shell: '/usr/bin/pip --disable-pip-version-check --no-cache-dir show Jinja2 2>/dev/null | grep -oPm 1 "(?<=^Version: )\d+\.\d+"'
+  register: jinja2_version
 - assert:
     that:
       - result.failed
       - not result.changed
       - "result.results|selectattr('changed')|length == 0"
       - "result.results|rejectattr('failed')|length == 0"
-      - "result.results|selectattr('msg', 'in', 'conflict')|length == 0"
+      # the 'in' test was added in jinja 2.10
+      - "jinja2_version.stdout|trim is version('2.10', '<') or result.results|selectattr('msg', 'in', 'conflict')|length == 0"
 
 - name: test rules with module defaults
   community.postgresql.postgresql_pg_hba:

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
@@ -1,4 +1,3 @@
-
 - name: set test variables
   set_fact:
     pghba_defaults: &pghba_defaults

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
@@ -1,0 +1,112 @@
+
+- name: set test variables
+  set_fact:
+    pghba_defaults: &pghba_defaults
+      create: yes
+      dest: "/tmp/pg_hba_bulk_test.conf"
+    test_rule0: &test_rule0
+      contype: host
+      databases: "db0"
+      users: "user0"
+      address: "2001:db8::0/128"
+      method: pam
+    test_rule1: &test_rule1
+      contype: host
+      databases: "db1"
+      users: "user1"
+      address: "2001:db8::1/128"
+      method: pam
+    test_rule2: &test_rule2
+      contype: host
+      databases: "db2"
+      users: "user2"
+      address: "2001:db8::2/128"
+      method: pam
+
+- name: create one rule to clear
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    state: "present"
+    <<: *test_rule0
+- name: overwrite with one normal rule
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    overwrite: true
+    <<: *test_rule1
+  register: result
+- assert:
+    that:
+      - "result.pg_hba|length == 1"
+      - "result.pg_hba[0].db == test_rule1.databases"
+      - "result.pg_hba[0].src == test_rule1.address"
+      - "result.pg_hba[0].usr == test_rule1.users"
+      - "result.pg_hba[0].type == test_rule1.contype"
+- name: overwrite with one bulk rule
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    overwrite: true
+    rules:
+      - "{{ test_rule2 }}"
+  register: result
+- assert:
+    that:
+      - "result.pg_hba|length == 1"
+      - "result.pg_hba[0].db == test_rule2.databases"
+      - "result.pg_hba[0].src == test_rule2.address"
+      - "result.pg_hba[0].usr == test_rule2.users"
+      - "result.pg_hba[0].type == test_rule2.contype"
+
+- name: test rules_behavior conflict
+  community.postgresql.postgresql_pg_hba: "{{ pghba_defaults|combine(item)|combine({'rules': [test_rule2]}) }}"
+  loop:
+    - address: 2001:db8::a/128
+    - comment: 'testcomment'
+    - contype: hostssl
+    - databases: db_a
+    - method: cert
+    - netmask: 255.255.255.0
+      # address: 192.0.2.0
+    - options: "clientcert=verify-full"
+    - state: absent
+    - users: testuser
+  register: result
+  ignore_errors: true
+- assert:
+    that:
+      - result.failed
+      - not result.changed
+      - "result.results|selectattr('changed')|length == 0"
+      - "result.results|rejectattr('failed')|length == 0"
+      - "result.results|selectattr('msg', 'in', 'conflict')|length == 0"
+
+- name: test rules with module defaults
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    rules:
+      - contype: hostssl
+  register: result
+- assert:
+    that:
+      - result.changed
+      # assert that module defaults are used
+      - "{'db': 'all', 'method': 'md5', 'src': 'samehost', 'type': 'hostssl', 'usr': 'all'} in result.pg_hba"
+
+- name: test rules with custom defaults
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    rules_behavior: combine
+    <<: *test_rule1
+    rules:
+      - {} # complete fallback to custom defaults
+      - databases: other_db # partial fallback to custom defaults
+      # no fallback
+      - <<: *test_rule2
+        state: absent
+  register: result
+- assert:
+    that:
+      - result.changed
+      - "{'db': 'all', 'method': 'md5', 'src': 'samehost', 'type': 'hostssl', 'usr': 'all'} in result.pg_hba" # unchanged preexisting from previous task
+      - "{'db': test_rule1.databases, 'method': test_rule1.method, 'src': test_rule1.address, 'type': test_rule1.contype, 'usr': test_rule1.users} in result.pg_hba"
+      - "{'db': test_rule2.databases, 'method': test_rule2.method, 'src': test_rule2.address, 'type': test_rule2.contype, 'usr': test_rule2.users} not in result.pg_hba"
+      - "{'db': 'other_db', 'method': test_rule1.method, 'src': test_rule1.address, 'type': test_rule1.contype, 'usr': test_rule1.users} in result.pg_hba"

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -182,6 +182,11 @@
     - 'not netmask_sameas_prefix_check is changed'
     - 'pg_hba_options is changed'
 
+- name: ensure test file is empty
+  copy:
+    content: ''
+    dest: /tmp/pg_hba2.conf
+
 - name: Create a rule with the comment 'comment1'
   postgresql_pg_hba:
     contype: host


### PR DESCRIPTION
feature PR, fixes #297

### add new arguments to postgresql_pg_hba to edit multiple rules at once

#### argument `rules`
A list of objects, specifying a rule for the pg_hba.conf. Each object can have the following keys (the "rule-specific arguments"), which are treated the same as if they were arguments of this module:
 - `address`
 - `comment`
 - `contype`
 - `databases`
 - `method`
 - `netmask`
 - `options`
 - `state`
 - `users`
See `rules_behavior` for what happens when one of these keys missing in a `rules` item.

#### argument `rules_behavior`
String, choices: `conflict` (default), `combine`.

When `conflict`, and `rules` is specified along with at least one normal rule-specific argument, the module fails. This should prevent accidental ambiguous operations. If a `rules` item is lacking some rule-specific argument, the respective module default is taken.

When `combine`, the normal rule-specific arguments are treated as fallback values for the content of `rules`. (They will not add or remove a role on their own.) When a value is neither specified in a `rules` item nor in the normal rule-specific argument, the module default is taken.

example:
```yaml
- name: rules with custom defaults
  community.postgresql.postgresql_pg_hba:
    dest: /tmp/pg_hba.conf
    rules_behavior: combine
    databases: db1
    address: 2001:db8::a/64
    rules:
      - users: user1    
      - users: user2
        address: 2001:db8::b/64

# is equivalent to
- name: rules with custom defaults
  community.postgresql.postgresql_pg_hba:
    dest: /tmp/pg_hba.conf
    rules_behavior: combine
    rules:
      - users: user1    
        databases: db1
        address: 2001:db8::a/64
      - users: user2
        databases: db1
        address: 2001:db8::b/64
```

#### argument `overwrite`
Boolean, default: false. When true, all pre-existing rules will be removed from the pg_hba.conf as if they where specified with `state: absent`.