### PR TITLE
postgresql_user: include "alter user" statements in return value "queries"

### DIFF
--- a/changelogs/fragments/308-postgresql_user_alter_statements_return.yml
+++ b/changelogs/fragments/308-postgresql_user_alter_statements_return.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_user - add ``alter user``-statements in the return value ``queries`` (https://github.com/ansible-collections/community.postgresql/issues/307).

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -554,8 +554,10 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
 
         query_password_data = dict(password=password, expires=expires)
         try:
-            cursor.execute(' '.join(alter), query_password_data)
+            statement = ' '.join(alter)
+            cursor.execute(statement, query_password_data)
             changed = True
+            executed_queries.append(statement)
         except psycopg2.InternalError as e:
             if e.pgcode == '25006':
                 # Handle errors due to read-only transactions indicated by pgcode 25006
@@ -598,7 +600,9 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
             alter.append('WITH %s' % role_attr_flags)
 
         try:
-            cursor.execute(' '.join(alter))
+            statement = ' '.join(alter)
+            cursor.execute(statement)
+            executed_queries.append(statement)
         except psycopg2.InternalError as e:
             if e.pgcode == '25006':
                 # Handle errors due to read-only transactions indicated by pgcode 25006


### PR DESCRIPTION
#### bugfix for postgresql_user module

Fixes #307 by including "alter user" statements in the return value "queries".

