### PR TITLE
fix: only parse the digits from the pg version (#315)

### DIFF
--- a/changelogs/fragments/316-postgresql_ping_fix_pg_version_parsing.yml
+++ b/changelogs/fragments/316-postgresql_ping_fix_pg_version_parsing.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - postgresql_ping - fix pg version parsing (https://github.com/ansible-collections/community.postgresql/issues/315).
+  - postgresql_info - fix pg version parsing (https://github.com/ansible-collections/community.postgresql/issues/315).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -506,6 +506,7 @@ settings:
       sample: false
 '''
 
+import re
 from fnmatch import fnmatch
 
 try:
@@ -959,13 +960,13 @@ class PgClusterInfo(object):
         query = "SELECT version()"
         raw = self.__exec_sql(query)[0][0]
         full = raw.split()[1]
-        tmp = full.split('.')
+        m = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", full)
 
-        major = int(tmp[0])
-        minor = int(tmp[1].rstrip(','))
+        major = int(m.group(1))
+        minor = int(m.group(2))
         patch = None
-        if len(tmp) >= 3:
-            patch = int(tmp[2].rstrip(','))
+        if m.group(3) is not None:
+            patch = int(m.group(3))
 
         self.pg_info["version"] = dict(
             major=major,

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -91,6 +91,8 @@ conn_err_msg:
   version_added: 1.7.0
 '''
 
+import re
+
 try:
     from psycopg2.extras import DictCursor
 except ImportError:
@@ -137,13 +139,13 @@ class PgPing(object):
         self.is_available = True
 
         full = raw.split()[1]
-        tmp = full.split('.')
+        m = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", full)
 
-        major = int(tmp[0])
-        minor = int(tmp[1].rstrip(','))
+        major = int(m.group(1))
+        minor = int(m.group(2))
         patch = None
-        if len(tmp) >= 3:
-            patch = int(tmp[2].rstrip(','))
+        if m.group(3) is not None:
+            patch = int(m.group(3))
 
         self.version = dict(
             major=major,


### PR DESCRIPTION
##### SUMMARY

Fixes `postgresql_ping` crashes parsing the yugabyte (aka yugabytedb) server version:

```
PostgreSQL 11.2-YB-2.15.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang version 13.0.1 (https://github.com/yugabyte/llvm-project.git 191e3a05a55c8671bcc88d7387c04c55a4310500), 64-bit
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #315

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

postgresql_ping
