### PR TITLE
added dsn field to allow additional connection parameters as a libpg string

### DIFF
--- a/changelogs/fragments/324-postgresql_add_dsn_field.yml
+++ b/changelogs/fragments/324-postgresql_add_dsn_field.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - postgresql_* - added ``dsn`` field to allow additional connection parameters as a libpg string

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -48,6 +48,10 @@ options:
       - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
     aliases: [ ssl_rootcert ]
+  dsn:
+    description:
+      - Connection parameters as a libpq connection string.
+    type: str
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - To avoid "Peer authentication failed for user postgres" error,

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -44,6 +44,7 @@ def postgres_common_argument_spec():
         port=dict(type='int', default=5432, aliases=['login_port']),
         ssl_mode=dict(default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ca_cert=dict(aliases=['ssl_rootcert']),
+        dsn=dict(default=''),
     )
 
 
@@ -185,7 +186,8 @@ def get_conn_params(module, params_dict, warn_db_default=True):
         "login_password": "password",
         "port": "port",
         "ssl_mode": "sslmode",
-        "ca_cert": "sslrootcert"
+        "ca_cert": "sslrootcert",
+        "dsn": "dsn"
     }
 
     # Might be different in the modules:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -150,6 +150,15 @@ EXAMPLES = r'''
       id_val: 1
       story_val: test
 
+- name: Use dsn to add any connection parameters as a libpg string
+  community.postgresql.postgresql_query:
+    dsn: "target_session_attrs=read-write"
+    login_host: "host1,host2"
+    login_user: "test"
+    login_password: "test1234"
+    db: 'test'
+    query: 'insert into test (test) values (now())'
+
 - name: Insert query to test_table in db test_db
   community.postgresql.postgresql_query:
     db: test_db

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -21,6 +21,7 @@ INPUT_DICT = dict(
         choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']
     ),
     ca_cert=dict(aliases=['ssl_rootcert']),
+    dsn=dict(default=''),
 )
 
 EXPECTED_DICT = dict(
@@ -61,6 +62,7 @@ class TestPostgresCommonArgSpec():
                 choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']
             ),
             ca_cert=dict(aliases=['ssl_rootcert']),
+            dsn=dict(default=''),
         )
         assert pg.postgres_common_argument_spec() == expected_dict
 

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -34,6 +34,7 @@ EXPECTED_DICT = dict(
         choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']
     ),
     sslrootcert=dict(aliases=['ssl_rootcert']),
+    dsn=dict(default=''),
 )
 
 
@@ -113,7 +114,7 @@ def m_psycopg2():
             self.extras = Extras()
             self.extensions = Extensions()
 
-        def connect(self, host=None, port=None, user=None,
+        def connect(self, dsn=None, host=None, port=None, user=None,
                     password=None, sslmode=None, sslrootcert=None):
             if user == 'Exception':
                 raise Exception()


### PR DESCRIPTION
##### SUMMARY

Added "dsn" field to allow connection parameters as a libpg string.

The postgres library "psycopg" used in this module allows to specify a
libpq connection string. It is named "dsn" there, so I took the same
name.

https://www.psycopg.org/docs/module.html#psycopg2.connect

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

postgres_*

Affects all modules that establish a database connection.

##### ADDITIONAL INFORMATION

The dsn parameter string is passed unmodified to the module.

Multiple connection parameters would be passed by separating each
parameter with a space, as decribed in the "psycopg" documentation.


For example:

There is a cluster setup "host1" and "host2". But we do not know which one
of the hosts is the primary (read-write access) and the secondary
(write-only access). We want to insert some data:

```
  - community.postgresql.postgresql_query:
      dsn: "target_session_attrs=read-write"
      login_host: "host1,host2"
      login_user: "test"
      login_password: "test1234"
      db: 'test'
      query: >
        insert into test (test) values (now())
```

We list both hosts in "login_host" and added
"target_session_attrs=read-write" as "dsn" to automatically select the
primary.

(Otherwise we would get "cannot execute INSERT in a read-only
transaction" if "host1" is currently the secondary.)

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING


