### PR TITLE
added connect_params to allow any additional parameters that libpg understands

### DIFF
--- a/changelogs/fragments/329-postgresql_add_connect_params_field.yml
+++ b/changelogs/fragments/329-postgresql_add_connect_params_field.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  postgresql_* - Add ``connect_params`` parameter dict to allow any additional libpg connection parameters.
+- postgresql_* - Add ``connect_params`` parameter dict to allow any additional libpg connection parameters.

--- a/changelogs/fragments/329-postgresql_add_connect_params_field.yml
+++ b/changelogs/fragments/329-postgresql_add_connect_params_field.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  postgresql_* - Add ``connect_params`` parameter dict to allow any additional libpg connection parameters.

--- a/changelogs/fragments/329-postgresql_add_connect_params_field.yml
+++ b/changelogs/fragments/329-postgresql_add_connect_params_field.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- postgresql_* - Add ``connect_params`` parameter dict to allow any additional libpg connection parameters.
+- postgresql_* - add the ``connect_params`` parameter dict to allow any additional ``libpg`` connection parameters (https://github.com/ansible-collections/community.postgresql/pull/329).

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -51,6 +51,7 @@ options:
   connect_params:
     description:
       - Any additional parameters to be passed to libpg.
+      - These parameters take precedence.
     type: dict
     version_added: '2.3.0'
 notes:

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -52,6 +52,7 @@ options:
     description:
       - Any additional parameters to be passed to libpg as kwargs.
     type: dict
+    version_added: '2.3.0'
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - To avoid "Peer authentication failed for user postgres" error,

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -48,6 +48,10 @@ options:
       - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     type: str
     aliases: [ ssl_rootcert ]
+  connect_params:
+    description:
+      - Any additional parameters to be passed to libpg as kwargs.
+    type: dict
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - To avoid "Peer authentication failed for user postgres" error,

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -50,7 +50,7 @@ options:
     aliases: [ ssl_rootcert ]
   connect_params:
     description:
-      - Any additional parameters to be passed to libpg as kwargs.
+      - Any additional parameters to be passed to libpg.
     type: dict
     version_added: '2.3.0'
 notes:

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -225,8 +225,8 @@ def get_conn_params(module, params_dict, warn_db_default=True):
         kw["host"] = params_dict["login_unix_socket"]
 
     # If connect_params is specified, merge it together
-    if params_dict["connect_params"]:
-        kw = {**kw, **params_dict["connect_params"]}
+    if params_dict.get("connect_params"):
+        kw.update(params_dict["connect_params"])
 
     return kw
 

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -44,7 +44,7 @@ def postgres_common_argument_spec():
         port=dict(type='int', default=5432, aliases=['login_port']),
         ssl_mode=dict(default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ca_cert=dict(aliases=['ssl_rootcert']),
-        connect_params=dict(type='dict'),
+        connect_params=dict(default={}, type='dict'),
     )
 
 

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -44,6 +44,7 @@ def postgres_common_argument_spec():
         port=dict(type='int', default=5432, aliases=['login_port']),
         ssl_mode=dict(default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ca_cert=dict(aliases=['ssl_rootcert']),
+        connect_params=dict(type='dict'),
     )
 
 
@@ -185,7 +186,7 @@ def get_conn_params(module, params_dict, warn_db_default=True):
         "login_password": "password",
         "port": "port",
         "ssl_mode": "sslmode",
-        "ca_cert": "sslrootcert"
+        "ca_cert": "sslrootcert",
     }
 
     # Might be different in the modules:
@@ -222,6 +223,10 @@ def get_conn_params(module, params_dict, warn_db_default=True):
 
     if is_localhost and params_dict["login_unix_socket"] != "":
         kw["host"] = params_dict["login_unix_socket"]
+
+    # If connect_params is specified, merge it together
+    if params_dict["connect_params"]:
+        kw = {**kw, **params_dict["connect_params"]}
 
     return kw
 

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -158,7 +158,7 @@ EXAMPLES = r'''
 - name: Use connect_params to add any additional connection parameters that libpg supports
   community.postgresql.postgresql_query:
     connect_params:
-      target_session_attrs: "read-write"
+      target_session_attrs: read-write
       connect_timeout: 10
     login_host: "host1,host2"
     login_user: "test"

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -155,6 +155,17 @@ EXAMPLES = r'''
     db: test_db
     query: INSERT INTO test_table (id, story) VALUES (2, 'my_long_story')
 
+- name: Use connect_params to add any additional connection parameters that libpg supports
+  community.postgresql.postgresql_query:
+    connect_params:
+      target_session_attrs: "read-write"
+      connect_timeout: "10"
+    login_host: "host1,host2"
+    login_user: "test"
+    login_password: "test1234"
+    db: 'test'
+    query: 'insert into test (test) values (now())'
+
 
 # WARNING: The path_to_script and as_single_query options have been deprecated
 # and will be removed in community.postgresql 3.0.0, please

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -159,7 +159,7 @@ EXAMPLES = r'''
   community.postgresql.postgresql_query:
     connect_params:
       target_session_attrs: "read-write"
-      connect_timeout: "10"
+      connect_timeout: 10
     login_host: "host1,host2"
     login_user: "test"
     login_password: "test1234"

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -9,6 +9,9 @@
     pg_parameters: &pg_parameters
       login_user: '{{ pg_user }}'
       login_db: '{{ db_default }}'
+      connect_params:
+        connect_timeout: 30
+
 
   block:
 

--- a/tests/integration/targets/postgresql_info/tasks/setup_publication.yml
+++ b/tests/integration/targets/postgresql_info/tasks/setup_publication.yml
@@ -10,6 +10,8 @@
     pg_parameters: &pg_parameters
       login_user: '{{ pg_user }}'
       login_db: '{{ test_db }}'
+      connect_params:
+        connect_timeout: 30
 
   block:
   - name: Create test db

--- a/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
+++ b/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
@@ -1,606 +1,585 @@
-- name: postgresql_query - drop test table if exists
-  become_user: '{{ pg_user }}'
-  become: true
-  shell: psql postgres -U "{{ pg_user }}" -t -c "DROP TABLE IF EXISTS test_table;"
-  ignore_errors: true
+- vars:
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: postgres
+      connect_params:
+        connect_timeout: 30
 
-- name: postgresql_query - create test table called test_table
-  become_user: '{{ pg_user }}'
-  become: true
-  shell: psql postgres -U "{{ pg_user }}" -t -c "CREATE TABLE test_table (id int, story text);"
-  ignore_errors: true
+  block:
 
-- name: postgresql_query - insert some data into test_table
-  become_user: '{{ pg_user }}'
-  become: true
-  shell: psql postgres -U "{{ pg_user }}" -t -c "INSERT INTO test_table (id, story) VALUES (1, 'first'), (2, 'second'), (3, 'third');"
-  ignore_errors: true
+  - name: postgresql_query - drop test table if exists
+    become_user: '{{ pg_user }}'
+    become: true
+    shell: psql postgres -U "{{ pg_user }}" -t -c "DROP TABLE IF EXISTS test_table;"
+    ignore_errors: true
 
-- name: Copy script files
-  become: yes
-  copy:
-    src: '{{ item }}'
-    dest: '~{{ pg_user }}/{{ item }}'
-    owner: '{{ pg_user }}'
-    force: yes
-  loop:
-  - test0.sql
-  - test1.sql
-  register: sql_file_created
-  ignore_errors: yes
+  - name: postgresql_query - create test table called test_table
+    become_user: '{{ pg_user }}'
+    become: true
+    shell: psql postgres -U "{{ pg_user }}" -t -c "CREATE TABLE test_table (id int, story text);"
+    ignore_errors: true
 
-- name: postgresql_query - analyze test_table
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: ANALYZE test_table
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - insert some data into test_table
+    become_user: '{{ pg_user }}'
+    become: true
+    shell: psql postgres -U "{{ pg_user }}" -t -c "INSERT INTO test_table (id, story) VALUES (1, 'first'), (2, 'second'), (3, 'third');"
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is changed
-    - result.query == 'ANALYZE test_table'
-    - result.query_list == ['ANALYZE test_table']
-    - result.rowcount == 0
-    - result.statusmessage == 'ANALYZE'
-    - result.query_result == {}
-    - result.query_all_results == [{}]
+  - name: Copy script files
+    become: yes
+    copy:
+      src: '{{ item }}'
+      dest: '~{{ pg_user }}/{{ item }}'
+      owner: '{{ pg_user }}'
+      force: yes
+    loop:
+    - test0.sql
+    - test1.sql
+    register: sql_file_created
+    ignore_errors: yes
 
-- name: postgresql_query - run queries from SQL script
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    path_to_script: ~{{ pg_user }}/test0.sql
-    positional_args:
-    - 1
-    encoding: UTF-8
-    as_single_query: no
-  register: result
-  ignore_errors: true
-  when: sql_file_created
+  - name: postgresql_query - analyze test_table
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: ANALYZE test_table
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == "\n\nSELECT story FROM test_table\n  WHERE id = 1 OR story = 'Данные'"
-    - result.query_result[0].story == 'first'
-    - result.rowcount == 2
-    - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
-  when: sql_file_created
+  - assert:
+      that:
+      - result is changed
+      - result.query == 'ANALYZE test_table'
+      - result.query_list == ['ANALYZE test_table']
+      - result.rowcount == 0
+      - result.statusmessage == 'ANALYZE'
+      - result.query_result == {}
+      - result.query_all_results == [{}]
 
-- name: postgresql_query - simple select query to test_table
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: SELECT * FROM test_table
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - run queries from SQL script
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      path_to_script: ~{{ pg_user }}/test0.sql
+      positional_args:
+      - 1
+      encoding: UTF-8
+      as_single_query: no
+    register: result
+    ignore_errors: true
+    when: sql_file_created
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == 'SELECT * FROM test_table'
-    - result.rowcount == 3
-    - result.statusmessage == 'SELECT 3' or result.statusmessage == 'SELECT'
-    - result.query_result[0].id == 1
-    - result.query_result[1].id == 2
-    - result.query_result[2].id == 3
-    - result.query_result[0].story == 'first'
-    - result.query_result[1].story == 'second'
-    - result.query_result[2].story == 'third'
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "\n\nSELECT story FROM test_table\n  WHERE id = 1 OR story = 'Данные'"
+      - result.query_result[0].story == 'first'
+      - result.rowcount == 2
+      - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
+    when: sql_file_created
 
-- name: postgresql_query - select query with named args
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: SELECT id FROM test_table WHERE id = %(id_val)s AND story = %(story_val)s
-    named_args:
-      id_val: 1
-      story_val: first
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - simple select query to test_table
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM test_table
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT id FROM test_table WHERE id = 1 AND story = 'first'" or result.query == "SELECT id FROM test_table WHERE id = 1 AND story = E'first'"
-    - result.rowcount == 1
-    - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
-    - result.query_result[0].id == 1
+  - assert:
+      that:
+      - result is not changed
+      - result.query == 'SELECT * FROM test_table'
+      - result.rowcount == 3
+      - result.statusmessage == 'SELECT 3' or result.statusmessage == 'SELECT'
+      - result.query_result[0].id == 1
+      - result.query_result[1].id == 2
+      - result.query_result[2].id == 3
+      - result.query_result[0].story == 'first'
+      - result.query_result[1].story == 'second'
+      - result.query_result[2].story == 'third'
 
-- name: postgresql_query - select query with positional arguments
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: SELECT story FROM test_table WHERE id = %s AND story = %s
-    positional_args:
-    - 2
-    - second
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - select query with named args
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT id FROM test_table WHERE id = %(id_val)s AND story = %(story_val)s
+      named_args:
+        id_val: 1
+        story_val: first
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT story FROM test_table WHERE id = 2 AND story = 'second'" or result.query == "SELECT story FROM test_table WHERE id = 2 AND story = E'second'"
-    - result.rowcount == 1
-    - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
-    - result.query_result[0].story == 'second'
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "SELECT id FROM test_table WHERE id = 1 AND story = 'first'" or result.query == "SELECT id FROM test_table WHERE id = 1 AND story = E'first'"
+      - result.rowcount == 1
+      - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
+      - result.query_result[0].id == 1
 
-- name: postgresql_query - simple update query
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: UPDATE test_table SET story = 'new' WHERE id = 3
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - select query with positional arguments
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT story FROM test_table WHERE id = %s AND story = %s
+      positional_args:
+      - 2
+      - second
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "UPDATE test_table SET story = 'new' WHERE id = 3"
-    - result.rowcount == 1
-    - result.statusmessage == 'UPDATE 1'
-    - result.query_result == {}
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "SELECT story FROM test_table WHERE id = 2 AND story = 'second'" or result.query == "SELECT story FROM test_table WHERE id = 2 AND story = E'second'"
+      - result.rowcount == 1
+      - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
+      - result.query_result[0].story == 'second'
 
-- name: check the previous update
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: SELECT * FROM test_table WHERE story = 'new' AND id = 3
-  register: result
+  - name: postgresql_query - simple update query
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: UPDATE test_table SET story = 'new' WHERE id = 3
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result.rowcount == 1
+  - assert:
+      that:
+      - result is changed
+      - result.query == "UPDATE test_table SET story = 'new' WHERE id = 3"
+      - result.rowcount == 1
+      - result.statusmessage == 'UPDATE 1'
+      - result.query_result == {}
 
-- name: postgresql_query - simple update query in check_mode
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: UPDATE test_table SET story = 'CHECK_MODE' WHERE id = 3
-  register: result
-  check_mode: true
+  - name: check the previous update
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM test_table WHERE story = 'new' AND id = 3
+    register: result
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "UPDATE test_table SET story = 'CHECK_MODE' WHERE id = 3"
-    - result.rowcount == 1
-    - result.statusmessage == 'UPDATE 1'
-    - result.query_result == {}
+  - assert:
+      that:
+      - result.rowcount == 1
 
-- name: check the previous update that nothing has been changed
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: SELECT * FROM test_table WHERE story = 'CHECK_MODE' AND id = 3
-  register: result
+  - name: postgresql_query - simple update query in check_mode
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: UPDATE test_table SET story = 'CHECK_MODE' WHERE id = 3
+    register: result
+    check_mode: true
 
-- assert:
-    that:
-    - result.rowcount == 0
+  - assert:
+      that:
+      - result is changed
+      - result.query == "UPDATE test_table SET story = 'CHECK_MODE' WHERE id = 3"
+      - result.rowcount == 1
+      - result.statusmessage == 'UPDATE 1'
+      - result.query_result == {}
 
-- name: postgresql_query - try to update not existing row
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: UPDATE test_table SET story = 'new' WHERE id = 100
-  register: result
-  ignore_errors: true
+  - name: check the previous update that nothing has been changed
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM test_table WHERE story = 'CHECK_MODE' AND id = 3
+    register: result
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == "UPDATE test_table SET story = 'new' WHERE id = 100"
-    - result.rowcount == 0
-    - result.statusmessage == 'UPDATE 0'
-    - result.query_result == {}
+  - assert:
+      that:
+      - result.rowcount == 0
 
-- name: postgresql_query - insert query
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: INSERT INTO test_table (id, story) VALUES (%s, %s)
-    positional_args:
-    - 4
-    - fourth
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - try to update not existing row
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: UPDATE test_table SET story = 'new' WHERE id = 100
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "INSERT INTO test_table (id, story) VALUES (4, 'fourth')" or result.query == "INSERT INTO test_table (id, story) VALUES (4, E'fourth')"
-    - result.rowcount == 1
-    - result.statusmessage == 'INSERT 0 1'
-    - result.query_result == {}
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "UPDATE test_table SET story = 'new' WHERE id = 100"
+      - result.rowcount == 0
+      - result.statusmessage == 'UPDATE 0'
+      - result.query_result == {}
 
-- name: postgresql_query - truncate test_table
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: TRUNCATE test_table
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - insert query
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: INSERT INTO test_table (id, story) VALUES (%s, %s)
+      positional_args:
+      - 4
+      - fourth
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "TRUNCATE test_table"
-    - result.rowcount == 0
-    - result.statusmessage == 'TRUNCATE TABLE'
-    - result.query_result == {}
+  - assert:
+      that:
+      - result is changed
+      - result.query == "INSERT INTO test_table (id, story) VALUES (4, 'fourth')" or result.query == "INSERT INTO test_table (id, story) VALUES (4, E'fourth')"
+      - result.rowcount == 1
+      - result.statusmessage == 'INSERT 0 1'
+      - result.query_result == {}
 
-- name: postgresql_query - alter test_table
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: ALTER TABLE test_table ADD COLUMN foo int
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - truncate test_table
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: TRUNCATE test_table
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "ALTER TABLE test_table ADD COLUMN foo int"
-    - result.rowcount == 0
-    - result.statusmessage == 'ALTER TABLE'
+  - assert:
+      that:
+      - result is changed
+      - result.query == "TRUNCATE test_table"
+      - result.rowcount == 0
+      - result.statusmessage == 'TRUNCATE TABLE'
+      - result.query_result == {}
 
-- name: postgresql_query - vacuum without autocommit must fail
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: VACUUM
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - alter test_table
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: ALTER TABLE test_table ADD COLUMN foo int
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result.failed == true
+  - assert:
+      that:
+      - result is changed
+      - result.query == "ALTER TABLE test_table ADD COLUMN foo int"
+      - result.rowcount == 0
+      - result.statusmessage == 'ALTER TABLE'
 
-- name: postgresql_query - autocommit in check_mode must fail
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: VACUUM
-    autocommit: true
-  check_mode: true
-  register: result
-  ignore_errors: true
+  - name: postgresql_query - vacuum without autocommit must fail
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: VACUUM
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result.failed == true
-    - result.msg == "Using autocommit is mutually exclusive with check_mode"
+  - assert:
+      that:
+      - result.failed == true
 
-- name: postgresql_query - vacuum with autocommit
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: VACUUM
-    autocommit: true
-  register: result
+  - name: postgresql_query - autocommit in check_mode must fail
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: VACUUM
+      autocommit: true
+    check_mode: true
+    register: result
+    ignore_errors: true
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "VACUUM"
-    - result.rowcount == 0
-    - result.statusmessage == 'VACUUM'
-    - result.query_result == {}
+  - assert:
+      that:
+      - result.failed == true
+      - result.msg == "Using autocommit is mutually exclusive with check_mode"
 
-- name: postgresql_query - create test table for issue 59955
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_table:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    name: test_array_table
-    columns:
-    - arr_col int[]
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - name: postgresql_query - vacuum with autocommit
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: VACUUM
+      autocommit: true
+    register: result
 
-- set_fact:
-    my_list:
-    - 1
-    - 2
-    - 3
-    my_arr: '{1, 2, 3}'
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - assert:
+      that:
+      - result is changed
+      - result.query == "VACUUM"
+      - result.rowcount == 0
+      - result.statusmessage == 'VACUUM'
+      - result.query_result == {}
 
-- name: postgresql_query - insert array into test table by positional args
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: INSERT INTO test_array_table (arr_col) VALUES (%s)
-    positional_args:
-    - '{{ my_list }}'
-  register: result
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - name: postgresql_query - create test table for issue 59955
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_table:
+      login_user: '{{ pg_user }}'
+      login_db: postgres
+      name: test_array_table
+      columns:
+      - arr_col int[]
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- assert:
-    that:
-    - result is changed
-    - result.query == "INSERT INTO test_array_table (arr_col) VALUES ('{1, 2, 3}')"
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - set_fact:
+      my_list:
+      - 1
+      - 2
+      - 3
+      my_arr: '{1, 2, 3}'
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- name: postgresql_query - select array from test table by passing positional_args
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: SELECT * FROM test_array_table WHERE arr_col = %s
-    positional_args:
-    - '{{ my_list }}'
-  register: result
-  when: postgres_version_resp.stdout is version('9.4', '>=')
-
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'"
-    - result.rowcount == 1
-  when: postgres_version_resp.stdout is version('9.4', '>=')
-
-- name: postgresql_query - select array from test table by passing named_args
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: SELECT * FROM test_array_table WHERE arr_col = %(arr_val)s
-    named_args:
-      arr_val:
+  - name: postgresql_query - insert array into test table by positional args
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: INSERT INTO test_array_table (arr_col) VALUES (%s)
+      positional_args:
       - '{{ my_list }}'
-  register: result
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+    register: result
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'"
-    - result.rowcount == 1
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - assert:
+      that:
+      - result is changed
+      - result.query == "INSERT INTO test_array_table (arr_col) VALUES ('{1, 2, 3}')"
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- name: postgresql_query - select array from test table by passing positional_args as a string
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: SELECT * FROM test_array_table WHERE arr_col = %s
-    positional_args:
-    - '{{ my_arr|string }}'
-    trust_input: yes
-  register: result
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - name: postgresql_query - select array from test table by passing positional_args
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM test_array_table WHERE arr_col = %s
+      positional_args:
+      - '{{ my_list }}'
+    register: result
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'"
-    - result.rowcount == 1
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'"
+      - result.rowcount == 1
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- name: postgresql_query - test trust_input parameter
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
-    query: SELECT version()
-    trust_input: no
-  ignore_errors: yes
-  register: result
+  - name: postgresql_query - select array from test table by passing named_args
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM test_array_table WHERE arr_col = %(arr_val)s
+      named_args:
+        arr_val:
+        - '{{ my_list }}'
+    register: result
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- assert:
-    that:
-    - result is failed
-    - result.msg is search('is potentially dangerous')
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'"
+      - result.rowcount == 1
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- name: postgresql_query - clean up
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_table:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    name: test_array_table
-    state: absent
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  - name: postgresql_query - select array from test table by passing positional_args as a string
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM test_array_table WHERE arr_col = %s
+      positional_args:
+      - '{{ my_arr|string }}'
+      trust_input: yes
+    register: result
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-#############################
-# Check search_path parameter
+  - assert:
+      that:
+      - result is not changed
+      - result.query == "SELECT * FROM test_array_table WHERE arr_col = '{1, 2, 3}'"
+      - result.rowcount == 1
+    when: postgres_version_resp.stdout is version('9.4', '>=')
 
-- name: postgresql_set - create test schemas
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_schema:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    name: '{{ item }}'
-  loop:
-  - query_test1
-  - query_test2
+  - name: postgresql_query - test trust_input parameter
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+      query: SELECT version()
+      trust_input: no
+    ignore_errors: yes
+    register: result
 
-- name: postgresql_set - create test tables
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_table:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    name: '{{ item }}'
-    columns:
-    - id int
-  loop:
-  - 'query_test1.test1'
-  - 'query_test2.test2'
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')
 
-- name: postgresql_query - insert data
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: 'INSERT INTO {{ item }} (id) VALUES (1)'
-    search_path:
+  - name: postgresql_query - clean up
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_table:
+      login_user: '{{ pg_user }}'
+      login_db: postgres
+      name: test_array_table
+      state: absent
+    when: postgres_version_resp.stdout is version('9.4', '>=')
+
+  #############################
+  # Check search_path parameter
+
+  - name: postgresql_set - create test schemas
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_schema:
+      login_user: '{{ pg_user }}'
+      login_db: postgres
+      name: '{{ item }}'
+    loop:
     - query_test1
     - query_test2
-  loop:
-  - test1
-  - test2
 
-- name: postgresql_query - get data
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: 'SELECT id FROM test1'
-    search_path:
-    - query_test1
-    - query_test2
-  register: result
+  - name: postgresql_set - create test tables
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_table:
+      login_user: '{{ pg_user }}'
+      login_db: postgres
+      name: '{{ item }}'
+      columns:
+      - id int
+    loop:
+    - 'query_test1.test1'
+    - 'query_test2.test2'
 
-- assert:
-    that:
-    - result.rowcount == 1
+  - name: postgresql_query - insert data
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: 'INSERT INTO {{ item }} (id) VALUES (1)'
+      search_path:
+      - query_test1
+      - query_test2
+    loop:
+    - test1
+    - test2
 
-- name: postgresql_query - get data, must fail
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    login_db: postgres
-    query: 'SELECT id FROM test1'
-  register: result
-  ignore_errors: yes
+  - name: postgresql_query - get data
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: 'SELECT id FROM test1'
+      search_path:
+      - query_test1
+      - query_test2
+    register: result
 
-- assert:
-    that:
-    - result is failed
+  - assert:
+      that:
+      - result.rowcount == 1
 
-# Tests for the as_single_query option
-- name: Run queries from SQL script as a single query
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    path_to_script: ~{{ pg_user }}/test1.sql
-    positional_args:
-    - 1
-    encoding: UTF-8
-    as_single_query: yes
-  register: result
+  - name: postgresql_query - get data, must fail
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: 'SELECT id FROM test1'
+    register: result
+    ignore_errors: yes
 
-- name: >
-    Must pass. Not changed because we can only
-    check statusmessage of the last query
-  assert:
-    that:
-    - result is not changed
-    - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
-    - result.query_list[0] == "CREATE FUNCTION add(integer, integer) RETURNS integer\n  AS 'select $1 + $2;'\n  LANGUAGE SQL\n  IMMUTABLE\n  RETURNS NULL ON NULL INPUT;\n\nSELECT story FROM test_table\n  WHERE id = %s OR story = 'Данные';\n\nSELECT version();\n"
+  - assert:
+      that:
+      - result is failed
 
-#############################################################################
-# Issue https://github.com/ansible-collections/community.postgresql/issues/45
-- name: Create table containing a decimal value
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: CREATE TABLE blabla (id int, num decimal)
+  # Tests for the as_single_query option
+  - name: Run queries from SQL script as a single query
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      path_to_script: ~{{ pg_user }}/test1.sql
+      positional_args:
+      - 1
+      encoding: UTF-8
+      as_single_query: yes
+    register: result
 
-- name: Insert data
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: INSERT INTO blabla (id, num) VALUES (1, 1::decimal)
+  - name: >
+      Must pass. Not changed because we can only
+      check statusmessage of the last query
+    assert:
+      that:
+      - result is not changed
+      - result.statusmessage == 'SELECT 1' or result.statusmessage == 'SELECT'
+      - result.query_list[0] == "CREATE FUNCTION add(integer, integer) RETURNS integer\n  AS 'select $1 + $2;'\n  LANGUAGE SQL\n  IMMUTABLE\n  RETURNS NULL ON NULL INPUT;\n\nSELECT story FROM test_table\n  WHERE id = %s OR story = 'Данные';\n\nSELECT version();\n"
 
-- name: Get data
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: SELECT * FROM blabla
-  register: result
+  #############################################################################
+  # Issue https://github.com/ansible-collections/community.postgresql/issues/45
+  - name: Create table containing a decimal value
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: CREATE TABLE blabla (id int, num decimal)
 
-- assert:
-    that:
-    - result.rowcount == 1
+  - name: Insert data
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: INSERT INTO blabla (id, num) VALUES (1, 1::decimal)
 
-#############################################################################
-# Issue https://github.com/ansible-collections/community.postgresql/issues/47
-- name: Get datetime.timedelta value
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: "SELECT EXTRACT(epoch from make_interval(secs => 3)) AS extract"
-  register: result
-  when: postgres_version_resp.stdout is version('10', '>=')
+  - name: Get data
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: SELECT * FROM blabla
+    register: result
 
-- assert:
-    that:
-    - result.rowcount == 1
-    - result.query_result[0]["extract"] == 3 or result.query_result[0]["extract"] == 3.0
-  when: postgres_version_resp.stdout is version('10', '>=')
+  - assert:
+      that:
+      - result.rowcount == 1
 
-- name: Get interval value
-  become_user: '{{ pg_user }}'
-  become: true
-  postgresql_query:
-    login_user: '{{ pg_user }}'
-    db: postgres
-    query: "SELECT make_interval(secs => 3)"
-  register: result
-  when: postgres_version_resp.stdout is version('10', '>=')
+  #############################################################################
+  # Issue https://github.com/ansible-collections/community.postgresql/issues/47
+  - name: Get datetime.timedelta value
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT EXTRACT(epoch from make_interval(secs => 3)) AS extract"
+    register: result
+    when: postgres_version_resp.stdout is version('10', '>=')
 
-- assert:
-    that:
-    - result.rowcount == 1
-    - result.query_result[0]["make_interval"] == "0:00:03"
-  when: postgres_version_resp.stdout is version('10', '>=')
+  - assert:
+      that:
+      - result.rowcount == 1
+      - result.query_result[0]["extract"] == 3 or result.query_result[0]["extract"] == 3.0
+    when: postgres_version_resp.stdout is version('10', '>=')
+
+  - name: Get interval value
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT make_interval(secs => 3)"
+    register: result
+    when: postgres_version_resp.stdout is version('10', '>=')
+
+  - assert:
+      that:
+      - result.rowcount == 1
+      - result.query_result[0]["make_interval"] == "0:00:03"
+    when: postgres_version_resp.stdout is version('10', '>=')

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -61,6 +61,7 @@ class TestPostgresCommonArgSpec():
                 choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']
             ),
             ca_cert=dict(aliases=['ssl_rootcert']),
+            connect_params=dict(default={}, type='dict'),
         )
         assert pg.postgres_common_argument_spec() == expected_dict
 
@@ -112,7 +113,7 @@ def m_psycopg2():
             self.extensions = Extensions()
 
         def connect(self, host=None, port=None, user=None,
-                    password=None, sslmode=None, sslrootcert=None):
+                    password=None, sslmode=None, sslrootcert=None, connect_params={}):
             if user == 'Exception':
                 raise Exception()
 

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -113,7 +113,7 @@ def m_psycopg2():
             self.extensions = Extensions()
 
         def connect(self, host=None, port=None, user=None,
-                    password=None, sslmode=None, sslrootcert=None, connect_params={}):
+                    password=None, sslmode=None, sslrootcert=None, connect_params=None):
             if user == 'Exception':
                 raise Exception()
 

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -189,7 +189,14 @@ def m_ansible_module():
     """Return an object of dummy AnsibleModule class."""
     class DummyAnsibleModule():
         def __init__(self):
-            self.params = pg.postgres_common_argument_spec()
+
+            # take default params from argument spec
+            spec = pg.postgres_common_argument_spec()
+            params = dict()
+            for k in spec.keys():
+                params[k] = spec[k].get('default')
+
+            self.params = params
             self.err_msg = ''
             self.warn_msg = ''
 


### PR DESCRIPTION
##### SUMMARY

Added "connect_params" parameter dict to allow any additional libpg connection parameters.

The postgres library "psycopg" used in this module allows to add
any parameters as kwargs.

The dict "connect_params" can be used to pass in any parameters as kwargs to "psycopg".

https://www.psycopg.org/docs/module.html#psycopg2.connect

This is a more generic approach of [PR#324](https://github.com/ansible-collections/community.postgresql/pull/324).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgres_*

Affects all modules that establish a database connection.

##### ADDITIONAL INFORMATION

The key/values of the connect_params parameter dict is passed unmodified as kwargs to the module.

For example:

There is a cluster setup "host1" and "host2". But we do not know which one
of the hosts is the primary (read-write access) and the secondary
(write-only access). In addition we want to set the connection timeout. 
We want to insert some data:

```
  - community.postgresql.postgresql_query:
      connect_params:
        target_session_attrs: "read-write"
        connect_timeout: "10"
      login_host: "host1,host2"
      login_user: "test"
      login_password: "test1234"
      db: 'test'
      query: >
        insert into test (test) values (now())
```

We list both hosts in "login_host" and added
"target_session_attrs=read-write" as additional connection parameter to automatically select the
primary.

(Otherwise we would get "cannot execute INSERT in a read-only
transaction" if "host1" is currently the secondary.)

And we set the connection timeout to 10 seconds.

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING