### PR TITLE
test: remove f35 from azure pipeline

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -103,8 +103,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 35
-              test: fedora35
             - name: Fedora 36
               test: fedora36
             - name: Ubuntu 20.04

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -118,8 +118,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 34
-              test: fedora34
+            - name: Fedora 35
+              test: fedora35
             - name: Ubuntu 20.04
               test: ubuntu2004
 


### PR DESCRIPTION

##### SUMMARY

As per [21](https://github.com/ansible-collections/news-for-maintainers/issues/21) remove Fedora 35 from the Azure pipeline

##### ISSUE TYPE
- Testing Change Request

