### PR TITLE
postgresql_privs: add support for alter default privileges grant usage on schemas

### DIFF
--- a/changelogs/fragments/332-postgresql_privs_def_privs_schemas.yml
+++ b/changelogs/fragments/332-postgresql_privs_def_privs_schemas.yml
@@ -1,2 +1,3 @@
 bugfixes:
 - postgresql_privs - add support for alter default privileges grant usage on schemas (https://github.com/ansible-collections/community.postgresql/issues/332).
+- postgresql_privs - cannot grant select on objects in all schemas; add the ``not-specified`` value to the ``schema`` parameter to make this possible (https://github.com/ansible-collections/community.postgresql/issues/332).

--- a/changelogs/fragments/332-postgresql_privs_def_privs_schemas.yml
+++ b/changelogs/fragments/332-postgresql_privs_def_privs_schemas.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - add support for alter default privileges grant usage on schemas (https://github.com/ansible-collections/community.postgresql/issues/332).

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -75,7 +75,7 @@ options:
       or C(default_privs). Defaults to C(public) in these cases.
     - Pay attention, for embedded types when I(type=type)
       I(schema) can be C(pg_catalog) or C(information_schema) respectively.
-    - If not specified, uses C(public). To avoid this, use C(not-specified).
+    - If not specified, uses C(public). Not to pass any schema, use C(not-specified).
     type: str
   roles:
     description:

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -75,6 +75,7 @@ options:
       or C(default_privs). Defaults to C(public) in these cases.
     - Pay attention, for embedded types when I(type=type)
       I(schema) can be C(pg_catalog) or C(information_schema) respectively.
+    - If not specified, uses C(public). To avoid this, use C(not-specified).
     type: str
   roles:
     description:
@@ -430,6 +431,14 @@ EXAMPLES = r'''
     objs: numeric
     schema: pg_catalog
     db: acme
+
+- name: Alter default privileges grant usage on schemas to datascience
+  community.postgresql.postgresql_privs:
+    database: test
+    type: default_privs
+    privs: usage
+    objs: schemas
+    role: datascience
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -461,11 +461,12 @@ from ansible.module_utils._text import to_native
 
 VALID_PRIVS = frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE',
                          'REFERENCES', 'TRIGGER', 'CREATE', 'CONNECT',
-                         'TEMPORARY', 'TEMP', 'EXECUTE', 'USAGE', 'ALL', 'USAGE'))
+                         'TEMPORARY', 'TEMP', 'EXECUTE', 'USAGE', 'ALL'))
 VALID_DEFAULT_OBJS = {'TABLES': ('ALL', 'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'),
                       'SEQUENCES': ('ALL', 'SELECT', 'UPDATE', 'USAGE'),
                       'FUNCTIONS': ('ALL', 'EXECUTE'),
-                      'TYPES': ('ALL', 'USAGE')}
+                      'TYPES': ('ALL', 'USAGE'),
+                      'SCHEMAS': ('CREATE', 'USAGE'),}
 
 executed_queries = []
 

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1494,6 +1494,56 @@
     that:
     - result is changed
 
+- name: Test community.postgresql issue 332 grant usage, run again
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: "{{ db_user3 }}"
+    objs: schemas
+    type: default_privs
+    privs: usage
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+
+- name: Test community.postgresql issue 333 grant usage
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: "{{ db_user3 }}"
+    objs: tables
+    type: default_privs
+    schema: not-specified
+    privs: select
+  register: result
+
+- assert:
+    that:
+    - result is changed
+
+- name: Test community.postgresql issue 333 grant usage, run again
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: "{{ db_user3 }}"
+    objs: tables
+    type: default_privs
+    schema: not-specified
+    privs: select
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+
 # Cleanup
 - name: Remove privs
   become: yes

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1478,7 +1478,7 @@
 
 ##############
 # Issue https://github.com/ansible-collections/community.postgresql/issues/332
-- name: Test community.postgresql issue 332
+- name: Test community.postgresql issue 332 grant usage
   become: yes
   become_user: "{{ pg_user }}"
   postgresql_privs:
@@ -1520,6 +1520,13 @@
   loop:
   - "{{ db_user2 }}"
   - "{{ db_user3 }}"
+
+- name: Drop a role for which the default privileges have been altered
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_query:
+    login_db: "{{ db_name }}"
+    query: "DROP OWNED BY {{ db_user3 }};"
 
 - name: Remove user given permissions
   become: yes

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1476,6 +1476,24 @@
     that:
     - result is not changed
 
+##############
+# Issue https://github.com/ansible-collections/community.postgresql/issues/332
+- name: Test community.postgresql issue 332
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: "{{ db_user3 }}"
+    objs: schemas
+    type: default_privs
+    privs: usage
+  register: result
+
+- assert:
+    that:
+    - result is changed
+
 # Cleanup
 - name: Remove privs
   become: yes


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/332
Fixes https://github.com/ansible-collections/community.postgresql/issues/333

Test task 332 executes the following queries:
```
ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM \"ansible_db_user3\";
ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO \"ansible_db_user3\"
```
Test task 333 executes the following:
```
ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM \"ansible_db_user3\"
ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO \"ansible_db_user3\"
```
Is it OK?

`not-specified` is introduced to preserve backwards compatibility, we can change it as a default in a later major release if needed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
