### PR TITLE
CI: update Fedora to 36 in docker_devel tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -103,8 +103,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 34
-              test: fedora34
+            - name: Fedora 36
+              test: fedora36
             - name: Ubuntu 20.04
               test: ubuntu2004
 


### PR DESCRIPTION
Fedora 35 and older releases have been removed from Docker devel set of
tests. This patch sets Fedora to use release 36, which is the supported version.

See, https://github.com/ansible-collections/news-for-maintainers/issues/21