### PR TITLE
fix(postgresql_info): properly quote args to SHOW to avoid triggering 'reserved word' errors

### DIFF
--- a/changelogs/fragments/314-postgresql_info-quote-show-args.yml
+++ b/changelogs/fragments/314-postgresql_info-quote-show-args.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_info - make arguments passed to SHOW command properly quoted to prevent the interpreter evaluating them for reserved keywords (https://github.com/ansible-collections/community.postgresql/issues/314).
+- postgresql_info - make arguments passed to SHOW command properly quoted to prevent the interpreter evaluating them (https://github.com/ansible-collections/community.postgresql/issues/314).

--- a/changelogs/fragments/314-postgresql_info-quote-show-args.yml
+++ b/changelogs/fragments/314-postgresql_info-quote-show-args.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_info - make arguments passed to SHOW command properly quoted to prevent the interpreter evaluating them for reserved keywords (https://github.com/ansible-collections/community.postgresql/issues/314).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -1036,7 +1036,7 @@ class PgClusterInfo(object):
 
     def __get_pretty_val(self, setting):
         """Get setting's value represented by SHOW command."""
-        return self.__exec_sql("SHOW %s" % setting)[0][0]
+        return self.__exec_sql('SHOW "%s"' % setting)[0][0]
 
     def __exec_sql(self, query):
         """Execute SQL and return the result."""


### PR DESCRIPTION
Co-authored-by: @Jhiliano

##### SUMMARY
Modify postgresql_info to properly quote arguments to the `SHOW` command so that PG doesn't run it through the parser and complain about reserved keywords.

Fixes #314 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_info

