### PR TITLE
postgresql_pg_hba: support connection types hostgssenc, hostnogssenc

### DIFF
--- a/changelogs/fragments/351-postgresql_pg_hba-add-connection-types.yml
+++ b/changelogs/fragments/351-postgresql_pg_hba-add-connection-types.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_pg_hba - support the connection types ``hostgssenc`` and ``hostnogssenc`` (https://github.com/ansible-collections/community.postgresql/pull/351).

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -50,7 +50,7 @@ options:
     description:
       - Type of the rule. If not set, C(postgresql_pg_hba) will only return contents.
     type: str
-    choices: [ local, host, hostnossl, hostssl ]
+    choices: [ local, host, hostnossl, hostssl, hostgssenc, hostnogssenc ]
   comment:
     description:
       - A comment that will be placed in the same line behind the rule. See also the I(keep_comments_at_rules) parameter.
@@ -272,7 +272,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 PG_HBA_METHODS = ["trust", "reject", "md5", "password", "gss", "sspi", "krb5", "ident", "peer",
                   "ldap", "radius", "cert", "pam", "scram-sha-256"]
-PG_HBA_TYPES = ["local", "host", "hostssl", "hostnossl"]
+PG_HBA_TYPES = ["local", "host", "hostssl", "hostnossl", "hostgssenc", "hostnogssenc"]
 PG_HBA_ORDERS = ["sdu", "sud", "dsu", "dus", "usd", "uds"]
 PG_HBA_HDR = ['type', 'db', 'usr', 'src', 'mask', 'method', 'options']
 

--- a/tests/integration/targets/postgresql_pg_hba/defaults/main.yml
+++ b/tests/integration/targets/postgresql_pg_hba/defaults/main.yml
@@ -21,3 +21,9 @@ pg_hba_test_ips:
 - source: '172.16.0.0'
   netmask: '255.255.0.0'
   method: trust
+- contype: hostgssenc
+  users: postgres
+  source: '::1/128'
+- contype: hostnogssenc
+  users: all
+  source: '::1/128'

--- a/tests/integration/targets/postgresql_pg_hba/defaults/main.yml
+++ b/tests/integration/targets/postgresql_pg_hba/defaults/main.yml
@@ -23,7 +23,7 @@ pg_hba_test_ips:
   method: trust
 - contype: hostgssenc
   users: postgres
-  source: '::1/128'
+  source: '2001:db8::1/128'
 - contype: hostnogssenc
   users: all
-  source: '::1/128'
+  source: '2001:db8::1/128'

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -161,18 +161,18 @@
            { "db": "all", "method": "md5", "type": "local", "usr": "postgres" },
            { "db": "all", "method": "md5", "type": "local", "usr": "test" },
            { "db": "all", "method": "md5", "type": "local", "usr": "all" },
+           { "db": "all", "method": "md5", "src": "2001:db8::1/128", "type": "hostgssenc", "usr": "postgres" },
            { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "md5", "src": "127.0.0.1/32", "type": "host", "usr": "all" },
+           { "db": "all", "method": "md5", "src": "2001:db8::1/128", "type": "hostnogssenc", "usr": "all" },
            { "db": "all", "method": "md5", "src": "::1/128", "type": "host", "usr": "all" },
            { "db": "all", "method": "scram-sha-256", "src": "0:ff00::/120", "type": "host", "usr": "all" },
            { "db": "replication", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "reject", "src": "192.168.1.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "trust", "src": "172.16.0.0/16", "type": "host", "usr": "all" },
-           { "db": "all", "method": "md5", "src": "0:fff0::/28", "type": "host", "usr": "all" },
-           { "db": "all", "method": "md5", "src": "::1/128", "type": "hostgssenc", "usr": "postgres" },
-           { "db": "all", "method": "md5", "src": "::1/128", "type": "hostnogssenc", "usr": "all" }
+           { "db": "all", "method": "md5", "src": "0:fff0::/28", "type": "host", "usr": "all" }
       ]'
     - 'pg_hba_change is changed'
     - 'pg_hba_checkmode_check.stat.exists == false'

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -170,7 +170,9 @@
            { "db": "all", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "reject", "src": "192.168.1.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "trust", "src": "172.16.0.0/16", "type": "host", "usr": "all" },
-           { "db": "all", "method": "md5", "src": "0:fff0::/28", "type": "host", "usr": "all" }
+           { "db": "all", "method": "md5", "src": "0:fff0::/28", "type": "host", "usr": "all" },
+           { "db": "all", "method": "md5", "src": "::1/128", "type": "hostgssenc", "usr": "postgres" },
+           { "db": "all", "method": "md5", "src": "::1/128", "type": "hostnogssenc", "usr": "all" }
       ]'
     - 'pg_hba_change is changed'
     - 'pg_hba_checkmode_check.stat.exists == false'


### PR DESCRIPTION
Add `hostgssenc` and `hostnogssenc` (see https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) to the list of supported connection types in pg_hba.conf.

fixes  issue #349