### PR TITLE
Adding a requirements.txt file for python dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+psycopg2-binary


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a requirements.txt file for python dependencies. I noticed that `psycopg2-binary` is mentioned in the readme, but there's no requirements.txt. When using ansible-builder with this collection, the dependency is not automatically picked up when it could be if the file was there.

Please let me know if there needs to be some range limitations added.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Local testing with ansible-builder
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ cp -a /home/jmighion/tmp/git/community.postgresql/ context/_build/
$ ansible-builder create
$ podman build -t test context/
...
[2/3] STEP 3/4: RUN ansible-builder introspect --sanitize --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt
# Sanitized dependencies for /usr/share/ansible/collections
---
python:
...
- 'psycopg2-binary  # from collection community.postgresql'
...
Successfully installed ... psycopg2-binary-2.9.5
```
