### PR TITLE
postgresql_pg_hba: fix false "changed" when called with "overwrite: true"

### DIFF
--- a/changelogs/fragments/378-postgresql_pg_hba_fix_change_detection.yml
+++ b/changelogs/fragments/378-postgresql_pg_hba_fix_change_detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_pg_hba - fix ``changed`` return value for when ``overwrite`` is enabled (https://github.com/ansible-collections/community.postgresql/pull/378).

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -337,6 +337,7 @@ class PgHba(object):
         # users, this might be totally off, but at least it is some info...
         self.users = set(['postgres'])
 
+        self.preexisting_rules = None
         self.read()
 
     def clear_rules(self):
@@ -381,6 +382,7 @@ class PgHba(object):
                         except PgHbaRuleError:
                             pass
             self.unchanged()
+            self.preexisting_rules = dict(self.rules)
         except IOError:
             pass
 
@@ -490,7 +492,9 @@ class PgHba(object):
         '''
         This method can be called to detect if the PgHba file has been changed.
         '''
-        return bool(self.diff['before']['pg_hba'] or self.diff['after']['pg_hba'])
+        if not self.preexisting_rules and not self.rules:
+            return False
+        return self.preexisting_rules != self.rules
 
 
 class PgHbaRule(dict):

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -366,7 +366,7 @@ class PgHba(object):
                         line, comment = line.split('#', 1)
                         if comment == '':
                             comment = None
-
+                        line = line.rstrip()
                     # if there is just a comment, save it
                     if line == '':
                         if comment is not None:

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_bulk_rules.yml
@@ -40,6 +40,16 @@
       - "result.pg_hba[0].src == test_rule1.address"
       - "result.pg_hba[0].usr == test_rule1.users"
       - "result.pg_hba[0].type == test_rule1.contype"
+- name: 'test the same again (overwrite: true, one normal rule) to ensure nothing changed'
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    overwrite: true
+    <<: *test_rule1
+  register: result
+- assert:
+    that:
+      - "result.changed == false"
+
 - name: overwrite with one bulk rule
   community.postgresql.postgresql_pg_hba:
     <<: *pghba_defaults
@@ -54,6 +64,16 @@
       - "result.pg_hba[0].src == test_rule2.address"
       - "result.pg_hba[0].usr == test_rule2.users"
       - "result.pg_hba[0].type == test_rule2.contype"
+- name: 'test the same again (overwrite: true, one bulk rule) to ensure nothing changes'
+  community.postgresql.postgresql_pg_hba:
+    <<: *pghba_defaults
+    overwrite: true
+    rules:
+      - "{{ test_rule2 }}"
+  register: result
+- assert:
+    that:
+      - "result.changed == false"
 
 - name: test rules_behavior conflict
   community.postgresql.postgresql_pg_hba: "{{ pghba_defaults|combine(item)|combine({'rules': [test_rule2]}) }}"


### PR DESCRIPTION
#### postgresql_pg_hba bugfix

fixes #376

- When parsing the `pg_hba.conf`, trim whitespace between the rule and comment in the same line, to ensure equality tests work.
- Determine whether something changed by checking if read and to-be-written rules differ. Previously the check was slightly different: When `overwrite` was enabled, the rule list was emptied and adding rules again counted as change.