### PR TITLE
postgresql_privs: raise an error when ALL_IN_SCHEMA is used with a value of the type parameter not in table, sequence, function or procedure

### DIFF
--- a/changelogs/fragments/379-postgresql_privs.yml
+++ b/changelogs/fragments/379-postgresql_privs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "postgresql_privs - raise an error when the ``objs: ALL_IN_SCHEMA`` is used with a value of ``type`` that is not ``table``, ``sequence``, ``function`` or ``procedure`` (https://github.com/ansible-collections/community.postgresql/issues/379)."

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -1101,6 +1101,13 @@ def main():
         module.fail_json(msg='Argument "schema" is not allowed '
                              'for type "%s".' % p.type)
 
+    # param "objs": ALL_IN_SCHEMA can be used only
+    # when param "type" is table, sequence, function or procedure
+    if p.objs == 'ALL_IN_SCHEMA' and p.type not in ('table', 'sequence', 'function', 'procedure'):
+        module.fail_json(msg='Argument "objs": ALL_IN_SCHEMA can be used only for '
+                             'type: table, sequence, function or procedure, '
+                             '%s was passed.' % p.type)
+
     # param "objs": default, required depends on param "type"
     if p.type == 'database':
         p.objs = p.objs or p.database

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1560,6 +1560,25 @@
     that:
     - result is changed
 
+- name: Test community.postgresql issue 379
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: "{{ db_user3 }}"
+    objs: ALL_IN_SCHEMA
+    type: default_privs
+    privs: SELECT,INSERT,UPDATE,DELETE,EXECUTE
+    schema: public
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is failed
+    - result.msg is search('ALL_IN_SCHEMA can be used only for type')
+
 # Cleanup
 - name: Remove privs
   become: true


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/379

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request