### PR TITLE
postgresql_privs: fix schema quoting

### DIFF
--- a/changelogs/fragments/382-postgresql_privs_fix_schemas_with_special_names.yml
+++ b/changelogs/fragments/382-postgresql_privs_fix_schemas_with_special_names.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_privs - fix quoting of the ``schema`` parameter in SQL statements (https://github.com/ansible-collections/community.postgresql/pull/382).

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -817,6 +817,7 @@ class Connection(object):
         if not objs:
             return False
 
+        quoted_schema_qualifier = '"%s"' % schema_qualifier.replace('"', '""') if schema_qualifier else None
         # obj_ids: quoted db object identifiers (sometimes schema-qualified)
         if obj_type in ('function', 'procedure'):
             obj_ids = []
@@ -825,9 +826,9 @@ class Connection(object):
                     f, args = obj.split('(', 1)
                 except Exception:
                     raise Error('Illegal function / procedure signature: "%s".' % obj)
-                obj_ids.append('"%s"."%s"(%s' % (schema_qualifier, f, args))
+                obj_ids.append('%s."%s"(%s' % (quoted_schema_qualifier, f, args))
         elif obj_type in ['table', 'sequence', 'type']:
-            obj_ids = ['"%s"."%s"' % (schema_qualifier, o) for o in objs]
+            obj_ids = ['%s."%s"' % (quoted_schema_qualifier, o) for o in objs]
         else:
             obj_ids = ['"%s"' % o for o in objs]
 
@@ -846,7 +847,7 @@ class Connection(object):
             # and privs was escaped when it was parsed
             # Note: Underscores are replaced with spaces to support multi-word obj_type
             if orig_objs is not None:
-                set_what = '%s ON %s %s' % (','.join(privs), orig_objs, schema_qualifier)
+                set_what = '%s ON %s %s' % (','.join(privs), orig_objs, quoted_schema_qualifier)
             else:
                 set_what = '%s ON %s %s' % (','.join(privs), obj_type.replace('_', ' '), ','.join(obj_ids))
 
@@ -875,9 +876,6 @@ class Connection(object):
         if target_roles:
             as_who = ','.join('"%s"' % r for r in target_roles)
 
-        if schema_qualifier:
-            schema_qualifier = '"%s"' % schema_qualifier
-
         status_before = get_status(objs)
 
         query = QueryBuilder(state) \
@@ -885,7 +883,7 @@ class Connection(object):
             .with_grant_option(grant_option) \
             .for_whom(for_whom) \
             .as_who(as_who) \
-            .for_schema(schema_qualifier) \
+            .for_schema(quoted_schema_qualifier) \
             .set_what(set_what) \
             .for_objs(objs) \
             .usage_on_types(usage_on_types) \

--- a/tests/integration/targets/postgresql_privs/defaults/main.yml
+++ b/tests/integration/targets/postgresql_privs/defaults/main.yml
@@ -7,6 +7,8 @@ db_user_with_dots2: role.with.dots2
 db_name_with_hyphens: ansible-db
 db_user_with_hyphens: ansible-db-user
 db_schema_with_hyphens: ansible-db-schema
+db_schema_with_dot: test.schema
+db_schema_with_quote: 'TEST_schema"'
 db_session_role1: session_role1
 db_session_role2: session_role2
 dangerous_name: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1477,6 +1477,92 @@
     - result is not changed
 
 ##############
+# Issue https://github.com/ansible-collections/community.postgresql/issues/381
+- name: create schemas with special names
+  become: true
+  become_user: "{{ pg_user }}"
+  postgresql_schema:
+    login_user: "{{ pg_user }}"
+    login_password: password
+    db: "{{ db_name }}"
+    name: '"{{ item|replace("\"", "\"\"") }}"'
+    state: present
+  loop:
+    - "{{ db_schema_with_dot }}"
+    - "{{ db_schema_with_quote }}"
+  register: result
+- assert:
+    that:
+      - result is changed
+- name: create tables in schemas with special names
+  become: true
+  become_user: "{{ pg_user }}"
+  postgresql_table:
+    login_user: "{{ pg_user }}"
+    login_password: password
+    db: "{{ db_name }}"
+    name: '"{{ item|replace("\"", "\"\"") }}"."test.table.name"'
+    columns: []
+  loop:
+    - "{{ db_schema_with_dot }}"
+    - "{{ db_schema_with_quote }}"
+  register: result
+- assert:
+    that:
+      - result is changed
+- name: grant privileges on all tables in schemas with special names
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: PUBLIC
+    objs: ALL_IN_SCHEMA
+    type: table
+    privs: SELECT
+    schema: "{{ item }}"
+  loop:
+    - "{{ db_schema_with_dot }}"
+    - "{{ db_schema_with_quote }}"
+  register: result
+- assert:
+    that:
+      - result is changed
+- name: grant privileges on some table in schemas with special names
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_privs:
+    login_user: "{{ pg_user }}"
+    login_db: "{{ db_name }}"
+    roles: PUBLIC
+    objs: 'test.table.name'
+    type: table
+    privs: SELECT
+    schema: "{{ item }}"
+  loop:
+    - "{{ db_schema_with_dot }}"
+    - "{{ db_schema_with_quote }}"
+  register: result
+- assert:
+    that:
+      - result is changed
+- name: cleanup test schemas with special names
+  become: true
+  become_user: "{{ pg_user }}"
+  postgresql_schema:
+    login_user: "{{ pg_user }}"
+    login_password: password
+    db: "{{ db_name }}"
+    name: "{{ item }}"
+    state: absent
+    cascade_drop: true
+  loop:
+    - "{{ db_schema_with_dot }}"
+    - "{{ db_schema_with_quote }}"
+  register: result
+
+
+##############
 # Issue https://github.com/ansible-collections/community.postgresql/issues/332
 - name: Test community.postgresql issue 332 grant usage
   become: yes

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1485,11 +1485,11 @@
     login_user: "{{ pg_user }}"
     login_password: password
     db: "{{ db_name }}"
-    name: '"{{ item|replace("\\"", "\\"\\"") }}"'
+    name: '"{{ item }}"'
     state: present
   loop:
-    - "{{ db_schema_with_dot }}"
-    - "{{ db_schema_with_quote }}"
+    - "{{ db_schema_with_dot|replace('\"', '\"\"') }}"
+    - "{{ db_schema_with_quote|replace('\"', '\"\"') }}"
   register: result
 - assert:
     that:
@@ -1501,11 +1501,11 @@
     login_user: "{{ pg_user }}"
     login_password: password
     db: "{{ db_name }}"
-    name: '"{{ item|replace("\\"", "\\"\\"") }}"."test.table.name"'
+    name: '"{{ item }}"."test.table.name"'
     columns: []
   loop:
-    - "{{ db_schema_with_dot }}"
-    - "{{ db_schema_with_quote }}"
+    - "{{ db_schema_with_dot|replace('\"', '\"\"') }}"
+    - "{{ db_schema_with_quote|replace('\"', '\"\"') }}"
   register: result
 - assert:
     that:

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1485,7 +1485,7 @@
     login_user: "{{ pg_user }}"
     login_password: password
     db: "{{ db_name }}"
-    name: '"{{ item|replace("\"", "\"\"") }}"'
+    name: '"{{ item|replace("\\"", "\\"\\"") }}"'
     state: present
   loop:
     - "{{ db_schema_with_dot }}"
@@ -1501,7 +1501,7 @@
     login_user: "{{ pg_user }}"
     login_password: password
     db: "{{ db_name }}"
-    name: '"{{ item|replace("\"", "\"\"") }}"."test.table.name"'
+    name: '"{{ item|replace("\\"", "\\"\\"") }}"."test.table.name"'
     columns: []
   loop:
     - "{{ db_schema_with_dot }}"

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1546,6 +1546,28 @@
 - assert:
     that:
       - result is changed
+- name: check permissions on tables in schemas with special names
+  become: true
+  become_user: "{{ pg_user }}"
+  postgresql_query:
+    login_user: "{{ pg_user }}"
+    db: "{{ db_name }}"
+    query: |
+      select true as granted from information_schema.role_table_grants
+      where table_schema=%s and table_name='test.table.name' and privilege_type='SELECT' and grantee='PUBLIC'
+    positional_args:
+      - "{{ item }}"
+  loop:
+    - "{{ db_schema_with_dot }}"
+    - "{{ db_schema_with_quote }}"
+  register: result
+- assert:
+    that:
+      - 'result.results|length == 2'
+      - 'result.results[0].rowcount == 1'
+      - 'not result.results[0].failed'
+      - 'result.results[1].rowcount == 1'
+      - 'not result.results[1].failed'
 - name: cleanup test schemas with special names
   become: true
   become_user: "{{ pg_user }}"

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -1575,12 +1575,12 @@
     login_user: "{{ pg_user }}"
     login_password: password
     db: "{{ db_name }}"
-    name: "{{ item }}"
+    name: '"{{ item }}"'
     state: absent
     cascade_drop: true
   loop:
-    - "{{ db_schema_with_dot }}"
-    - "{{ db_schema_with_quote }}"
+    - "{{ db_schema_with_dot|replace('\"', '\"\"') }}"
+    - "{{ db_schema_with_quote|replace('\"', '\"\"') }}"
   register: result
 
 


### PR DESCRIPTION
fixes #381

Make postgresql_privs work with schema names containing arbitrary characters (e.g. `"` or `.`).