### PR TITLE
Add missing psycopg2.extras import

### DIFF
--- a/changelogs/fragments/399-missing-import.yml
+++ b/changelogs/fragments/399-missing-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_query - could crash under certain conditions because of a missing import to `psycopg2.extras` (https://github.com/ansible-collections/community.postgresql/issues/283).

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 psycopg2 = None  # This line needs for unit tests
 try:
     import psycopg2
+    import psycopg2.extras
     HAS_PSYCOPG2 = True
 except ImportError:
     HAS_PSYCOPG2 = False


### PR DESCRIPTION
##### SUMMARY

On some of our systems the `postgresql_query` task failed with the following error:

    AttributeError: module 'psycopg2' has no attribute 'extras'

Applying the patch from this commit fixed the issue for me on those systems. This was previously reported in issue #283. However now that some time has passed, I am unable to reproduce the issue on our newer systems.

In any case, this is still a mistake that could cause problems in the future, so I think it would be better to fix it.

The reason that this mistake is not causing any actual errors in normal situations is because of how the python import system functions: All of the entrypoints (all the source files under plugins/modules) have an import for `psycopg2.extras`. This causes `extras` to be available on `psycopg2` for any code (in any module) that executes after that import statement, such as the function bodies in `module_utils/postgres.py`.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
community.postgresql

##### ADDITIONAL INFORMATION
Fixes #283