### PR TITLE
Fix postgresql_set module if single-value param contains comma in value

### DIFF
--- a/changelogs/fragments/0-postgresql_set_avoid_wrong_values.yml
+++ b/changelogs/fragments/0-postgresql_set_avoid_wrong_values.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_set - avoid wrong values for single-value parameters containing commas (https://github.com/ansible-collections/community.postgresql/pull/357).
+- postgresql_set - avoid wrong values for single-value parameters containing commas (https://github.com/ansible-collections/community.postgresql/pull/400).

--- a/changelogs/fragments/0-postgresql_set_avoid_wrong_values.yml
+++ b/changelogs/fragments/0-postgresql_set_avoid_wrong_values.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - avoid wrong values for single-value parameters containing commas.

--- a/changelogs/fragments/0-postgresql_set_avoid_wrong_values.yml
+++ b/changelogs/fragments/0-postgresql_set_avoid_wrong_values.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_set - avoid wrong values for single-value parameters containing commas.
+- postgresql_set - avoid wrong values for single-value parameters containing commas (https://github.com/ansible-collections/community.postgresql/pull/357).

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -315,7 +315,7 @@ def param_set(cursor, module, name, value, context):
         if str(value).lower() == 'default':
             query = "ALTER SYSTEM SET %s = DEFAULT" % name
         else:
-            if isinstance(value, str) and ',' in value and not name.endswith('_command') and not name.endswith('_prefix'):
+            if isinstance(value, str) and ',' in value and not name.endswith(('_command', '_prefix')):
                 # Issue https://github.com/ansible-collections/community.postgresql/issues/78
                 # Change value from 'one, two, three' -> "'one','two','three'"
                 value = ','.join(["'" + elem.strip() + "'" for elem in value.split(',')])

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -315,7 +315,7 @@ def param_set(cursor, module, name, value, context):
         if str(value).lower() == 'default':
             query = "ALTER SYSTEM SET %s = DEFAULT" % name
         else:
-            if isinstance(value, str) and ',' in value:
+            if isinstance(value, str) and ',' in value and not name.endswith('_command') and not name.endswith('_prefix'):
                 # Issue https://github.com/ansible-collections/community.postgresql/issues/78
                 # Change value from 'one, two, three' -> "'one','two','three'"
                 value = ','.join(["'" + elem.strip() + "'" for elem in value.split(',')])

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -30,6 +30,7 @@
         log_statement: mod
         track_functions: none
         shared_preload_libraries: 'pg_stat_statements, pgaudit'
+        log_line_prefix: '%m [%p]: [%l-1] db=%d,user=%u,app=%a,client=%h '
 
   # Check mode:
   - name: Set settings in check mode
@@ -59,3 +60,13 @@
   - assert:
       that:
       - result.stdout == "shared_preload_libraries = 'pg_stat_statements, pgaudit'"
+  
+  # Test for single-value params with commas and spaces in value
+  - name: Test single-value param with commas and spaces in value
+    <<: *task_parameters
+    shell: "grep log_line_prefix {{ pg_auto_conf }}"
+    register: result
+
+  - assert:
+      that:
+      - result.stdout == "log_line_prefix = '%m [%p]: [%l-1] db=%d,user=%u,app=%a,client=%h '"

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -30,7 +30,7 @@
         log_statement: mod
         track_functions: none
         shared_preload_libraries: 'pg_stat_statements, pgaudit'
-        log_line_prefix: '%m [%p]: [%l-1] db=%d,user=%u,app=%a,client=%h '
+        log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
 
   # Check mode:
   - name: Set settings in check mode
@@ -69,4 +69,4 @@
 
   - assert:
       that:
-      - result.stdout == "log_line_prefix = '%m [%p]: [%l-1] db=%d,user=%u,app=%a,client=%h '"
+      - result.stdout == "log_line_prefix = 'db=%d,user=%u,app=%a,client=%h '"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The PR #357 fix the multi-value parameters management (issue #78), but the new check assumes as multi-value each parameter with a comma in the value, that is incorrect as there are single-value parameters with comma in value.

If a single-value parameter is treated as a multi-value, the 'param_set' function builds an ALTER SYSTEM SET command with multiple comma-separated values, that fails with the message:
```
ERROR:  SET log_line_prefix takes only one argument
```

Single-value parameters with possible comma in value are  "*_command" and "*_prefix" that for exmple in v12 are:
- ssl_passphrase_command
- archive_command
- restore_command
- archive_cleanup_command
- recovery_end_command
- log_line_prefix

The most critical (that I add in tests) is 'log_line_prefix' because often it contains comma and a space at the end.

I simply fix the check to evaluate as single-value all parameters that ends with '_command' and '_prefix'.

If the fix is accepted, It can be back-ported also in stable branch.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_set

