### PR TITLE
Added search for PGPORT and PGUSER environment variables

### DIFF
--- a/changelogs/fragments/0-postgres.yml
+++ b/changelogs/fragments/0-postgres.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- postgresql - when receiving the connection parameters, the ``PGPORT`` and ``PGUSER`` environment variables are checked. The order of assigning values. ``environment variables`` -> ``default values`` -> ``set values`` (https://github.com/ansible-collections/community.postgresql/issues/311).
+- postgresql - when receiving the connection parameters, the ``PGPORT`` and ``PGUSER`` environment variables are checked. The order of assigning values: ``environment variables`` -> ``default values`` -> ``set values`` (https://github.com/ansible-collections/community.postgresql/issues/311).

--- a/changelogs/fragments/0-postgres.yml
+++ b/changelogs/fragments/0-postgres.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- postgresql - when receiving the connection parameters, the ``PGPORT`` and ``PGUSER`` environment variables are checked. The order of assigning values: ``environment variables`` -> ``default values`` -> ``set values`` (https://github.com/ansible-collections/community.postgresql/issues/311).
+- postgresql - when receiving the connection parameters, the ``PGPORT`` and ``PGUSER`` environment variables are checked. The order of assigning values ``environment variables`` -> ``default values`` -> ``set values`` (https://github.com/ansible-collections/community.postgresql/issues/311).

--- a/changelogs/fragments/0-postgres.yml
+++ b/changelogs/fragments/0-postgres.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql - when receiving the connection parameters, the ``PGPORT`` and ``PGUSER`` environment variables are checked. The order of assigning values. ``environment variables`` -> ``default values`` -> ``set values`` (https://github.com/ansible-collections/community.postgresql/issues/311).

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -41,31 +41,19 @@ def postgres_common_argument_spec():
     env_vars = environ
 
     dict_options = dict(
-        login_user=dict(default='postgres'),
+        login_user=dict(default='postgres' if not env_vars.get("PGUSER") else env_vars.get("PGUSER")),
         login_password=dict(default='', no_log=True),
         login_host=dict(default=''),
         login_unix_socket=dict(default=''),
-        port=dict(type='int', default=5432, aliases=['login_port']),
+        port=dict(
+            type='int',
+            default=5432 if not env_vars.get("PGPORT") else int(env_vars.get("PGPORT")),
+            aliases=['login_port']
+        ),
         ssl_mode=dict(default='prefer', choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ca_cert=dict(aliases=['ssl_rootcert']),
         connect_params=dict(default={}, type='dict'),
     )
-
-    # Setting the value for the port, if there is a PGPORT
-    if env_vars.get("PGPORT"):
-        dict_options.update(
-            port={
-                'type': 'int',
-                'default': int(env_vars.get("PGPORT")),
-                'aliases': ['login_port']
-            }
-        )
-
-    # Setting the value for the login_user, if there is a PGUSER
-    if env_vars.get("PGUSER"):
-        dict_options.update(
-            login_user={'default': env_vars.get("PGUSER")}
-        )
 
     return dict_options
 

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -14,6 +14,7 @@ __metaclass__ = type
 
 from datetime import timedelta
 from decimal import Decimal
+from os import environ
 
 psycopg2 = None  # This line needs for unit tests
 try:
@@ -36,7 +37,10 @@ def postgres_common_argument_spec():
 
     The options are commonly used by most of PostgreSQL modules.
     """
-    return dict(
+    # Getting a dictionary of environment variables
+    env_vars = environ
+
+    dict_options = dict(
         login_user=dict(default='postgres'),
         login_password=dict(default='', no_log=True),
         login_host=dict(default=''),
@@ -46,6 +50,24 @@ def postgres_common_argument_spec():
         ca_cert=dict(aliases=['ssl_rootcert']),
         connect_params=dict(default={}, type='dict'),
     )
+
+    # Setting the value for the port, if there is a PGPORT
+    if env_vars.get("PGPORT"):
+        dict_options.update(
+            port={
+                'type': 'int',
+                'default': int(env_vars.get("PGPORT")),
+                'aliases': ['login_port']
+                }
+        )
+
+    # Setting the value for the login_user, if there is a PGUSER
+    if env_vars.get("PGUSER"):
+        dict_options.update(
+            login_user={'default': env_vars.get("PGUSER")}
+        )
+
+    return dict_options
 
 
 def ensure_required_libs(module):

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -58,7 +58,7 @@ def postgres_common_argument_spec():
                 'type': 'int',
                 'default': int(env_vars.get("PGPORT")),
                 'aliases': ['login_port']
-                }
+            }
         )
 
     # Setting the value for the login_user, if there is a PGUSER

--- a/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
@@ -46,6 +46,39 @@
       - result.server_version == {}
       - result is not changed
 
+- name: postgresql_ping - check ping of the database on non-existent port does not return anything
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_ping:
+    db: "{{ db_default }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  environment:
+    PGPORT: 5435
+  ignore_errors: true
+
+- assert:
+    that:
+      - result.is_available == false
+      - result.server_version == {}
+      - result is not changed
+
+- name: postgresql_ping - check ping of the database by a non-existent user does not return anything
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_ping:
+    db: "{{ db_default }}"
+  register: result
+  environment:
+    PGUSER: 'test_user'
+  ignore_errors: true
+
+- assert:
+    that:
+      - result.is_available == false
+      - result.server_version == {}
+      - result is not changed
+
 - name: postgresql_ping - ping DB with SSL
   become_user: "{{ pg_user }}"
   become: true

--- a/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
@@ -79,6 +79,30 @@
       - result.server_version == {}
       - result is not changed
 
+- name: Creating a "test_user" in postresql
+  shell:
+    cmd: psql -U "{{ pg_user }}" -c "CREATE ROLE test_user WITH LOGIN PASSWORD 'TEST_PASSWORD';"
+
+- name: postgresql_ping - check ping of the database by a existent user
+  become_user: "{{ pg_user }}"
+  become: true
+  environment:
+    PGUSER: 'test_user'
+  ignore_errors: true
+  postgresql_ping:
+    db: "{{ db_default }}"
+    login_password: "TEST_PASSWORD"
+  register: result
+
+- assert:
+    that:
+      - result.is_available == true
+      - result.server_version != {}
+      - result.server_version.raw is search('PostgreSQL')
+      - result.server_version.major != ''
+      - result.server_version.minor != ''
+      - result is not changed
+
 - name: postgresql_ping - ping DB with SSL
   become_user: "{{ pg_user }}"
   become: true

--- a/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
@@ -49,13 +49,13 @@
 - name: postgresql_ping - check ping of the database on non-existent port does not return anything
   become_user: "{{ pg_user }}"
   become: true
+  environment:
+    PGPORT: 5435
+  ignore_errors: true
   postgresql_ping:
     db: "{{ db_default }}"
     login_user: "{{ pg_user }}"
   register: result
-  environment:
-    PGPORT: 5435
-  ignore_errors: true
 
 - assert:
     that:
@@ -66,12 +66,12 @@
 - name: postgresql_ping - check ping of the database by a non-existent user does not return anything
   become_user: "{{ pg_user }}"
   become: true
-  postgresql_ping:
-    db: "{{ db_default }}"
-  register: result
   environment:
     PGUSER: 'test_user'
   ignore_errors: true
+  postgresql_ping:
+    db: "{{ db_default }}"
+  register: result
 
 - assert:
     that:

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -3,6 +3,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
+from os import environ
 
 import pytest
 
@@ -63,6 +64,21 @@ class TestPostgresCommonArgSpec():
             ca_cert=dict(aliases=['ssl_rootcert']),
             connect_params=dict(default={}, type='dict'),
         )
+        assert pg.postgres_common_argument_spec() == expected_dict
+
+        # Setting new values for checking environment variables
+        expected_dict.update(
+            port={
+                'type': 'int',
+                'default': 5435,
+                'aliases': ['login_port']
+            },
+            login_user={'default': 'test_user'}
+        )
+
+        # Setting environment variables
+        environ['PGUSER'] = 'test_user'
+        environ['PGPORT'] = '5435'
         assert pg.postgres_common_argument_spec() == expected_dict
 
 

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -67,14 +67,8 @@ class TestPostgresCommonArgSpec():
         assert pg.postgres_common_argument_spec() == expected_dict
 
         # Setting new values for checking environment variables
-        expected_dict.update(
-            port={
-                'type': 'int',
-                'default': 5435,
-                'aliases': ['login_port']
-            },
-            login_user={'default': 'test_user'}
-        )
+        expected_dict['port']['default'] = 5435
+        expected_dict['login_user']['default'] = 'test_user'
 
         # Setting environment variables
         environ['PGUSER'] = 'test_user'


### PR DESCRIPTION
SUMMARY
Added search for PGPORT and PGUSER environment variables

If there are environment variables, and the port and user are not specified, then the value PGPORT and PGUSER is assigned

In other cases, default values or explicitly specified values are assigned

issue #311 

ISSUE TYPE
Feature Pull Request
