### PR TITLE
postgresql_query, postgresql_script: let psycopg2 do the list -> pg array conversion

### DIFF
--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -396,44 +396,6 @@ def set_search_path(cursor, search_path):
     cursor.execute('SET search_path TO %s' % search_path)
 
 
-def convert_elements_to_pg_arrays(obj):
-    """Convert list elements of the passed object
-    to PostgreSQL arrays represented as strings.
-
-    Args:
-        obj (dict or list): Object whose elements need to be converted.
-
-    Returns:
-        obj (dict or list): Object with converted elements.
-    """
-    if isinstance(obj, dict):
-        for (key, elem) in iteritems(obj):
-            if isinstance(elem, list):
-                obj[key] = list_to_pg_array(elem)
-
-    elif isinstance(obj, list):
-        for i, elem in enumerate(obj):
-            if isinstance(elem, list):
-                obj[i] = list_to_pg_array(elem)
-
-    return obj
-
-
-def list_to_pg_array(elem):
-    """Convert the passed list to PostgreSQL array
-    represented as a string.
-
-    Args:
-        elem (list): List that needs to be converted.
-
-    Returns:
-        elem (str): String representation of PostgreSQL array.
-    """
-    elem = str(elem).strip('[]')
-    elem = '{' + elem + '}'
-    return elem
-
-
 def convert_to_supported(val):
     """Convert unsupported type to appropriate.
     Args:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -317,7 +317,6 @@ from ansible_collections.community.postgresql.plugins.module_utils.database impo
 )
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
     connect_to_db,
-    convert_elements_to_pg_arrays,
     convert_to_supported,
     ensure_required_libs,
     get_conn_params,
@@ -441,11 +440,6 @@ def main():
         args = named_args
     else:
         args = None
-
-    # Convert elements of type list to strings
-    # representing PG arrays
-    if args:
-        args = convert_elements_to_pg_arrays(args)
 
     # Set defaults:
     changed = False

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -225,11 +225,9 @@ from ansible_collections.community.postgresql.plugins.module_utils.database impo
 )
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
     connect_to_db,
-    convert_elements_to_pg_arrays,
     convert_to_supported,
     ensure_required_libs,
     get_conn_params,
-    list_to_pg_array,
     postgres_common_argument_spec,
     set_search_path,
     TYPES_NEED_TO_CONVERT,
@@ -298,11 +296,6 @@ def main():
         args = named_args
     else:
         args = None
-
-    # Convert elements of type list to strings
-    # representing PG arrays
-    if args:
-        args = convert_elements_to_pg_arrays(args)
 
     # Execute script content:
     try:


### PR DESCRIPTION
fixes #411

This PR removes the logic which converts a query argument from a python list to a postgres array, because psycopg2 can do this better.

This changes the module arguments to SQL translation, so I'm not sure if this should be categorized as just a bugfix or a major change.