### PR TITLE
fix: Make pretty_to_bytes return IP addresses as is, instead of throwing ValueError

### DIFF
--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -269,7 +269,11 @@ def pretty_to_bytes(pretty_val):
             pretty_val = int(pretty_val)
 
         except ValueError:
-            pretty_val = float(pretty_val)
+            try:
+                pretty_val = float(pretty_val)
+
+            except ValueError:
+                return pretty_val
 
         return pretty_val
 

--- a/tests/unit/plugins/modules/test_postgresql_set.py
+++ b/tests/unit/plugins/modules/test_postgresql_set.py
@@ -21,6 +21,7 @@ from ansible_collections.community.postgresql.plugins.modules.postgresql_set imp
     ('100MB', 104857600),
     ('1GB', 1073741824),
     ('10GB', 10737418240),
+    ('127.0.0.1', '127.0.0.1')
 ]
 )
 def test_pretty_to_bytes(input_, expected):


### PR DESCRIPTION
##### SUMMARY
During dry-run, `postgresql_set` may be confused and throw `ValueError` for certain values:

```yaml
community.postgresql.postgresql_set:
  name: "listen_addresses"
  value: "0.0.0.0"
```

gives

```text
ValueError: could not convert string to float: '0.0.0.0'
```

Errors like this [have been fixed before](https://github.com/ansible-collections/community.postgresql/pull/52), but that did not cover IP addresses. This PR will handle the `ValueError` that may result from `float(pretty_val)`, and just return `pretty_val` as is. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/postgresql_set.py

##### ADDITIONAL INFORMATION
