### PR TITLE
Pg hba re comment parsing

### DIFF
--- a/changelogs/fragments/423-postgresql_pg_hba_comment_parsing.yml
+++ b/changelogs/fragments/423-postgresql_pg_hba_comment_parsing.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_pg_hba - comment parsing assumed any hash starts a comment, but could be in quoted values (https://github.com/ansible-collections/community.postgresql/issues/420)
+  - postgresql_pg_hba - add support for double-quoted values and escaped quotes when parsing pg_hba.conf (https://github.com/ansible-collections/community.postgresql/issues/420)

--- a/changelogs/fragments/423-postgresql_pg_hba_comment_parsing.yml
+++ b/changelogs/fragments/423-postgresql_pg_hba_comment_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_pg_hba - comment parsing assumed any hash starts a comment, but could be in quoted values (https://github.com/ansible-collections/community.postgresql/issues/420)

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -364,7 +364,9 @@ class PgHba(object):
                     line = line.strip()
                     comment = None
                     if '#' in line:
-                        line, comment = line.split('#', 1)
+                        result = re.search(r'((("[^"]*"|([^#"])))*)(#(.*))?', line)
+                        comment = result.group(6)
+                        line = result.group(1)
                         if comment == '':
                             comment = None
                         line = line.rstrip()

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -364,7 +364,7 @@ class PgHba(object):
                     line = line.strip()
                     comment = None
                     if '#' in line:
-                        result = re.search(r'((("[^"]*"|([^#"])))*)(#(.*))?', line)
+                        result = re.search(r'((("([^"]|\")*"|([^#"])))*)(#(.*))?', line)
                         comment = result.group(6)
                         line = result.group(1)
                         if comment == '':

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -365,7 +365,7 @@ class PgHba(object):
                     comment = None
                     if '#' in line:
                         result = re.search(r'((("([^"]|\")*"|([^#"])))*)(#(.*))?', line)
-                        comment = result.group(6)
+                        comment = result.group(7)
                         line = result.group(1)
                         if comment == '':
                             comment = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #420 (# in quoted parameters)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
postgresql_pg_hba

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

simple splitting at first hashmark is replaced by a regex

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
