### PR TITLE
 add support for non numeric extenstion version

### DIFF
--- a/changelogs/fragments/428-postgres_info_support_non_numeric_extenstion_version.yml
+++ b/changelogs/fragments/428-postgres_info_support_non_numeric_extenstion_version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_info - add support for non numeric extenstion version (https://github.com/ansible-collections/community.postgresql/issues/428).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -766,7 +766,7 @@ class PgClusterInfo(object):
                 ext_ver = [None]
             else:
                 ext_ver = i[1].split('.')
-                if re.search('-', ext_ver[1]) is None:
+                if re.search('-', ext_ver[1]) is not None:
                     ext_ver[1] = ext_ver[1].split('-')[0]
 
             if len(ext_ver) < 2:

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -761,14 +761,20 @@ class PgClusterInfo(object):
         ext_dict = {}
         for i in res:
             ext_ver_raw = i[1]
-            ext_ver = i[1].split('.')
+            
+            if re.search('^([0-9]+([\-]*[0-9]+)?\.)+[0-9]+([\-]*[0-9]+)?$', i[1]) == None:
+                ext_ver = [None]
+            else:
+                ext_ver = i[1].split('.')
+                if re.search('-', ext_ver[1]) is None:
+                    ext_ver[1] = ext_ver[1].split('-')[0]
 
             if len(ext_ver) < 2:
                 ext_ver.append(None)
 
             ext_dict[i[0]] = dict(
                 extversion=dict(
-                    major=int(ext_ver[0]),
+                    major=int(ext_ver[0]) if ext_ver[0] else None,
                     minor=int(ext_ver[1]) if ext_ver[1] else None,
                     raw=ext_ver_raw,
                 ),

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -762,15 +762,19 @@ class PgClusterInfo(object):
         for i in res:
             ext_ver_raw = i[1]
 
-            if re.search(r'^([0-9]+([\-]*[0-9]+)?\.)+[0-9]+([\-]*[0-9]+)?$', i[1]) is None:
-                ext_ver = [None]
+            if re.search(r'^([0-9]+([\-]*[0-9]+)?\.)*[0-9]+([\-]*[0-9]+)?$', i[1]) is None:
+                ext_ver = [None, None]
             else:
                 ext_ver = i[1].split('.')
-                if re.search('-', ext_ver[1]) is not None:
-                    ext_ver[1] = ext_ver[1].split('-')[0]
+                if re.search(r'-', ext_ver[0]) is not None:
+                    ext_ver = ext_ver[0].split('-')
+                else:
+                    try:
+                        if re.search(r'-', ext_ver[1]) is not None:
+                            ext_ver[1] = ext_ver[1].split('-')[0]
+                    except IndexError:
+                        ext_ver.append(None)
 
-            if len(ext_ver) < 2:
-                ext_ver.append(None)
 
             ext_dict[i[0]] = dict(
                 extversion=dict(

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -775,7 +775,6 @@ class PgClusterInfo(object):
                     except IndexError:
                         ext_ver.append(None)
 
-
             ext_dict[i[0]] = dict(
                 extversion=dict(
                     major=int(ext_ver[0]) if ext_ver[0] else None,

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -761,8 +761,8 @@ class PgClusterInfo(object):
         ext_dict = {}
         for i in res:
             ext_ver_raw = i[1]
-            
-            if re.search('^([0-9]+([\-]*[0-9]+)?\.)+[0-9]+([\-]*[0-9]+)?$', i[1]) == None:
+
+            if re.search(r'^([0-9]+([\-]*[0-9]+)?\.)+[0-9]+([\-]*[0-9]+)?$', i[1]) is None:
                 ext_ver = [None]
             else:
                 ext_ver = i[1].split('.')

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -205,7 +205,7 @@
     <<: *task_parameters
     postgresql_query:
       <<: *pg_parameters
-      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '3.0'"
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '4.0'"
 
   - assert:
       that:
@@ -228,7 +228,7 @@
     <<: *task_parameters
     postgresql_query:
       <<: *pg_parameters
-      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '3.0'"
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '4.0'"
 
   - assert:
       that:
@@ -265,7 +265,7 @@
     <<: *task_parameters
     postgresql_query:
       <<: *pg_parameters
-      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '3.0'"
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '4.0'"
 
   - assert:
       that:
@@ -321,7 +321,7 @@
     <<: *task_parameters
     postgresql_query:
       <<: *pg_parameters
-      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '3.0'"
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '4.0'"
 
   - assert:
       that:
@@ -385,6 +385,139 @@
       - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == None
       - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '0'
 
+  - name: Upgrade extension to a version that have a sub minor version 3.0-1
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: '3.0-1'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 3
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == 0
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3.0-1'
+
+  - name: Upgrade extension to version 3.0-foo
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: '3.0-foo'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3.0-foo'
+
+  - name: Upgrade extension to version 3.beta
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: '3.beta'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3.beta'
+
+  - name: Upgrade extension to version 3-1.0
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: '3-1.0'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 3
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == 1
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3-1.0'
+
+  - name: Upgrade extension to version 3-1.0-1
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: '3-1.0-1'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 3
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == 1
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3-1.0-1'
+
+  - name: Upgrade extension to version 3-1.foo
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: '3-1.foo'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3-1.foo'
+
+  - name: Upgrade extension to version v4
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: '{{ test_ext }}'
+      schema: '{{ test_schema }}'
+      version: 'v4'
+
+  - name: Test
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == None
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == 'v4'
+
   - name: Upgrade extension to the latest
     <<: *task_parameters
     postgresql_ext:
@@ -400,9 +533,9 @@
 
   - assert:
       that:
-      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 3
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['major'] == 4
       - result['databases']['postgres']['extensions']['dummy']['extversion']['minor'] == 0
-      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '3.0'
+      - result['databases']['postgres']['extensions']['dummy']['extversion']['raw'] == '4.0'
 
   # Cleanup:
   - name: postgresql_ext_version - drop the extension

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--3-1.0-1.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--3-1.0-1.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''3-1.0-1'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--3-1.0.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--3-1.0.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''3-1.0'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--3-1.foo.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--3-1.foo.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''3-1.foo'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--3.0-1.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--3.0-1.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''3.0-1'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--3.0-foo.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--3.0-foo.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''3.0-foo'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--3.beta.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--3.beta.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''3.beta'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--4.0.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--4.0.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''4.0'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy--v4.sql
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy--v4.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''v4'')::text';

--- a/tests/integration/targets/setup_postgresql_db/files/dummy.control
+++ b/tests/integration/targets/setup_postgresql_db/files/dummy.control
@@ -1,3 +1,3 @@
 comment = 'dummy extension used to test postgresql_ext Ansible module'
-default_version = '3.0'
+default_version = '4.0'
 relocatable = true

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -223,6 +223,14 @@
   - dummy--1.0.sql
   - dummy--2.0.sql
   - dummy--3.0.sql
+  - dummy--3.0-1.sql
+  - dummy--3.0-foo.sql
+  - dummy--3.beta.sql
+  - dummy--3-1.0.sql
+  - dummy--3-1.0-1.sql
+  - dummy--3-1.foo.sql
+  - dummy--v4.sql
+  - dummy--4.0.sql
   when: ansible_os_family == 'Debian'
 
 - name: add update paths
@@ -234,6 +242,14 @@
   - dummy--0--1.0.sql
   - dummy--1.0--2.0.sql
   - dummy--2.0--3.0.sql
+  - dummy--3.0--3.0-1.sql
+  - dummy--3.0-1--3.0-foo.sql
+  - dummy--3.0-foo--3.beta.sql
+  - dummy--3.beta--3-1.0.sql
+  - dummy--3-1.0--3-1.0-1.sql
+  - dummy--3-1.0-1--3-1.foo.sql
+  - dummy--3-1.foo--v4.sql
+  - dummy--v4--4.0.sql
   when: ansible_os_family == 'Debian'
 
 - name: Get PostgreSQL version


### PR DESCRIPTION
##### SUMMARY

- add regex check that find out if extension version is numeric e.g. 1.0 , 1.0.1 or 1.1-1
- get first part of minor if it is split in to parts like this: '4-1'
- also set major to None if extension version is not numeric.

Fixes [#425](https://github.com/ansible-collections/community.postgresql/issues/425)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_info

