### PR TITLE
Added action_group all for module_defaults.

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,27 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  all:
+    - postgresql_copy
+    - postgresql_db
+    - postgresql_ext
+    - postgresql_idx
+    - postgresql_info
+    - postgresql_lang
+    - postgresql_membership
+    - postgresql_owner
+    - postgresql_pg_hba
+    - postgresql_ping
+    - postgresql_privs
+    - postgresql_publication
+    - postgresql_query
+    - postgresql_schema
+    - postgresql_script
+    - postgresql_sequence
+    - postgresql_set
+    - postgresql_slot
+    - postgresql_subscription
+    - postgresql_table
+    - postgresql_tablespace
+    - postgresql_user
+    - postgresql_user_obj_stat_info


### PR DESCRIPTION
##### SUMMARY

Fixes #313

Adds possibility to set `module_defaults` for calling modules with same arguments, e.g. `login_user` and `login_password` as described in [https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html](https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html).


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`meta/runtime.yml`

##### ADDITIONAL INFORMATION
This change adds the Module defaults group `all`, which allows setting common arguments.

For example, these tasks both need to define `login_user` and `login_password` for successful connection:

```yaml
- name: Create a new database with name "acme"
  community.postgresql.postgresql_db:
    login_user: test
    login_password: test
    name: acme

- name: Add a comment on django user
  community.postgresql.postgresql_user:
    login_user: test
    login_password: test
    db: postgres
    name: django
    comment: This is a test user
```

With *module_defaults* and the new `all` group these login settings can be defined as defaults at play level:

```yaml
---
- name: Converge
  hosts: all
  module_defaults:
    group/community.postgresql.all:
      login_user: test
      login_password: test
  roles:
    - postgres_configuration
```

Both tasks now don't need to define the arguments themselves

```yaml
- name: Create a new database with name "acme"
  community.postgresql.postgresql_db:
    name: acme

- name: Add a comment on django user
  community.postgresql.postgresql_user:
    db: postgres
    name: django
    comment: This is a test user
```


