### PR TITLE
postgresql_user: fix db closing

### DIFF
--- a/changelogs/fragments/0-postgresql_user.yml
+++ b/changelogs/fragments/0-postgresql_user.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_user - didn't close connection to DB. Fix now connection to DB is closed `` (https://github.com/ansible-collections/community.postgresql/issues/431).
+- postgresql_user - properly close DB connections to prevent possible connection limit exhaustion (https://github.com/ansible-collections/community.postgresql/issues/431).

--- a/changelogs/fragments/0-postgresql_user.yml
+++ b/changelogs/fragments/0-postgresql_user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_user - didn't close connection to DB. Fix now connection to DB is closed `` (https://github.com/ansible-collections/community.postgresql/issues/431).

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -1063,11 +1063,13 @@ def main():
                     module.fail_json(msg=msg)
                 kw['user_removed'] = user_removed
 
-    if changed:
-        if module.check_mode:
-            db_connection.rollback()
-        else:
-            db_connection.commit()
+    if module.check_mode:
+        db_connection.rollback()
+    else:
+        db_connection.commit()
+
+    cursor.close()
+    db_connection.close()
 
     kw['changed'] = changed
     kw['queries'] = executed_queries


### PR DESCRIPTION
##### SUMMARY
This PR for ISSUE https://github.com/ansible-collections/community.postgresql/issues/431

##### COMPONENT NAME
postgresql_user

##### ADDITIONAL INFORMATION
We have to remove the check "if changed" at the end of the code before rollback or commit because we anyway open a transaction and at the end ought to close it. (but this is not a big problem and we still can hold it in code if folks want it :) 
It's not from just a theoretical part, I tested and saw transactions "in idle in transaction" status as well :) 