### PR TITLE
Added checking of available columns when receiving a subscription from the database

### DIFF
--- a/changelogs/fragments/0-postgresql_info.yml
+++ b/changelogs/fragments/0-postgresql_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - when getting information about subscriptions, check the list of available columns in the pg_subscription table (https://github.com/ansible-collections/community.postgresql/issues/429).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -688,15 +688,15 @@ class PgClusterInfo(object):
                             "FROM information_schema.columns "
                             "WHERE table_schema = 'pg_catalog' "
                             "AND table_name = 'pg_subscription'")
-        columns_result = self.____exec_sql(columns_sub_table)
-        columns = ", ".join([f"s.{column[0]}" for column in columns_result])
+        columns_result = self.__exec_sql(columns_sub_table)
+        columns = ", ".join(["s.%s" % column[0] for column in columns_result])
 
-        query = (f"SELECT {columns}, r.rolname AS ownername, d.datname AS dbname "
+        query = ("SELECT %s, r.rolname AS ownername, d.datname AS dbname "
                  "FROM pg_catalog.pg_subscription s "
                  "JOIN pg_catalog.pg_database d "
                  "ON s.subdbid = d.oid "
                  "JOIN pg_catalog.pg_roles AS r "
-                 "ON s.subowner = r.oid")
+                 "ON s.subowner = r.oid" % columns)
 
         result = self.__exec_sql(query)
 

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -685,9 +685,9 @@ class PgClusterInfo(object):
     def get_subscr_info(self):
         """Get subscription statistics."""
         columns_sub_table = ("SELECT column_name "
-                            "FROM information_schema.columns "
-                            "WHERE table_schema = 'pg_catalog' "
-                            "AND table_name = 'pg_subscription'")
+                             "FROM information_schema.columns "
+                             "WHERE table_schema = 'pg_catalog' "
+                             "AND table_name = 'pg_subscription'")
         columns_result = self.__exec_sql(columns_sub_table)
         columns = ", ".join(["s.%s" % column[0] for column in columns_result])
 


### PR DESCRIPTION
##### SUMMARY
When an unprivileged user received a subscription, an error occurred: permission denied for table pg_subscription.
Now a check has been added, by getting the available columns and displaying only them.
Solution of the issue: #429 

##### ISSUE TYPE
Feature Pull Request
