### PR TITLE
Fix CI tests, postgresql_info and _subscription integration tests now use PostgreSQL 15

### DIFF
--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -162,6 +162,7 @@
     <<: *task_parameters
     postgresql_info:
       <<: *pg_parameters
+      login_port: '{{ replica_port }}'
       filter: ver*,role*
 
   - assert:
@@ -178,6 +179,7 @@
     <<: *task_parameters
     postgresql_info:
       <<: *pg_parameters
+      login_port: '{{ replica_port }}'
       filter: ver*
 
   - assert:
@@ -189,6 +191,7 @@
     <<: *task_parameters
     postgresql_info:
       <<: *pg_parameters
+      login_port: '{{ replica_port }}'
       filter:
       - "!ver*"
       - "!rol*"

--- a/tests/integration/targets/setup_postgresql_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_postgresql_replication/defaults/main.yml
@@ -10,10 +10,6 @@ pg_package_list:
 packages_to_remove:
 - postgresql
 - postgresql-client
-- postgresql-contrib
-- postgresql-server
-- postgresql-libs
-- python3-psycopg2
 
 # Master specific defaults:
 primary_root_dir: '/var/lib/pgsql/primary'

--- a/tests/integration/targets/setup_postgresql_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_postgresql_replication/defaults/main.yml
@@ -3,14 +3,13 @@ pg_user: postgres
 db_default: postgres
 
 pg_package_list:
-- apt-utils
-- postgresql-14
-- postgresql-contrib
+- postgresql
+- postgresql-client
 - python3-psycopg2
 
 packages_to_remove:
-- postgresql-14
-- postgresql-15
+- postgresql
+- postgresql-client
 - postgresql-contrib
 - postgresql-server
 - postgresql-libs

--- a/tests/integration/targets/setup_postgresql_replication/handlers/main.yml
+++ b/tests/integration/targets/setup_postgresql_replication/handlers/main.yml
@@ -7,12 +7,6 @@
   - { datadir: '{{ replica_data_dir }}', port: '{{ replica_port }}' }
   listen: stop postgresql
 
-- name: Kill all postgres processes
-  shell: 'pkill -9 -u {{ pg_user }}'
-  become: true
-  ignore_errors: true
-  listen: kill postgresql processes
-
 - name: Remove packages
   apt:
     name: '{{ packages_to_remove }}'

--- a/tests/integration/targets/setup_postgresql_replication/handlers/main.yml
+++ b/tests/integration/targets/setup_postgresql_replication/handlers/main.yml
@@ -7,6 +7,12 @@
   - { datadir: '{{ replica_data_dir }}', port: '{{ replica_port }}' }
   listen: stop postgresql
 
+- name: Kill all postgres processes
+  shell: 'pkill -9 -u {{ pg_user }}'
+  become: true
+  ignore_errors: true
+  listen: kill postgresql processes
+
 - name: Remove packages
   apt:
     name: '{{ packages_to_remove }}'
@@ -17,6 +23,7 @@
   file:
     state: absent
     path: "{{ item }}"
+    force: true
   loop:
   - "{{ primary_root_dir }}"
   - "{{ replica_root_dir }}"

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -8,30 +8,31 @@
   become: true
   apt:
     autoremove: true
-
-# Install PostgreSQL 15 on Ubuntu 20.04 and later
-# Though currently this target runs only on ubuntu >= 20.04
-- name: Install wget
-  package:
-    name: wget
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
-
-- name: Add a repository
-  shell: echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
-
-- name: Add a repository
-  shell: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
-
-- name: Add a repository
-  shell: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
-
-- name: Add a repository
-  shell: apt -y update
-  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
-#=================
+    
+- name: Configure Ubuntu 20 for PostgreSQL
+  when:
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_major_version'] is version('20', 'ge')
+  block:    
+    - name: Install wget
+      package:
+        name: wget
+    
+    - name: Add PGDG repository
+      lineinfile:
+        create: true
+        line: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
+        path: '/etc/apt/sources.list.d/pgdg.list'
+        state: 'present'
+    
+    - name: Add PGDG GPG key
+      get_url:
+        dest: '/etc/apt/trusted.gpg.d/ACCC4CF8.asc'
+        url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+    
+    - name: Update apt cache
+      apt:
+        update_cache: true
 
 - name: Install apt-utils
   apt:

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -31,7 +31,8 @@
         url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     
     - name: Update apt cache
-      command: apt update
+      apt:
+        update_cache: true
 
 - name: Install apt-utils
   apt:

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -21,7 +21,7 @@
     - name: Add PGDG repository
       lineinfile:
         create: true
-        line: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
+        line: "deb http://apt.postgresql.org/pub/repos/apt {{ ansible_facts['distribution_release'] }}-pgdg main"
         path: '/etc/apt/sources.list.d/pgdg.list'
         state: 'present'
     

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -26,9 +26,9 @@
         state: 'present'
     
     - name: Add PGDG GPG key
-      get_url:
-        dest: '/etc/apt/trusted.gpg.d/ACCC4CF8.asc'
-        url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+      ansible.builtin.apt_key:
+        state: present
+        url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     
     - name: Update apt cache
       apt:

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -123,16 +123,11 @@
   shell: '{{ pg_ctl }} -D {{ primary_data_dir }} -o "-p {{ primary_port }}" -l {{ primary_data_dir }}/primary.log start'
   notify:
   - stop postgresql
-  - kill postgresql processes
-  async: 15
-  poll: 0
 
 - name: Start replica
   become: true
   become_user: '{{ pg_user }}'
   shell: '{{ pg_ctl }} -D {{ replica_data_dir }} -o "-p {{ replica_port }}" -l {{ replica_data_dir }}/replica.log start'
-  async: 15
-  poll: 0
 
 - name: Check connectivity to the primary and get PostgreSQL version
   become: true

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -2,31 +2,15 @@
   apt:
     name: '{{ packages_to_remove }}'
     state: absent
-
-#=================
-- name: Kill all postgres processes
-  shell: 'pkill -u {{ pg_user }}'
   become: true
-  ignore_errors: true
 
-- name: stop postgresql service
-  service: name={{ postgresql_service }} state=stopped
-  ignore_errors: true
+- name: Run autoremove
+  become: true
+  apt:
+    autoremove: true
 
-- name: Delete postgresql related files
-  file:
-    state: absent
-    path: '{{ item }}'
-  loop:
-  - '{{ primary_root_dir }}'
-  - '{{ primary_data_dir }}'
-  - '{{ replica_root_dir }}'
-  - '{{ replica_data_dir }}'
-  - /etc/postgresql
-  - /var/lib/postgresql
-
-#
-# Install PostgreSQL 14 on Ubuntu 20.04 and later
+# Install PostgreSQL 15 on Ubuntu 20.04 and later
+# Though currently this target runs only on ubuntu >= 20.04
 - name: Install wget
   package:
     name: wget
@@ -41,27 +25,55 @@
   when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
 
 - name: Add a repository
+  shell: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
+  when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
+
+- name: Add a repository
   shell: apt -y update
   when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version >= '20'
 #=================
+
+- name: Install apt-utils
+  apt:
+    name: apt-utils
 
 - name: Install packages
   apt:
     name: '{{ pg_package_list }}'
   notify: cleanup postgresql
 
-- name: Create root dirs
+# Andersson007 has no idea why it runs after installation w/o asking..
+- name: Stop service if running
+  become: true
+  systemd:
+    name: postgresql
+    state: stopped
+    enabled: false
+    force: yes
+
+- name: Delete postgresql related files
+  file:
+    state: absent
+    path: '{{ item }}'
+    force: true
+  loop:
+  - '{{ primary_root_dir }}'
+  - '{{ replica_root_dir }}'
+  - /etc/postgresql
+  - /var/lib/postgresql
+
+- name: Create dirs needed
   file:
     state: directory
+    recurse: true
     path: '{{ item }}'
     owner: postgres
     group: postgres
     mode: '0700'
   loop:
-  - '{{ primary_root_dir }}'
   - '{{ primary_data_dir }}'
-  - '{{ replica_root_dir }}'
   - '{{ replica_data_dir }}'
+  - /var/lib/postgresql
   notify: cleanup postgresql
 
 - name: Find initdb
@@ -105,16 +117,22 @@
   set_fact:
     pg_ctl: '{{ result.stdout }}'
 
-- name: Start servers
+- name: Start primary
   become: true
   become_user: '{{ pg_user }}'
-  shell: '{{ pg_ctl }} -D {{ item.datadir }} -o "-p {{ item.port }}" start'
-  loop:
-  - datadir: '{{ primary_data_dir }}'
-    port: '{{ primary_port }}'
-  - datadir: '{{ replica_data_dir }}'
-    port: '{{ replica_port }}'
-  notify: stop postgresql
+  shell: '{{ pg_ctl }} -D {{ primary_data_dir }} -o "-p {{ primary_port }}" -l {{ primary_data_dir }}/primary.log start'
+  notify:
+  - stop postgresql
+  - kill postgresql processes
+  async: 15
+  poll: 0
+
+- name: Start replica
+  become: true
+  become_user: '{{ pg_user }}'
+  shell: '{{ pg_ctl }} -D {{ replica_data_dir }} -o "-p {{ replica_port }}" -l {{ replica_data_dir }}/replica.log start'
+  async: 15
+  poll: 0
 
 - name: Check connectivity to the primary and get PostgreSQL version
   become: true

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -41,16 +41,8 @@
 - name: Install packages
   apt:
     name: '{{ pg_package_list }}'
+    policy_rc_d: 101  # prevent the service from starting
   notify: cleanup postgresql
-
-# Andersson007 has no idea why it runs after installation w/o asking..
-- name: Stop service if running
-  become: true
-  systemd:
-    name: postgresql
-    state: stopped
-    enabled: false
-    force: yes
 
 - name: Delete postgresql related files
   file:

--- a/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -31,8 +31,7 @@
         url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     
     - name: Update apt cache
-      apt:
-        update_cache: true
+      command: apt update
 
 - name: Install apt-utils
   apt:


### PR DESCRIPTION
##### SUMMARY
Fix CI tests, postgresql_info and _subscription integration tests now use PostgreSQL 15

There were several issues:
- mess with package installation. From now on `_info` and `_subscription` (which use this target) will run against PG 15
- postgresql_info tasks using a wrong port (default)
- main reason why servers hung indefinitely were ..logs. After I added `pg_ctl start .. -l <personal_log_file>` to each launch task, it will run

If other maintainers are OK, after merging and backporting, please relaunch tests in https://github.com/ansible-collections/community.postgresql/pull/444 and merge-backport it if green