### PR TITLE
Fix connect_params being ignored on postgresql_privs

### DIFF
--- a/changelogs/fragments/451-postgresql_privs_fix_connect_params_being_ignored.yml
+++ b/changelogs/fragments/451-postgresql_privs_fix_connect_params_being_ignored.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - fix connect_params being ignored (https://github.com/ansible-collections/community.postgresql/issues/450).

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -441,7 +441,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.database impo
     pg_quote_identifier,
     check_input,
 )
-from ansible_collections.community.postgresql.plugins.module_utils.postgres import postgres_common_argument_spec
+from ansible_collections.community.postgresql.plugins.module_utils.postgres import postgres_common_argument_spec, get_conn_params
 from ansible.module_utils._text import to_native
 
 VALID_PRIVS = frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE',
@@ -507,19 +507,13 @@ class Connection(object):
             "ca_cert": "sslrootcert"
         }
 
-        kw = dict((params_map[k], getattr(params, k)) for k in params_map
-                  if getattr(params, k) != '' and getattr(params, k) is not None)
-
-        # If a login_unix_socket is specified, incorporate it here.
-        is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
-        if is_localhost and params.login_unix_socket != "":
-            kw["host"] = params.login_unix_socket
+        conn_params = get_conn_params(module, module.params, warn_db_default=False)
 
         sslrootcert = params.ca_cert
         if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
             raise ValueError('psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
-        self.connection = psycopg2.connect(**kw)
+        self.connection = psycopg2.connect(**conn_params)
         self.cursor = self.connection.cursor()
         self.pg_version = self.connection.server_version
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #450
Where connect_params were ignored for community.postgresql.postgresql_privs

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_privs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Previous connect_params were ignored. A helper method used in postgresql_user took care of this and other checking which was being done here, including unix socket check. 

The end result is connect_params being properly honored now.

<!--- Paste verbatim command output below, e.g. before and after your change -->
connect_params with:
```
    connect_params:
      sslcert: "{{ db_cert }}"
      sslkey: "{{ db_key }}"
      sslrootcert: "{{ db_ca }}"
 ```
 Before: (fails with cert error, same cert error I get if I leave out connect_params entirely)
```
failed: [foo -> 127.0.0.1] (item={'privs': 'ALL', 'objs': 'tables', 'type': 'default_privs'}) => {"ansible_loop_var": "privilege", "changed": false, "msg": "Could not connect to database: connection to server at \"<redacted>\" (<redacted>), port 443 failed: SSL error: sslv3 alert bad certificate\n", "privilege": {"objs": "tables", "privs": "ALL", "type": "default_privs"}}
```
After: (uses the connect_params successfuly, like `community.postgresql.postgresql_membership` and `community.postgresql.postgresql_user` do)
```
ok: [foo -> 127.0.0.1] => (item={'privs': 'ALL', 'objs': 'tables', 'type': 'default_privs'})
```
