### PR TITLE
[PR #451/bbb32575 backport][stable-1] Fix connect_params being ignored (#451)

### DIFF
--- a/changelogs/fragments/451-postgresql_privs_fix_connect_params_being_ignored.yml
+++ b/changelogs/fragments/451-postgresql_privs_fix_connect_params_being_ignored.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - fix connect_params being ignored (https://github.com/ansible-collections/community.postgresql/issues/450).


### PR DESCRIPTION
(cherry picked from commit bbb325758ec4cba98e731a3d72dace3c3b3ac2d3)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a backport of the changes in #451 resolving a conflict in `postgresql_privs.py`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_privs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Previous connect_params were ignored. A helper method used in postgresql_user took care of this and other checking which was being done here, including unix socket check. 

The end result is connect_params being properly honored now.

<!--- Paste verbatim command output below, e.g. before and after your change -->
connect_params with:
```
    connect_params:
      sslcert: "{{ db_cert }}"
      sslkey: "{{ db_key }}"
      sslrootcert: "{{ db_ca }}"
 ```
 Before: (fails with cert error, same cert error I get if I leave out connect_params entirely)
```
failed: [foo -> 127.0.0.1] (item={'privs': 'ALL', 'objs': 'tables', 'type': 'default_privs'}) => {"ansible_loop_var": "privilege", "changed": false, "msg": "Could not connect to database: connection to server at \"<redacted>\" (<redacted>), port 443 failed: SSL error: sslv3 alert bad certificate\n", "privilege": {"objs": "tables", "privs": "ALL", "type": "default_privs"}}
```
After: (uses the connect_params successfuly, like `community.postgresql.postgresql_membership` and `community.postgresql.postgresql_user` do)
```
ok: [foo -> 127.0.0.1] => (item={'privs': 'ALL', 'objs': 'tables', 'type': 'default_privs'})
```
