### PR TITLE
postgresql_pg_hba: fix file parsing

### DIFF
--- a/changelogs/fragments/458-postgresql_pg_hba_fix_parsing.yml
+++ b/changelogs/fragments/458-postgresql_pg_hba_fix_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_pg_hba - add support for double-quoted values and escaped quotes when parsing pg_hba.conf (https://github.com/ansible-collections/community.postgresql/issues/420)

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -277,7 +277,7 @@ PG_HBA_ORDERS = ["sdu", "sud", "dsu", "dus", "usd", "uds"]
 PG_HBA_HDR = ['type', 'db', 'usr', 'src', 'mask', 'method', 'options']
 
 PG_HBA_ITEM_REGEX = re.compile(r'("(\\"|[^"])*"|[^"#\s]+)')
-PG_HBA_LINE_REGEX = re.compile(r'(("(\\"|[^"])*"|[^"#])*)(#(.*))?')
+PG_HBA_LINE_REGEX = re.compile(r'\A(("(\\"|[^"])*"|[^"#])*)(#(.*))?\Z')
 
 
 class PgHbaError(Exception):
@@ -363,10 +363,10 @@ class PgHba(object):
                 for line in file:
                     # split into line and comment
                     line = line.strip()
-                    parsed_line = PG_HBA_LINE_REGEX.fullmatch(line)
-                    line = parsed_line[1]
+                    parsed_line = PG_HBA_LINE_REGEX.match(line)
+                    line = parsed_line.group(1)
                     comment = parsed_line.group(5)
-                    if comment.strip() == '':
+                    if comment is not None and comment.strip() == '':
                         comment = None
                     line = line.rstrip()
                     # if there is just a comment, save it

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -574,7 +574,7 @@ class PgHbaRule(dict):
         if not line.strip():
             # skip an empty line
             return
-        cols = [item for item, _ in PG_HBA_ITEM_REGEX.findall(line)]
+        cols = [item for item, ignored in PG_HBA_ITEM_REGEX.findall(line)]
         if len(cols) < 4:
             msg = "Rule {0} has too few columns."
             raise PgHbaValueError(msg.format(line))


### PR DESCRIPTION
fixes #420, replaces #423

This PR is a bugfix for the postgresql_pg_hba module: Lines of the `pg_hba.conf` can contain quoted fields which can contain `#` or an escaped quote (`\"`). This was not parsed correctly before.