### PR TITLE
Duplicates in Notes for postgresql_ext

### DIFF
--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -75,11 +75,11 @@ notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - To avoid "Peer authentication failed for user postgres" error,
   use postgres user as a I(become_user).
-- This module uses psycopg2, a Python PostgreSQL database adapter. You must
-  ensure that psycopg2 is installed on the host before using this module.
+- This module uses C(psycopg2), a Python PostgreSQL database adapter. You must
+  ensure that C(psycopg2) is installed on the host before using this module.
 - If the remote host is the PostgreSQL server (which is the default case), then
   PostgreSQL must also be installed on the remote host.
-- For Ubuntu-based systems, install the postgresql, libpq-dev, and python-psycopg2 packages
+- For Ubuntu-based systems, install the C(postgresql), C(libpq-dev), and C(python-psycopg2) packages
   on the remote host before using this module.
 - The ca_cert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 requirements: [ psycopg2 ]

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -102,14 +102,6 @@ seealso:
   link: https://www.postgresql.org/docs/current/sql-droppublication.html
 notes:
 - Supports C(check_mode).
-- The default authentication assumes that you are either logging in as
-  or sudo'ing to the C(postgres) account on the host.
-- This module uses I(psycopg2), a Python PostgreSQL database adapter.
-- You must ensure that C(psycopg2) is installed on the host before using this module.
-- If the remote host is the PostgreSQL server (which is the default case),
-  then PostgreSQL must also be installed on the remote host.
-- For Ubuntu-based systems, install the C(postgresql), C(libpq-dev),
-  and C(python-psycopg2) packages on the remote host before using this module.
 - Incomparable versions, for example PostGIS ``unpackaged``, cannot be installed.
 requirements: [ psycopg2 ]
 author:


### PR DESCRIPTION
##### SUMMARY
Fixes #476 
Removing duplicate Notes from postgresql_ext module documentation.
Adding highlights to doc_fragments to make the look consistent.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
postgresql_ext

##### ADDITIONAL INFORMATION
https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_ext_module.html#notes