### PR TITLE
Doc attributes

### DIFF
--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -74,7 +74,7 @@ options:
 
 attributes:
   check_mode:
-    description: Can run in check_mode and return changed status prediction without modifying target
+    description: Can run in check_mode and return changed status prediction without modifying target.
 
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -71,6 +71,11 @@ options:
     type: dict
     default: {}
     version_added: '2.3.0'
+
+attributes:
+  check_mode:
+    description: Can run in check_mode and return changed status prediction without modifying target
+
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - To avoid "Peer authentication failed for user postgres" error,
@@ -82,5 +87,6 @@ notes:
 - For Ubuntu-based systems, install the C(postgresql), C(libpq-dev), and C(python-psycopg2) packages
   on the remote host before using this module.
 - The ca_cert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
+
 requirements: [ psycopg2 ]
 '''

--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -79,11 +79,16 @@ options:
 notes:
 - Supports PostgreSQL version 9.4+.
 - COPY command is only allowed to database superusers.
-- If I(check_mode=true), we just check the src/dst table availability
-  and return the COPY query that actually has not been executed.
-- If i(check_mode=true) and the source has been passed as SQL, the module
-  will execute it and rolled the transaction back but pay attention
-  it can affect database performance (e.g., if SQL collects a lot of data).
+
+attributes:
+  check_mode:
+    support: partial
+    details:
+      - If I(check_mode=true), we just check the src/dst table availability
+        and return the COPY query that actually has not been executed.
+      - If i(check_mode=true) and the source has been passed as SQL, the module
+        will execute it and roll the transaction back, but pay attention
+        it can affect database performance (e.g., if SQL collects a lot of data).
 
 seealso:
 - name: COPY command reference

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -20,13 +20,6 @@ options:
     type: str
     required: true
     aliases: [ db ]
-  port:
-    description:
-      - Database port to connect (if needed).
-    type: int
-    default: 5432
-    aliases:
-      - login_port
   owner:
     description:
       - Name of the role to set as owner of the database.
@@ -153,13 +146,18 @@ seealso:
 - module: community.postgresql.postgresql_tablespace
 - module: community.postgresql.postgresql_info
 - module: community.postgresql.postgresql_ping
+
 notes:
 - State C(dump) and C(restore) don't require I(psycopg2) since version 2.8.
-- Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
+
 author: "Ansible Core Team"
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -100,19 +100,23 @@ seealso:
 - name: DROP EXTENSION reference
   description: Complete reference of the DROP EXTENSION command documentation.
   link: https://www.postgresql.org/docs/current/sql-droppublication.html
+
 notes:
-- Supports C(check_mode).
 - Incomparable versions, for example PostGIS ``unpackaged``, cannot be installed.
-requirements: [ psycopg2 ]
+
+attributes:
+  check_mode:
+    support: full
+
 author:
 - Daniel Schep (@dschep)
 - Thomas O'Donnell (@andytom)
 - Sandro Santilli (@strk)
 - Andrew Klychkov (@Andersson007)
 - Keith Fiske (@keithf4)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_idx.py
+++ b/plugins/modules/postgresql_idx.py
@@ -135,9 +135,12 @@ seealso:
   link: https://www.postgresql.org/docs/current/sql-dropindex.html
 
 notes:
-- Supports C(check_mode).
 - The index building process can affect database performance.
 - To avoid table locks on production databases, use I(concurrent=true) (default behavior).
+
+attributes:
+  check_mode:
+    support: full
 
 author:
 - Andrew Klychkov (@Andersson007)
@@ -145,7 +148,6 @@ author:
 
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -47,15 +47,19 @@ options:
     type: bool
     default: true
     version_added: '0.2.0'
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - module: community.postgresql.postgresql_ping
+
 author:
 - Andrew Klychkov (@Andersson007)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_lang.py
+++ b/plugins/modules/postgresql_lang.py
@@ -78,24 +78,6 @@ options:
     type: str
     default: present
     choices: [ absent, present ]
-  login_unix_socket:
-    description:
-      - Path to a Unix domain socket for local connections.
-    type: str
-  ssl_mode:
-    description:
-      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for more information on the modes.
-      - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
   owner:
     description:
       - Set an owner for the language.
@@ -123,14 +105,17 @@ seealso:
 - name: DROP LANGUAGE reference
   description: Complete reference of the DROP LANGUAGE command documentation.
   link: https://www.postgresql.org/docs/current/sql-droplanguage.html
+
+attributes:
+  check_mode:
+    support: full
+
 author:
 - Jens Depuydt (@jensdepuydt)
 - Thomas O'Donnell (@andytom)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -87,12 +87,16 @@ seealso:
 - name: PostgreSQL role attributes reference
   description: Complete reference of the PostgreSQL role attributes documentation.
   link: https://www.postgresql.org/docs/current/role-attributes.html
+
+attributes:
+  check_mode:
+    support: full
+
 author:
 - Andrew Klychkov (@Andersson007)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -81,12 +81,16 @@ seealso:
 - name: PostgreSQL REASSIGN OWNED command reference
   description: Complete reference of the PostgreSQL REASSIGN OWNED command documentation.
   link: https://www.postgresql.org/docs/current/sql-reassign-owned.html
+
+attributes:
+  check_mode:
+    support: full
+
 author:
 - Andrew Klychkov (@Andersson007)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -144,7 +144,6 @@ notes:
      After the C(pg_hba) file is rewritten by the M(community.postgresql.postgresql_pg_hba) module, the ip specific rule will be sorted above the range rule.
      And then it will hit, which will give unexpected results.
    - With the 'order' parameter you can control which field is used to sort first, next and last.
-   - The module supports a check mode and a diff mode.
 
 seealso:
 - name: PostgreSQL pg_hba.conf file reference
@@ -152,7 +151,15 @@ seealso:
   link: https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
 
 requirements:
-    - ipaddress
+  - ipaddress
+
+attributes:
+  check_mode:
+    support: full
+    description: Can run in check_mode and return changed status prediction without modifying target
+  diff_mode:
+    support: full
+    description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
 
 author:
 - Sebastiaan Mannem (@sebasmannem)

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -37,12 +37,13 @@ options:
     version_added: '0.2.0'
 seealso:
 - module: community.postgresql.postgresql_info
+attributes:
+  check_mode:
+    support: full
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment:
 - community.postgresql.postgres
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -120,21 +120,6 @@ options:
     - Mutually exclusive with I(login_password).
     type: str
     default: ''
-  ssl_mode:
-    description:
-    - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-    - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for more information on the modes.
-    - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-    - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-    - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    type: str
-    aliases:
-    - ssl_rootcert
   trust_input:
     description:
     - If C(false), check whether values of parameters I(roles), I(target_roles), I(session_role),
@@ -157,7 +142,6 @@ options:
     version_added: '1.2.0'
 
 notes:
-- Supports C(check_mode).
 - Parameters that accept comma separated lists (I(privs), I(objs), I(roles))
   have singular alias names (I(priv), I(obj), I(role)).
 - To revoke only C(GRANT OPTION) for a specific object, set I(state) to
@@ -184,9 +168,12 @@ seealso:
   description: Complete reference of the PostgreSQL REVOKE command documentation.
   link: https://www.postgresql.org/docs/current/sql-revoke.html
 
+attributes:
+  check_mode:
+    support: full
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 
 author:
 - Bernhard Weitzhofer (@b6d)

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -74,9 +74,14 @@ options:
     type: bool
     default: true
     version_added: '0.2.0'
+
 notes:
 - PostgreSQL version must be 10 or greater.
-- Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - name: CREATE PUBLICATION reference
   description: Complete reference of the CREATE PUBLICATION command documentation.

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -116,14 +116,18 @@ seealso:
 - name: PostgreSQL Schema reference
   description: Complete reference of the PostgreSQL schema documentation.
   link: https://www.postgresql.org/docs/current/ddl-schemas.html
+
+attributes:
+  check_mode:
+    support: full
+
 author:
 - Felix Archambault (@archf)
 - Andrew Klychkov (@Andersson007)
 - Will Rouesnel (@wrouesnel)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -52,20 +52,6 @@ options:
     - Drop schema with CASCADE to remove child objects.
     type: bool
     default: false
-  ssl_mode:
-    description:
-      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for more information on the modes.
-      - Default of C(prefer) matches libpq default.
-    type: str
-    default: prefer
-    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
-  ca_cert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    type: str
-    aliases: [ ssl_rootcert ]
   trust_input:
     description:
     - If C(false), check whether values of parameters I(schema), I(owner), I(session_role) are potentially dangerous.
@@ -86,13 +72,17 @@ seealso:
 - name: DROP SCHEMA reference
   description: Complete reference of the DROP SCHEMA command documentation.
   link: https://www.postgresql.org/docs/current/sql-dropschema.html
+
+attributes:
+  check_mode:
+    support: full
+
 author:
 - Flavien Chantelot (@Dorn-) <contact@flavien.io>
 - Thomas O'Donnell (@andytom)
+
 extends_documentation_fragment:
 - community.postgresql.postgres
-notes:
-- Supports C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -81,6 +81,10 @@ seealso:
   description: Complete reference of the PostgreSQL schema documentation.
   link: https://www.postgresql.org/docs/current/ddl-schemas.html
 
+attributes:
+  check_mode:
+    support: none
+
 author:
 - Douglas J Hunley (@hunleyd)
 - A. Hart (@jtelcontar)
@@ -89,9 +93,6 @@ author:
 
 extends_documentation_fragment:
 - community.postgresql.postgres
-
-notes:
-- Does not support C(check_mode).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_sequence.py
+++ b/plugins/modules/postgresql_sequence.py
@@ -138,10 +138,15 @@ options:
     type: bool
     default: true
     version_added: '0.2.0'
+
 notes:
-- Supports C(check_mode).
 - If you do not pass db parameter, sequence will be created in the database
   named postgres.
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - module: community.postgresql.postgresql_table
 - module: community.postgresql.postgresql_owner

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -62,7 +62,6 @@ options:
     version_added: '0.2.0'
 notes:
 - Supported version of PostgreSQL is 9.4 and later.
-- Supports C(check_mode).
 - Pay attention, change setting with 'postmaster' context can return changed is true
   when actually nothing changes because the same value may be presented in
   several different form, for example, 1024MB, 1GB, etc. However in pg_settings

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -71,6 +71,11 @@ notes:
   not restarted and the value in pg_settings is not updated yet.
 - For some parameters restart of PostgreSQL server is required.
   See official documentation U(https://www.postgresql.org/docs/current/view-pg-settings.html).
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - module: community.postgresql.postgresql_info
 - name: PostgreSQL server configuration
@@ -86,7 +91,6 @@ author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: postgresql_slot
 short_description: Add or remove replication slots from a PostgreSQL database
@@ -77,7 +77,10 @@ options:
 notes:
 - Physical replication slots were introduced to PostgreSQL with version 9.4,
   while logical replication slots were added beginning with version 10.0.
-- Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
 
 seealso:
 - name: PostgreSQL pg_replication_slots view reference
@@ -96,7 +99,6 @@ author:
 - Thomas O'Donnell (@andytom)
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -95,7 +95,10 @@ options:
 
 notes:
 - PostgreSQL version must be 10 or greater.
-- Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
 
 seealso:
 - module: community.postgresql.postgresql_publication
@@ -115,7 +118,6 @@ author:
 
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -100,12 +100,17 @@ options:
     type: bool
     default: true
     version_added: '0.2.0'
+
 notes:
-- Supports C(check_mode).
 - If you do not pass db parameter, tables will be created in the database
   named postgres.
 - PostgreSQL allows to create columnless table, so columns param is optional.
 - Unlogged tables are available from PostgreSQL server version 9.1.
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - module: community.postgresql.postgresql_sequence
 - module: community.postgresql.postgresql_idx
@@ -130,7 +135,6 @@ author:
 - Andrei Klychkov (@Andersson007)
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -83,6 +83,10 @@ notes:
   support check mode because the corresponding PostgreSQL DROP and CREATE TABLESPACE commands
   can not be run inside the transaction block.
 
+attributes:
+  check_mode:
+    support: partial
+
 seealso:
 - name: PostgreSQL tablespaces
   description: General information about PostgreSQL tablespaces.
@@ -104,7 +108,6 @@ author:
 
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -78,14 +78,13 @@ options:
     default: true
     version_added: '0.2.0'
 
-notes:
-- I(state=absent) and I(state=present) (the second one if the tablespace doesn't exist) do not
-  support check mode because the corresponding PostgreSQL DROP and CREATE TABLESPACE commands
-  can not be run inside the transaction block.
-
 attributes:
   check_mode:
     support: partial
+    details:
+      - I(state=absent) and I(state=present) (the second one if the tablespace doesn't exist) do not
+        support check mode because the corresponding PostgreSQL DROP and CREATE TABLESPACE commands
+        can not be run inside the transaction block.
 
 seealso:
 - name: PostgreSQL tablespaces

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -178,7 +178,11 @@ notes:
 - On some systems (such as AWS RDS), C(SUPERUSER) is unavailable. This means the C(SUPERUSER) and
   C(NOSUPERUSER) I(role_attr_flags) should not be specified to preserve idempotency and avoid
   InsufficientPrivilege errors.
-- Supports ``check_mode``.
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - module: community.postgresql.postgresql_privs
 - module: community.postgresql.postgresql_membership
@@ -193,7 +197,6 @@ author:
 - Ansible Core Team
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/postgresql_user_obj_stat_info.py
@@ -52,7 +52,11 @@ notes:
 - C(size) and C(total_size) returned values are presented in bytes.
 - For tracking function statistics the PostgreSQL C(track_functions) parameter must be enabled.
   See U(https://www.postgresql.org/docs/current/runtime-config-statistics.html) for more information.
-- Supports C(check_mode).
+
+attributes:
+  check_mode:
+    support: full
+
 seealso:
 - module: community.postgresql.postgresql_info
 - module: community.postgresql.postgresql_ping
@@ -64,7 +68,6 @@ author:
 - Thomas O'Donnell (@andytom)
 extends_documentation_fragment:
 - community.postgresql.postgres
-
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### SUMMARY
Moved all `check_mode` notes in `DOCUMENTATION` to the `attributes:` section.
Fixes #435

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
All modules documentation

##### ADDITIONAL INFORMATION
Most modules have full support for the `check_mode`, with few exceptions:
* postgresql_script doesn't support the check_mode
* postgresql_tablespace has partial support
* not sure whether postgresql_copy should be marked as `full` or `partial`, any feedback welcome

postgresql_pg_hba also supports the `diff_mode`, so that was also added to the attributes section for this module. The pg_hba module isn't sharing the postgres.py doc fragment, so its documentation structure is different from the rest.

