### PR TITLE
Use get properties to define default port for PG

### DIFF
--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -51,7 +51,7 @@ def postgres_common_argument_spec():
         login_unix_socket=dict(default='', aliases=['unix_socket']),
         port=dict(
             type='int',
-            default=5432 if not env_vars.get("PGPORT") else int(env_vars.get("PGPORT")),
+            default=int(env_vars.get("PGPORT", 5432)),
             aliases=['login_port']
         ),
         ssl_mode=dict(


### PR DESCRIPTION
##### SUMMARY
Instead of a using a ternary operator we rely on get function to define the default value for the PostgreSQL port.

##### ISSUE TYPE
None, just a small and minor change.

##### ADDITIONAL INFORMATION
Rely on python method envinron.get to define the default value for th postgresql port.
