### PR TITLE
postgresql_ext - Added idempotence when version=latest

### DIFF
--- a/changelogs/fragments/504_postgresql_ext.yml
+++ b/changelogs/fragments/504_postgresql_ext.yml
@@ -1,2 +1,2 @@
-major_changes:
+minor_changes:
 - "postgresql_privs - added idempotence when version=latest (https://github.com/ansible-collections/community.postgresql/pull/504)."

--- a/changelogs/fragments/504_postgresql_ext.yml
+++ b/changelogs/fragments/504_postgresql_ext.yml
@@ -1,0 +1,2 @@
+major_changes:
+- "postgresql_privs - added idempotence when version=latest (https://github.com/ansible-collections/community.postgresql/pull/504)."

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -424,7 +424,7 @@ def main():
                             else:
                                 update_cmd_executed = ext_update_version(cursor, ext, version)
                                 if version == 'latest':
-                                    new_curr_version, _ = ext_get_versions(cursor, ext)
+                                    new_curr_version, new_available_versions = ext_get_versions(cursor, ext)
                                     changed = curr_version != new_curr_version
                                 else:
                                     changed = update_cmd_executed

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -404,6 +404,11 @@ def main():
         # Get extension info and available versions:
         curr_version, available_versions = ext_get_versions(cursor, ext)
 
+        # Extract latest available version
+        latest_version = None
+        if available_versions:
+            latest_version = max(available_versions)
+
         if state == "present":
 
             # If version passed
@@ -413,8 +418,10 @@ def main():
                     # Given version already installed
                     if curr_version == version:
                         changed = False
-                    # Attempt to update to given version or latest version defined in extension control file
-                    # ALTER EXTENSION is actually run if valid, so 'changed' will be true even if nothing updated
+                    # Latest version required but already installed
+                    elif version == 'latest' and curr_version == latest_version:
+                        changed = False
+                    # Version update required
                     else:
                         valid_update_path = ext_valid_update_path(cursor, ext, curr_version, version)
                         if valid_update_path:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -415,7 +415,7 @@ def main():
                         changed = False
                     # Attempt to update to given version or latest version defined in extension control file
                     # ALTER EXTENSION is actually run if valid, so check if installed version is changed
-                    # when latest version is requested
+                    # when update to latest version is requested
                     else:
                         valid_update_path = ext_valid_update_path(cursor, ext, curr_version, version)
                         if valid_update_path:

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -211,7 +211,7 @@
       that:
       - result.rowcount == 1
 
-  - name: postgresql_ext_version - try to update the extension to the latest version again which always runs an update.
+  - name: postgresql_ext_version - try to update the extension to the latest version again which always runs an update
     <<: *task_parameters
     postgresql_ext:
       <<: *pg_parameters
@@ -222,7 +222,7 @@
 
   - assert:
       that:
-      - result is changed
+      - result is not changed
 
   - name: postgresql_ext_version - check that version number did not change even though update ran
     <<: *task_parameters


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Actually postgresql_ext module always results changed if version=latest.

When latest extension version is installed, every update command has no effect:

```
test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             |
(1 row)

test=# CREATE EXTENSION adminpack VERSION '1.0';
CREATE EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 1.0
(1 row)

test=# ALTER EXTENSION adminpack UPDATE TO '2.0';
ALTER EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.0
(1 row)

test=# ALTER EXTENSION adminpack UPDATE TO '2.0';
NOTICE:  version "2.0" of extension "adminpack" is already installed
ALTER EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.0
(1 row)

test=# ALTER EXTENSION adminpack UPDATE;
ALTER EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.1
(1 row)

test=# ALTER EXTENSION adminpack UPDATE;
NOTICE:  version "2.1" of extension "adminpack" is already installed
ALTER EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.1
(1 row)
```

Message **"version <ext_ver> of extension <ext_name> is already installed"** is present only once is source code and after it no actions are performed:

https://github.com/postgres/postgres/blob/d088ba5a5aa410d39b64f013e8433ad9eb3d17f1/src/backend/commands/extension.c#L3078

My PR add idempotence when provided version=latest, checking if installed version is changed after update command when provided version=latest. Tests regarding always-changed when provided version=latest has been updated.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_ext

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The second task of following play results not changed:
```paste below
- hosts: dbs
  tasks:
    - name: Install extension adminpack at latest version
      community.postgresql.postgresql_ext:
        database: test
        state: present
        name: adminpack
        version: latest

    - name: Update extension adminpack at latest version
      community.postgresql.postgresql_ext:
        database: test
        state: present
        name: adminpack
        version: latest
```
