### PR TITLE
postgresql_set - fixed error message in param_set function

### DIFF
--- a/changelogs/fragments/505-postgresql_set.yml
+++ b/changelogs/fragments/505-postgresql_set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - fixed error message in param_set function (https://github.com/ansible-collections/community.postgresql/pull/505)

--- a/changelogs/fragments/505-postgresql_set.yml
+++ b/changelogs/fragments/505-postgresql_set.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_set - fixed error message in param_set function (https://github.com/ansible-collections/community.postgresql/pull/505)
+- postgresql_set - fixed error message in param_set function (https://github.com/ansible-collections/community.postgresql/pull/505).

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -335,7 +335,7 @@ def param_set(cursor, module, name, value, context):
             cursor.execute("SELECT pg_reload_conf()")
 
     except Exception as e:
-        module.fail_json(msg="Unable to get %s value due to : %s" % (name, to_native(e)))
+        module.fail_json(msg="Unable to set %s value due to : %s" % (name, to_native(e)))
 
     return True
 

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -325,6 +325,8 @@ def param_set(cursor, module, name, value, context):
             if isinstance(value, str) and ',' in value and not name.endswith(('_command', '_prefix')):
                 # Issue https://github.com/ansible-collections/community.postgresql/issues/78
                 # Change value from 'one, two, three' -> "'one','two','three'"
+                # PR https://github.com/ansible-collections/community.postgresql/pull/400
+                # Parameter names ends with '_command' or '_prefix' can contains commas but are not lists
                 value = ','.join(["'" + elem.strip() + "'" for elem in value.split(',')])
                 query = "ALTER SYSTEM SET %s = %s" % (name, value)
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

My PR fixes an error message in postgresql_set and adds a missing comment (both in param_set function).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_set

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Error in param_set is "Unable to **get** ..." but must be "Unable to **set** ...".
Comment is missed from PR #400.
