### PR TITLE
Updated list of tested versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,17 @@ Tested with the following `ansible-core` releases:
 - 2.12
 - 2.13
 - 2.14
+- 2.15
 - current development version
 
 Ansible-core versions before 2.12.0 are not supported.
 Our AZP CI includes testing with the following docker images / PostgreSQL versions:
 
 - CentOS 7: 9.2
-- RHEL 8.3 / 8.4: 10
-- Fedora 34: 13
-- Ubuntu 20.04: 14
+- RHEL 8: 10
+- Fedora 34/35: 13
+- Fedora 36/37: 14
+- Ubuntu 20.04: 15
 
 ## Included content
 


### PR DESCRIPTION
##### SUMMARY
Updated list of tested Postgres versions

Fixes #509

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
README

##### ADDITIONAL INFORMATION
Small update to the list of tested OS and PG versions.
Among other things we test against many versions of RHEL 8 - 8.3, 8.4, 8.5, 8.6, 8.7 - probably not necessary to list them all.
