### PR TITLE
Added test target Ubuntu 2204 with Psycopg 3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:3.0.0
+      image: quay.io/ansible/azure-pipelines-test-container:4.0.1
 
 pool: Standard
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -191,8 +191,8 @@ stages:
         parameters:
           testFormat: devel/{0}/1
           targets:
-            - name: RHEL 8.7
-              test: rhel/8.7
+            - name: RHEL 8.8
+              test: rhel/8.8
 
   - stage: Remote_2_15
     displayName: Remote 2.15

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -134,6 +134,8 @@ stages:
               test: fedora37
             - name: Ubuntu 20.04
               test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
 
   - stage: Docker_2_14
     displayName: Docker 2.14

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -119,6 +119,8 @@ stages:
               test: fedora37
             - name: Ubuntu 20.04
               test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
 
   - stage: Docker_2_15
     displayName: Docker 2.15

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 - RHEL 8: 10
 - Fedora 34/35: 13
 - Fedora 36/37: 14
-- Ubuntu 20.04: 15
+- Ubuntu 20.04/22.04: 15
 
 ## Included content
 

--- a/tests/integration/targets/setup_postgresql_db/defaults/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/defaults/main.yml
@@ -4,6 +4,8 @@ postgresql_packages:
     - postgresql-server
     - python-psycopg2
 
+pip_packages: []
+
 pg_user: postgres
 pg_group: root
 

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -141,7 +141,7 @@
     mode: '0644'
 
 - name: Generate locales (Debian)
-  community.general.locale_gen:
+  locale_gen:
     name: '{{ item }}'
     state: present
   with_items:

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -66,21 +66,16 @@
     loop_var: loop_item
 
 #
-# Install PostgreSQL 15 on Ubuntu 20.04
-- name: Install PostgreSQL 15 on Ubuntu 20.04
+# Prepare Ubuntu for PostgreSQL install
+- name: Prepare Ubuntu for PostgreSQL
   when:
     - ansible_facts.distribution == 'Ubuntu'
-    - ansible_facts.distribution_major_version == '20'
   block:
   - name: Run autoremove
     become: true
     apt:
       autoremove: true
   
-  - name: Install wget
-    package:
-      name: wget
-
   - name: Create the file repository configuration
     lineinfile:
       create: true
@@ -108,13 +103,20 @@
 ##
 #
 
-- name: install dependencies for postgresql test
+- name: Install required OS packages
   package:
     name: '{{ postgresql_package_item }}'
     state: present
   with_items: '{{ postgresql_packages }}'
   loop_control:
     loop_var: postgresql_package_item
+
+- name: Install required Pip packages
+  pip:
+    name: "{{ pip_package_item }}"
+  with_items: "{{ pip_packages }}"
+  loop_control:
+    loop_var: pip_package_item
 
 - name: Initialize postgres (RedHat systemd)
   command: postgresql-setup initdb
@@ -139,7 +141,7 @@
     mode: '0644'
 
 - name: Generate locales (Debian)
-  locale_gen:
+  community.general.locale_gen:
     name: '{{ item }}'
     state: present
   with_items:

--- a/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-20-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-20-py3.yml
@@ -1,13 +1,14 @@
+pg_ver: 15
+
 postgresql_packages:
   - "apt-utils"
-  - "postgresql"
+  - "postgresql-{{ pg_ver }}"
   - "postgresql-common"
   - "python3-psycopg2"
   - "postgresql-client"
 
-pg_hba_location: "/etc/postgresql/15/main/pg_hba.conf"
-pg_dir: "/var/lib/postgresql/15/main"
+pg_hba_location: "/etc/postgresql/{{ pg_ver }}/main/pg_hba.conf"
+pg_dir: "/var/lib/postgresql/{{ pg_ver }}/main"
 pg_auto_conf: "{{ pg_dir }}/postgresql.auto.conf"
-pg_ver: 15
 
-postgis: postgresql-15-postgis-3
+postgis: "postgresql-{{ pg_ver }}-postgis-3"

--- a/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-22-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-22-py3.yml
@@ -8,7 +8,7 @@ postgresql_packages:
   - "postgresql-client"
 
 pip_packages:
-  - psycopg
+  - "psycopg>=3.1" # We need Client-side-binding cursors
 
 pg_hba_location: "/etc/postgresql/{{ pg_ver }}/main/pg_hba.conf"
 pg_dir: "/var/lib/postgresql/{{ pg_ver }}/main"

--- a/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-22-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-22-py3.yml
@@ -1,0 +1,17 @@
+pg_ver: 15
+
+postgresql_packages:
+  - "apt-utils"
+  - "postgresql-{{ pg_ver }}"
+  - "postgresql-common"
+  - "python3-psycopg2"
+  - "postgresql-client"
+
+pip_packages:
+  - psycopg
+
+pg_hba_location: "/etc/postgresql/{{ pg_ver }}/main/pg_hba.conf"
+pg_dir: "/var/lib/postgresql/{{ pg_ver }}/main"
+pg_auto_conf: "{{ pg_dir }}/postgresql.auto.conf"
+
+postgis: postgresql-{{ pg_ver }}-postgis-3


### PR DESCRIPTION
##### SUMMARY
Added a new test target with Ubuntu 2204 and Psycopg 3.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
The test environment

##### ADDITIONAL INFORMATION
Only one new test target for now, to enable automated testing of modules modified to work with the new Psycopg 3 in #499

This PR doesn't touch the collection functionality, it only updates the test environment.

Also updated the test container as per https://github.com/ansible-collections/news-for-maintainers/issues/49

And updated the Remote devel RHEL test to use RHEL 8.8
