### PR TITLE
Psycopg and server version

### DIFF
--- a/changelogs/fragments/518-psycopg-server_version.yml
+++ b/changelogs/fragments/518-psycopg-server_version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Collection core functions - use ``get_server_version`` in all modules (https://github.com/ansible-collections/community.postgresql/pull/518)."

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -523,6 +523,8 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
 )
@@ -530,10 +532,9 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     connect_to_db,
     ensure_required_libs,
     get_conn_params,
+    get_server_version,
     postgres_common_argument_spec,
 )
-from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_native
 
 
 # ===========================================
@@ -1038,7 +1039,7 @@ class PgClusterInfo(object):
                 size=i[6],
             )
 
-        if self.cursor.connection.server_version >= 100000:
+        if get_server_version(self.cursor.connection) >= 100000:
             subscr_info = self.get_subscr_info()
 
         for datname in db_dict:
@@ -1053,7 +1054,7 @@ class PgClusterInfo(object):
             db_dict[datname]['namespaces'] = self.get_namespaces()
             db_dict[datname]['extensions'] = self.get_ext_info()
             db_dict[datname]['languages'] = self.get_lang_info()
-            if self.cursor.connection.server_version >= 100000:
+            if get_server_version(self.cursor.connection) >= 100000:
                 db_dict[datname]['publications'] = self.get_pub_info()
                 db_dict[datname]['subscriptions'] = subscr_info.get(datname, {})
 

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -431,12 +431,16 @@ except ImportError:
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils._text import to_native
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     pg_quote_identifier,
     check_input,
 )
-from ansible_collections.community.postgresql.plugins.module_utils.postgres import postgres_common_argument_spec, get_conn_params
-from ansible.module_utils._text import to_native
+from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
+    get_conn_params,
+    get_server_version,
+    postgres_common_argument_spec
+)
 
 VALID_PRIVS = frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'CREATE',
                          'CONNECT', 'TEMPORARY', 'TEMP', 'EXECUTE', 'USAGE', 'ALL', 'SET', 'ALTER_SYSTEM'))
@@ -496,7 +500,7 @@ class Connection(object):
 
         self.connection = psycopg2.connect(**conn_params)
         self.cursor = self.connection.cursor()
-        self.pg_version = self.connection.server_version
+        self.pg_version = get_server_version(self.connection)
 
     def commit(self):
         self.connection.commit()

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -184,6 +184,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
     pg_quote_identifier,
@@ -193,9 +194,9 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    get_server_version,
     postgres_common_argument_spec,
 )
-from ansible.module_utils.six import iteritems
 
 SUPPORTED_PG_VERSION = 10000
 
@@ -648,7 +649,7 @@ def main():
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     # Check version:
-    if cursor.connection.server_version < SUPPORTED_PG_VERSION:
+    if get_server_version(cursor.connection) < SUPPORTED_PG_VERSION:
         module.fail_json(msg="PostgreSQL server version should be 10.0 or greater")
 
     # Nothing was changed by default:

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -178,6 +178,7 @@ except Exception:
 from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
 )
@@ -185,9 +186,9 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     connect_to_db,
     ensure_required_libs,
     get_conn_params,
+    get_server_version,
     postgres_common_argument_spec,
 )
-from ansible.module_utils._text import to_native
 
 PG_REQ_VER = 90400
 
@@ -395,7 +396,7 @@ def main():
 
     kw = {}
     # Check server version (needs 9.4 or later):
-    ver = db_connection.server_version
+    ver = get_server_version(db_connection)
     if ver < PG_REQ_VER:
         module.warn("PostgreSQL is %s version but %s or later is required" % (ver, PG_REQ_VER))
         kw = dict(

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -162,6 +162,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    get_server_version,
     postgres_common_argument_spec,
 )
 
@@ -195,7 +196,7 @@ class PgSlot(object):
 
         if kind == 'physical':
             # Check server version (immediately_reserved needs 9.6+):
-            if self.cursor.connection.server_version < 90600:
+            if get_server_version(self.cursor.connection) < 90600:
                 query = "SELECT pg_create_physical_replication_slot(%(name)s)"
 
             else:

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -211,15 +211,16 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
     connect_to_db,
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    get_server_version,
     postgres_common_argument_spec,
 )
-from ansible.module_utils.six import iteritems
 
 SUPPORTED_PG_VERSION = 10000
 
@@ -670,7 +671,7 @@ def main():
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 
     # Check version:
-    if cursor.connection.server_version < SUPPORTED_PG_VERSION:
+    if get_server_version(cursor.connection) < SUPPORTED_PG_VERSION:
         module.fail_json(msg="PostgreSQL server version should be 10.0 or greater")
 
     # Set defaults:


### PR DESCRIPTION
##### SUMMARY
Psycopg version 2 and 3 provide the database server version slightly differently.

This PR takes advantage of existing get_server_version function which already handles the Psycopg functionality change.
It will help with https://github.com/ansible-collections/community.postgresql/issues/499.

No functionality change

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
Several modules

##### ADDITIONAL INFORMATION

See get_server_version at https://github.com/ansible-collections/community.postgresql/blob/main/plugins/module_utils/postgres.py#L466
