### PR TITLE
postgresql_set - Fix GUC_LIST_QUOTE parameters

### DIFF
--- a/changelogs/fragments/-postgresql_set.yml
+++ b/changelogs/fragments/-postgresql_set.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- postgresql_set - fixed GUC_LIST_QUOTE parameters (https://github.com/ansible-collections/community.postgresql/pull/).

--- a/changelogs/fragments/-postgresql_set.yml
+++ b/changelogs/fragments/-postgresql_set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - fixed GUC_LIST_QUOTE parameters (https://github.com/ansible-collections/community.postgresql/pull/).

--- a/changelogs/fragments/521-postgresql_set.yml
+++ b/changelogs/fragments/521-postgresql_set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - fixed GUC_LIST_QUOTE parameters (https://github.com/ansible-collections/community.postgresql/pull/521).

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -229,16 +229,7 @@ def param_is_guc_list_quote(server_version, name):
 
 def param_guc_list_unquote(value):
     # unquote GUC_LIST_QUOTE parameter (each element can be quoted or not)
-    value_unquoted = []
-    for v in value.split(','):
-        v = v.strip()  # strip whitespaces at start/end
-        if v and v[0] == v[-1] == '"':
-            # is quoted -> strip quotes
-            value_unquoted.append(v[1:-1])
-        else:
-            # is not quoted -> no changes
-            value_unquoted.append(v)
-    return ', '.join(value_unquoted)
+    return ', '.join([v.strip('" ') for v in value.split(',')])
 
 
 def param_get(cursor, module, name, is_guc_list_quote):

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -205,7 +205,7 @@ PARAMETERS_GUC_LIST_QUOTE = (
         'temp_tablespaces',
         'unix_socket_directories'
     )),
-    (90400,  (
+    (90400, (
         'local_preload_libraries',
         'search_path',
         'session_preload_libraries',
@@ -274,7 +274,7 @@ def param_get(cursor, module, name, is_guc_list_quote):
         # unquote GUC_LIST_QUOTE parameter (each element can be quoted or not)
         raw_vals_unquoted = []
         for v in raw_val.split(','):
-            v = v.strip() # strip whitespaces at start/end
+            v = v.strip()  # strip whitespaces at start/end
             if v[0] == v[-1] == '"':
                 # is quoted -> strip quotes
                 raw_vals_unquoted.append(v[1:-1])

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -275,7 +275,7 @@ def param_get(cursor, module, name, is_guc_list_quote):
         raw_vals_unquoted = []
         for v in raw_val.split(','):
             v = v.strip()  # strip whitespaces at start/end
-            if v[0] == v[-1] == '"':
+            if v and v[0] == v[-1] == '"':
                 # is quoted -> strip quotes
                 raw_vals_unquoted.append(v[1:-1])
             else:

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -228,7 +228,8 @@ def param_is_guc_list_quote(server_version, name):
 
 
 def param_guc_list_unquote(value):
-    # unquote GUC_LIST_QUOTE parameter (each element can be quoted or not)
+    # Unquote GUC_LIST_QUOTE parameter (each element can be quoted or not)
+    # Assume the parameter is GUC_LIST_QUOTE (check in param_is_guc_list_quote function)
     return ', '.join([v.strip('" ') for v in value.split(',')])
 
 

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -370,9 +370,9 @@ def param_set(cursor, module, name, value, context, server_version):
             query = "ALTER SYSTEM SET %s = DEFAULT" % name
         else:
             if isinstance(value, str) and \
-                ',' in value and \
-                not name.endswith(('_command', '_prefix')) and \
-                not (server_version < 140000 and name == 'unix_socket_directories'):
+                    ',' in value and \
+                    not name.endswith(('_command', '_prefix')) and \
+                    not (server_version < 140000 and name == 'unix_socket_directories'):
                 # Issue https://github.com/ansible-collections/community.postgresql/issues/78
                 # Change value from 'one, two, three' -> "'one','two','three'"
                 # PR https://github.com/ansible-collections/community.postgresql/pull/400

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -378,7 +378,8 @@ def param_set(cursor, module, name, value, context, server_version):
                 # PR https://github.com/ansible-collections/community.postgresql/pull/400
                 # Parameter names ends with '_command' or '_prefix' can contains commas but are not lists
                 # PR https://github.com/ansible-collections/community.postgresql/pull/521
-                # unix_socket_directories up to PostgreSQL 13 lacks GUC_LIST_INPUT and GUC_LIST_QUOTE options so it is a single value parameter
+                # unix_socket_directories up to PostgreSQL 13 lacks GUC_LIST_INPUT and
+                # GUC_LIST_QUOTE options so it is a single value parameter
                 value = ','.join(["'" + elem.strip() + "'" for elem in value.split(',')])
                 query = "ALTER SYSTEM SET %s = %s" % (name, value)
             else:

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -75,7 +75,7 @@
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '"/tmp", "/var/run/postgresql"'"
+      - result.stdout == "unix_socket_directories = '\"/tmp\", \"/var/run/postgresql\"'"
     when: postgres_version_resp.stdout is version('14', '>=')
 
   # https://github.com/ansible-collections/community.postgresql/pull/400

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -37,8 +37,8 @@
       state: directory
       path: "{{ item }}"
       owner: "{{ pg_user }}"
-      group: "{{ pg_group }}"
-      mode: 770
+      group: "{{ pg_user }}"
+      mode: 777
     become: true
     with_list:
       - /var/run/postgresql

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -30,7 +30,7 @@
         track_functions: none
         shared_preload_libraries: 'pg_stat_statements, pgcrypto'
         log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
-        unix_socket_directories: '/var/run/postgresql, /tmp'
+        unix_socket_directories: '/tmp, /var/run/postgresql'
 
   # Check mode:
   - name: Set settings in check mode
@@ -108,4 +108,4 @@
   - name: Check idempotence after restart
     assert:
       that: not item.changed
-    with_items: test_idempotence.results
+    with_items: '{{ test_idempotence.results }}'

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -106,12 +106,6 @@
     service:
       name: "{{ postgresql_service }}"
       state: restarted
-    ignore_errors: true
-
-  - name: Check journalctl
-    become: true
-    shell: "journalctl -x -e --no-pager"
-    register: journalctl_res
 
   # Idempotence:
   - name: Set settings in actual mode again after restart for idempotence

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -30,7 +30,16 @@
         track_functions: none
         shared_preload_libraries: 'pg_stat_statements, pgcrypto'
         log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
-        unix_socket_directories: '/tmp, /var/run/postgresql'
+        unix_socket_directories: '/var/run/postgresql, /tmp/postgresql'
+
+  - name: Ensure /tmp/postgresql directory exists
+    file:
+      state: directory
+      path: /tmp/postgresql
+      owner: "{{ pg_user }}"
+      group: "{{ pg_group }}"
+      mode: 770
+    become: true
 
   # Check mode:
   - name: Set settings in check mode
@@ -70,12 +79,12 @@
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '/tmp, /var/run/postgresql'"
+      - result.stdout == "unix_socket_directories = '/var/run/postgresql, /tmp/postgresql'"
     when: postgres_version_resp.stdout is version('14', '<')
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '\"/tmp\", \"/var/run/postgresql\"'"
+      - result.stdout == "unix_socket_directories = '\"/var/run/postgresql\", \"/tmp/postgresql\"'"
     when: postgres_version_resp.stdout is version('14', '>=')
 
   # https://github.com/ansible-collections/community.postgresql/pull/400

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -38,7 +38,7 @@
       path: "{{ item }}"
       owner: "{{ pg_user }}"
       group: "{{ pg_user }}"
-      mode: 777
+      mode: '0777'
     become: true
     with_list:
       - /var/run/postgresql

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -61,7 +61,7 @@
       that:
       - result.stdout == "shared_preload_libraries = 'pg_stat_statements, pgcrypto'"
 
-  # https://github.com/ansible-collections/community.postgresql/pull/
+  # https://github.com/ansible-collections/community.postgresql/pull/521
   # unix_socket_directories is a GUC_LIST_QUOTE parameter only from PostgreSQL 14
   - name: Test param with comma containing values and quotes
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -70,12 +70,12 @@
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '/var/run/postgresql, /tmp'"
+      - result.stdout == "unix_socket_directories = '/tmp, /var/run/postgresql'"
     when: postgres_version_resp.stdout is version('14', '<')
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '\"/var/run/postgresql\", \"/tmp\"'"
+      - result.stdout == "unix_socket_directories = '"/tmp", "/var/run/postgresql"'"
     when: postgres_version_resp.stdout is version('14', '>=')
 
   # https://github.com/ansible-collections/community.postgresql/pull/400

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -11,19 +11,6 @@
       login_db: postgres
 
   block:
-
-  - name: Restart PostgreSQL
-    become: true
-    service:
-      name: "{{ postgresql_service }}"
-      state: restarted
-    ignore_errors: true
-
-  - name: Check journalctl
-    become: true
-    shell: "journalctl -x -e --no-pager"
-    register: journalctl_res
-
   - name: Define a test setting map
     set_fact:
       setting_map:

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -11,6 +11,19 @@
       login_db: postgres
 
   block:
+
+  - name: Restart PostgreSQL
+    become: true
+    service:
+      name: "{{ postgresql_service }}"
+      state: restarted
+    ignore_errors: true
+
+  - name: Check journalctl
+    become: true
+    shell: "journalctl -x -e --no-pager"
+    register: journalctl_res
+
   - name: Define a test setting map
     set_fact:
       setting_map:
@@ -30,7 +43,7 @@
         track_functions: none
         shared_preload_libraries: 'pg_stat_statements, pgcrypto'
         log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
-        unix_socket_directories: '/var/run/postgresql, /tmp/postgresql'
+        unix_socket_directories: '/var/run/postgresql, /var/run/postgresql2'
 
   - name: Ensure unix_socket_directories exist
     file:
@@ -42,7 +55,7 @@
     become: true
     with_list:
       - /var/run/postgresql
-      - /tmp/postgresql
+      - /var/run/postgresql2
 
   # Check mode:
   - name: Set settings in check mode
@@ -82,12 +95,12 @@
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '/var/run/postgresql, /tmp/postgresql'"
+      - result.stdout == "unix_socket_directories = '/var/run/postgresql, /var/run/postgresql2'"
     when: postgres_version_resp.stdout is version('14', '<')
 
   - assert:
       that:
-      - result.stdout == "unix_socket_directories = '\"/var/run/postgresql\", \"/tmp/postgresql\"'"
+      - result.stdout == "unix_socket_directories = '\"/var/run/postgresql\", \"/var/run/postgresql2\"'"
     when: postgres_version_resp.stdout is version('14', '>=')
 
   # https://github.com/ansible-collections/community.postgresql/pull/400
@@ -106,6 +119,12 @@
     service:
       name: "{{ postgresql_service }}"
       state: restarted
+    ignore_errors: true
+
+  - name: Check journalctl
+    become: true
+    shell: "journalctl -x -e --no-pager"
+    register: journalctl_res
 
   # Idempotence:
   - name: Set settings in actual mode again after restart for idempotence

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -32,14 +32,17 @@
         log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
         unix_socket_directories: '/var/run/postgresql, /tmp/postgresql'
 
-  - name: Ensure /tmp/postgresql directory exists
+  - name: Ensure unix_socket_directories exist
     file:
       state: directory
-      path: /tmp/postgresql
+      path: "{{ item }}"
       owner: "{{ pg_user }}"
       group: "{{ pg_group }}"
       mode: 770
     become: true
+    with_list:
+      - /var/run/postgresql
+      - /tmp/postgresql
 
   # Check mode:
   - name: Set settings in check mode

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -28,8 +28,9 @@
         wal_level: replica
         log_statement: mod
         track_functions: none
-        shared_preload_libraries: 'pg_stat_statements, pgaudit'
+        shared_preload_libraries: 'pg_stat_statements, pgcrypto'
         log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
+        unix_socket_directories: '/var/run/postgresql, /tmp'
 
   # Check mode:
   - name: Set settings in check mode
@@ -51,16 +52,33 @@
     with_dict: '{{ setting_map }}'
 
   # https://github.com/ansible-collections/community.postgresql/issues/78
-  - name: Test param with comma containing values
+  - name: Test param with comma containing values but no quotes
     <<: *task_parameters
     shell: "grep shared_preload_libraries {{ pg_auto_conf }}"
     register: result
 
   - assert:
       that:
-      - result.stdout == "shared_preload_libraries = 'pg_stat_statements, pgaudit'"
-  
-  # Test for single-value params with commas and spaces in value
+      - result.stdout == "shared_preload_libraries = 'pg_stat_statements, pgcrypto'"
+
+  # https://github.com/ansible-collections/community.postgresql/pull/
+  # unix_socket_directories is a GUC_LIST_QUOTE parameter only from PostgreSQL 14
+  - name: Test param with comma containing values and quotes
+    <<: *task_parameters
+    shell: "grep unix_socket_directories {{ pg_auto_conf }}"
+    register: result
+
+  - assert:
+      that:
+      - result.stdout == "unix_socket_directories = '/var/run/postgresql, /tmp'"
+    - when: postgres_version_resp.stdout is version('14', '<')
+
+  - assert:
+      that:
+      - result.stdout == "unix_socket_directories = '\"/var/run/postgresql\", \"/tmp\"'"
+    - when: postgres_version_resp.stdout is version('14', '>=')
+
+  # https://github.com/ansible-collections/community.postgresql/pull/400
   - name: Test single-value param with commas and spaces in value
     <<: *task_parameters
     shell: "grep log_line_prefix {{ pg_auto_conf }}"
@@ -69,3 +87,25 @@
   - assert:
       that:
       - result.stdout == "log_line_prefix = 'db=%d,user=%u,app=%a,client=%h '"
+
+  # Restart PostgreSQL:
+  - name: Restart PostgreSQL
+    become: true
+    service:
+      name: "{{ postgresql_service }}"
+      state: restarted
+
+  # Idempotence:
+  - name: Set settings in actual mode again after restart for idempotence
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: '{{ item.key }}'
+      value: '{{ item.value }}'
+    register: test_idempotence
+    with_dict: '{{ setting_map }}'
+
+  - name: Check idempotence after restart
+    assert:
+      that: not item.changed
+    with_items: test_idempotence.results

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -71,12 +71,12 @@
   - assert:
       that:
       - result.stdout == "unix_socket_directories = '/var/run/postgresql, /tmp'"
-    - when: postgres_version_resp.stdout is version('14', '<')
+    when: postgres_version_resp.stdout is version('14', '<')
 
   - assert:
       that:
       - result.stdout == "unix_socket_directories = '\"/var/run/postgresql\", \"/tmp\"'"
-    - when: postgres_version_resp.stdout is version('14', '>=')
+    when: postgres_version_resp.stdout is version('14', '>=')
 
   # https://github.com/ansible-collections/community.postgresql/pull/400
   - name: Test single-value param with commas and spaces in value

--- a/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
+++ b/tests/integration/targets/postgresql_set/tasks/options_coverage.yml
@@ -32,7 +32,7 @@
         log_line_prefix: 'db=%d,user=%u,app=%a,client=%h '
         unix_socket_directories: '/var/run/postgresql, /var/run/postgresql2'
 
-  - name: Ensure unix_socket_directories exist
+  - name: Ensure all unix_socket_directories directories exist
     file:
       state: directory
       path: "{{ item }}"
@@ -40,9 +40,7 @@
       group: "{{ pg_user }}"
       mode: '0777'
     become: true
-    with_list:
-      - /var/run/postgresql
-      - /var/run/postgresql2
+    with_list: "{{ setting_map['unix_socket_directories'].split(',') | map('trim') | list }}"
 
   # Check mode:
   - name: Set settings in check mode

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -75,7 +75,7 @@
     become: true
     apt:
       autoremove: true
-  
+
   - name: Create the file repository configuration
     lineinfile:
       create: true
@@ -127,7 +127,7 @@
   when: ansible_os_family == "RedHat" and ansible_service_mgr != "systemd"
 
 - name: Initialize postgres (Debian)
-  shell: . /usr/share/postgresql-common/maintscripts-functions && set_system_locale && /usr/bin/pg_createcluster -u postgres {{ pg_ver }} main
+  shell: . /usr/share/postgresql-common/maintscripts-functions && set_system_locale && /usr/bin/pg_createcluster -u postgres {{ pg_ver }} main
   args:
     creates: /etc/postgresql/{{ pg_ver }}/
   when: ansible_os_family == 'Debian'

--- a/tests/integration/targets/setup_postgresql_db/vars/RedHat-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/RedHat-py3.yml
@@ -1,5 +1,6 @@
 postgresql_packages:
   - "postgresql-server"
+  - "postgresql-contrib"
   - "python3-psycopg2"
   - "bzip2"
   - "xz"

--- a/tests/integration/targets/setup_postgresql_db/vars/RedHat.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/RedHat.yml
@@ -1,5 +1,6 @@
 postgresql_packages:
   - "postgresql-server"
+  - "postgresql-contrib"
   - "python-psycopg2"
   - "bzip2"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

My PR fixes *GUC_LIST_QUOTE* parameters management in *postgresql_set* module.

*GUC_LIST_QUOTE* parameters are multi-value parameters (like *GUC_LIST_INPUT* parameters) whose elements are surrounded by double-quotes if not match `^[A-Za-z09_]+$` pattern.
Now such double-quotes are ignored by *postgresql_set* module and it causes an always-changed status in these cases. It is a **very serious bug** if the parameter is a *postmaster*, as *unix_socket_directories* (it became *GUC_LIST_QUOTE* in PostgreSQL 14).
The bug has not seen until now as *GUC_LIST_QUOTE* parameters are few and many of them have not valid values that contain special characters (as *shared_preload_libraries* parameter).

Examples:
```
#### PostgreSQL 13

pg13=# ALTER SYSTEM SET unix_socket_directories = '/var/run/postgresql';
ALTER SYSTEM

postgres@pg13:~$ grep unix_socket_directories postgresql.auto.conf 
unix_socket_directories = '/var/run/postgresql'

pg13=# ALTER SYSTEM SET unix_socket_directories = '/var/run/postgresql,/tmp'; --> NEVER DONE FROM PR #357 
ALTER SYSTEM

postgres@pg13:~$ grep unix_socket_directories postgresql.auto.conf 
unix_socket_directories = '/var/run/postgresql,/tmp' --> RIGHT BUT NOW NEVER OBTAINED (AS CONSIDERED MULTI_VALUE)

pg13=# ALTER SYSTEM SET unix_socket_directories = '/var/run/postgresql','/tmp';
ERROR:  SET unix_socket_directories takes only one argument

#### PostgreSQL 14

pg14=# ALTER SYSTEM SET unix_socket_directories = '/var/run/postgresql';
ALTER SYSTEM

postgres@pg14:~$ grep unix_socket_directories postgresql.auto.conf 
unix_socket_directories = '"/var/run/postgresql"'

pg13=# ALTER SYSTEM SET unix_socket_directories = '/var/run/postgresql,/tmp'; --> NEVER DONE FROM PR #357 
ALTER SYSTEM

postgres@pg13:~$ grep unix_socket_directories postgresql.auto.conf 
unix_socket_directories = '"/var/run/postgresql,/tmp"' --> WRONG (SO CORRECT BEHAVIOR)

pg14=# ALTER SYSTEM SET unix_socket_directories = '/var/run/postgresql','/tmp';
ALTER SYSTEM

postgres@pg14:~$ grep unix_socket_directories postgresql.auto.conf
unix_socket_directories = '"/var/run/postgresql", "/tmp"'
```

To solve the bug the only way is to hard-code *GUC_LIST_QUOTE* parameters list in the code (very short and static in the time) as there is no way to distinguish the case in with a parameter value need an unquote or not (specially with values composed by a single elements). The same approach is applied in *pg_dump* code (*variable_is_guc_list_quote* function).

Hard-code also the list of *GUC_LIST_INPUT* parameters is expensive and for now (I think) not necessary. However I added a check to not consider multi-value *unix_socket_directories* parameter until PostgreSQL 13, as only from PostgreSQL 14 *GUC_LIST_INPUT* and *GUC_LIST_QUOTE* options are added to that parameter.

In test added there is also a general idempotence check after a reboot (as *unix_socket_directories* parameter is *postmaster*).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_set

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

@ PostgreSQL 14 -> Add GUC_LIST_INPUT and GUC_LIST_QUOTE to unix_socket_directories 
https://github.com/postgres/postgres/commit/a05dbf477b0ef173adb1ae5d004cbeb0cf400b66

@ List of GUC params (PostgreSQL 15 only)
https://github.com/postgres/postgres/blob/5edf438eeb00271cca5d19d0ea10a2d6e8d018c4/src/backend/utils/misc/guc_tables.c

@ Fixed list of GUC_LIST_QUOTE params in each supported major version (*variable_is_guc_list_quote* function)
[15](https://github.com/postgres/postgres/releases/tag/REL_15_3)  -> https://github.com/postgres/postgres/blob/8382864eb5c9f9ebe962ac20b3392be5ae304d23/src/bin/pg_dump/dumputils.c#L689
[14](https://github.com/postgres/postgres/releases/tag/REL_14_8)  -> https://github.com/postgres/postgres/blob/b6cf730e80e8571066c0ce76e76ce99b9144c149/src/bin/pg_dump/dumputils.c#L849
[13](https://github.com/postgres/postgres/releases/tag/REL_13_11) -> https://github.com/postgres/postgres/blob/2faab87390b03929a8cbb5a9336a04faa45a27c5/src/bin/pg_dump/dumputils.c#L849
[12](https://github.com/postgres/postgres/releases/tag/REL_12_15) -> https://github.com/postgres/postgres/blob/117dd58fd9cd01e661a2c36977e16a2722306a6d/src/bin/pg_dump/dumputils.c#L849
[11](https://github.com/postgres/postgres/releases/tag/REL_11_20) -> https://github.com/postgres/postgres/blob/f96e531b1c079ae148b927a204845c7150a573f8/src/bin/pg_dump/dumputils.c#L849
[10](https://github.com/postgres/postgres/releases/tag/REL_10_23) -> https://github.com/postgres/postgres/blob/02991e79f8f58bc208f05dcc8af0c62dbe0a6ea4/src/bin/pg_dump/dumputils.c#L846
[9.6](https://github.com/postgres/postgres/releases/tag/REL9_6_24) -> https://github.com/postgres/postgres/blob/a4116b8d5a4f68803452d8f1aa3f74f302049a90/src/bin/pg_dump/dumputils.c#L853
[9.5](https://github.com/postgres/postgres/releases/tag/REL9_5_25) -> https://github.com/postgres/postgres/blob/202c587e2f28bc295f6935d044e20680b627e7a1/src/bin/pg_dump/dumputils.c#L1536
[9.4](https://github.com/postgres/postgres/releases/tag/REL9_4_26) -> https://github.com/postgres/postgres/blob/30ffdd24d7222bc01183a56d536c236240674516/src/bin/pg_dump/dumputils.c#L1537

@ GUC_LIST_QUOTE element quote function (*quote_identifier* function - PostgreSQL 15 only)
https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/ruleutils.c#L11930

@ GUC_LIST_INPUT/GUC_LIST_QUOTE elements split function (*SplitGUCList* function - PostgreSQL 15 only)
https://github.com/postgres/postgres/blob/6ee01e25b7f79bdf835d12927b306ad922c55fd3/src/backend/utils/adt/varlena.c#L3702
