### PR TITLE
Common cursor arguments

### DIFF
--- a/changelogs/fragments/522-psycopg-cursor_args.yml
+++ b/changelogs/fragments/522-psycopg-cursor_args.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Collection core functions - use common cursor arguments in all modules (https://github.com/ansible-collections/community.postgresql/pull/522)."

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -16,18 +16,23 @@ from datetime import timedelta
 from decimal import Decimal
 from os import environ
 
-psycopg2 = None  # This line needs for unit tests
-try:
-    import psycopg2
-    import psycopg2.extras
-    HAS_PSYCOPG2 = True
-except ImportError:
-    HAS_PSYCOPG2 = False
-
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.version import LooseVersion
+
+psycopg2 = None  # This line needs for unit tests
+pg_cursor_args = None
+PSYCOPG_VERSION = None
+
+try:
+    import psycopg2
+    from psycopg2.extras import DictCursor
+    PSYCOPG_VERSION = LooseVersion(psycopg2.__version__)
+    HAS_PSYCOPG2 = True
+    pg_cursor_args = {"cursor_factory": DictCursor}
+except ImportError:
+    HAS_PSYCOPG2 = False
 
 TYPES_NEED_TO_CONVERT = (Decimal, timedelta)
 

--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -178,14 +178,8 @@ dst:
   sample: "/tmp/data.csv"
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
     pg_quote_identifier,
@@ -195,9 +189,9 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
-from ansible.module_utils.six import iteritems
 
 
 class PgCopyData(object):
@@ -388,7 +382,7 @@ def main():
     # Connect to DB and make cursor object:
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     ##############
     # Create the object and do main job:

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -268,13 +268,6 @@ import os
 import subprocess
 import traceback
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    HAS_PSYCOPG2 = False
-else:
-    HAS_PSYCOPG2 = True
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_native
@@ -287,6 +280,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     ensure_required_libs,
     get_conn_params,
     get_server_version,
+    pg_cursor_args,
     postgres_common_argument_spec
 )
 
@@ -713,7 +707,7 @@ def main():
 
     if not raw_connection:
         db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
-        cursor = db_connection.cursor(cursor_factory=DictCursor)
+        cursor = db_connection.cursor(**pg_cursor_args)
 
         if session_role:
             try:

--- a/plugins/modules/postgresql_idx.py
+++ b/plugins/modules/postgresql_idx.py
@@ -257,13 +257,6 @@ valid:
   sample: true
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -271,6 +264,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -294,13 +288,13 @@ class Index(object):
 
     Args:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor object of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg library
         schema (str) -- name of the index schema
         name (str) -- name of the index
 
     Attrs:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor object of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg library
         schema (str) -- name of the index schema
         name (str) -- name of the index
         exists (bool) -- flag the index exists in the DB or not
@@ -520,11 +514,11 @@ def main():
     if cascade and state != 'absent':
         module.fail_json(msg="cascade parameter used only with state=absent")
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     # Set defaults:
     changed = False

--- a/plugins/modules/postgresql_lang.py
+++ b/plugins/modules/postgresql_lang.py
@@ -174,6 +174,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     connect_to_db,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -235,7 +236,7 @@ def get_lang_owner(cursor, lang):
     """Get language owner.
 
     Args:
-        cursor (cursor): psycopg2 cursor object.
+        cursor (cursor): psycopg cursor object.
         lang (str): language name.
     """
     query = ("SELECT r.rolname FROM pg_language l "
@@ -249,7 +250,7 @@ def set_lang_owner(cursor, lang, owner):
     """Set language owner.
 
     Args:
-        cursor (cursor): psycopg2 cursor object.
+        cursor (cursor): psycopg cursor object.
         lang (str): language name.
         owner (str): name of new owner.
     """
@@ -294,11 +295,11 @@ def main():
         # Check input for potentially dangerous elements:
         check_input(module, lang, session_role, owner)
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
-    cursor = db_connection.cursor()
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     changed = False
     kw = {'db': db, 'lang': lang, 'trust': trust}

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -163,13 +163,6 @@ state:
     sample: "present"
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -177,6 +170,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     ensure_required_libs,
     get_conn_params,
     PgMembership,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -212,11 +206,11 @@ def main():
         # Check input for potentially dangerous elements:
         check_input(module, groups, target_roles, session_role)
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     ##############
     # Create the object and do main job:

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -148,13 +148,6 @@ queries:
   sample: [ 'REASSIGN OWNED BY "bob" TO "alice"' ]
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
@@ -165,6 +158,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -175,7 +169,7 @@ class PgOwnership(object):
 
     Arguments:
         module (AnsibleModule): Object of Ansible module class.
-        cursor (psycopg2.connect.cursor): Cursor object for interaction with the database.
+        cursor (psycopg.connect.cursor): Cursor object for interaction with the database.
         role (str): Role name to set as a new owner of objects.
 
     Important:
@@ -426,11 +420,11 @@ def main():
         # Check input for potentially dangerous elements:
         check_input(module, new_owner, obj_name, reassign_owned_by, session_role)
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     ##############
     # Create the object and do main job:

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -94,13 +94,6 @@ conn_err_msg:
 
 import re
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
@@ -110,6 +103,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -190,7 +184,7 @@ def main():
         conn_err_msg='',
     )
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection, err = connect_to_db(module, conn_params, fail_on_conn=False)
@@ -198,7 +192,7 @@ def main():
         result['conn_err_msg'] = err
 
     if db_connection is not None:
-        cursor = db_connection.cursor(cursor_factory=DictCursor)
+        cursor = db_connection.cursor(**pg_cursor_args)
 
     # Do job:
     pg_ping = PgPing(module, cursor)

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -437,8 +437,10 @@ from ansible_collections.community.postgresql.plugins.module_utils.database impo
     check_input,
 )
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
+    connect_to_db,
     get_conn_params,
     get_server_version,
+    pg_cursor_args,
     postgres_common_argument_spec
 )
 
@@ -489,8 +491,8 @@ class Connection(object):
         if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
             raise ValueError('psycopg2 must be at least 2.4.3 in order to user the ca_cert parameter')
 
-        self.connection = psycopg2.connect(**conn_params)
-        self.cursor = self.connection.cursor()
+        self.connection, dummy = connect_to_db(module, conn_params, autocommit=False)
+        self.cursor = self.connection.cursor(**pg_cursor_args)
         self.pg_version = get_server_version(self.connection)
 
         # implicit roles in current pg version

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -252,7 +252,6 @@ rowcount:
 
 try:
     from psycopg2 import ProgrammingError as Psycopg2ProgrammingError
-    from psycopg2.extras import DictCursor
 except ImportError:
     # it is needed for checking 'no result to fetch' in main(),
     # psycopg2 availability will be checked by connect_to_db() into
@@ -271,6 +270,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     convert_to_supported,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
     set_search_path,
     TYPES_NEED_TO_CONVERT,
@@ -337,13 +337,13 @@ def main():
     else:  # if it's a list
         query_list = query
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=autocommit)
     if encoding is not None:
         db_connection.set_client_encoding(encoding)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     if search_path:
         set_search_path(cursor, '%s' % ','.join([x.strip(' ') for x in search_path]))

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -118,18 +118,12 @@ queries:
 
 import traceback
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
     connect_to_db,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
@@ -247,11 +241,11 @@ def main():
 
     changed = False
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     try:
         if module.check_mode:

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -213,7 +213,6 @@ rowcount:
 
 try:
     from psycopg2 import ProgrammingError as Psycopg2ProgrammingError
-    from psycopg2.extras import DictCursor
 except ImportError:
     # it is needed for checking 'no result to fetch' in main(),
     # psycopg2 availability will be checked by connect_to_db() into
@@ -230,6 +229,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     convert_to_supported,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
     set_search_path,
     TYPES_NEED_TO_CONVERT,
@@ -280,13 +280,13 @@ def main():
     except Exception as e:
         module.fail_json(msg="Cannot read file '%s' : %s" % (path, to_native(e)))
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
     if encoding is not None:
         db_connection.set_client_encoding(encoding)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     if search_path:
         set_search_path(cursor, '%s' % ','.join([x.strip(' ') for x in search_path]))

--- a/plugins/modules/postgresql_sequence.py
+++ b/plugins/modules/postgresql_sequence.py
@@ -301,13 +301,6 @@ newschema:
 '''
 
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
@@ -317,6 +310,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -326,11 +320,11 @@ class Sequence(object):
 
     Arguments:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor object of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg library
 
     Attributes:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor object of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg library
         changed (bool) --  something was changed after execution or not
         executed_queries (list) -- executed queries
         name (str) -- name of the sequence
@@ -539,12 +533,12 @@ def main():
 
     # Change autocommit to False if check_mode:
     autocommit = not module.check_mode
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     # Connect to DB and make cursor object:
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=autocommit)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     ##############
     # Create the object and do main job:

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -146,13 +146,6 @@ queries:
   sample: [ "SELECT pg_create_physical_replication_slot('physical_one', False, False)" ]
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
@@ -163,6 +156,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     ensure_required_libs,
     get_conn_params,
     get_server_version,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -272,11 +266,11 @@ def main():
     else:
         warn_db_default = False
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params, warn_db_default=warn_db_default)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     ##################################
     # Create an object and do main job

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -242,13 +242,6 @@ storage_params:
   sample: [ "fillfactor=100", "autovacuum_analyze_threshold=1" ]
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
@@ -259,6 +252,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -536,11 +530,11 @@ def main():
     if including and not like:
         module.fail_json(msg="%s: including param needs like param specified" % table)
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     if storage_params:
         storage_params = ','.join(storage_params)

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -180,7 +180,6 @@ state:
 
 try:
     from psycopg2 import __version__ as PSYCOPG2_VERSION
-    from psycopg2.extras import DictCursor
     from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT as AUTOCOMMIT
     from psycopg2.extensions import ISOLATION_LEVEL_READ_COMMITTED as READ_COMMITTED
 except ImportError:
@@ -199,6 +198,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 
@@ -209,12 +209,12 @@ class PgTablespace(object):
 
     Args:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor object of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg library
         name (str) -- name of the tablespace
 
     Attrs:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor object of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg library
         name (str) -- name of the tablespace
         exists (bool) -- flag the tablespace exists in the DB or not
         owner (str) -- tablespace owner
@@ -429,11 +429,11 @@ def main():
         check_input(module, tablespace, location, owner,
                     rename_to, session_role, settings_list)
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     # Change autocommit to False if check_mode:
     if module.check_mode:

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -291,7 +291,6 @@ from base64 import b64decode
 
 try:
     import psycopg2
-    from psycopg2.extras import DictCursor
 except ImportError:
     # psycopg2 is checked by connect_to_db()
     # from ansible.module_utils.postgres
@@ -308,6 +307,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     ensure_required_libs,
     get_conn_params,
     get_server_version,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -469,7 +469,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
     """Change user password and/or attributes. Return True if changed, False otherwise."""
     changed = False
 
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
     # Note: role_attr_flags escaped by parse_role_attrs and encrypted is a
     # literal
     if user == 'PUBLIC':
@@ -966,11 +966,11 @@ def main():
         check_input(module, user, password, privs, expires,
                     role_attr_flags, comment, session_role)
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection, dummy = connect_to_db(module, conn_params)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     srv_version = get_server_version(db_connection)
 

--- a/plugins/modules/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/postgresql_user_obj_stat_info.py
@@ -104,13 +104,6 @@ functions:
   sample: {"public": {"inc": {"calls": 1, "funcid": 26722, "self_time": 0.23, "total_time": 0.23}}}
 '''
 
-try:
-    from psycopg2.extras import DictCursor
-except ImportError:
-    # psycopg2 is checked by connect_to_db()
-    # from ansible.module_utils.postgres
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
@@ -120,6 +113,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     exec_sql,
     ensure_required_libs,
     get_conn_params,
+    pg_cursor_args,
     postgres_common_argument_spec,
 )
 from ansible.module_utils.six import iteritems
@@ -135,11 +129,11 @@ class PgUserObjStatInfo():
 
     Args:
         module (AnsibleModule): Object of AnsibleModule class.
-        cursor (cursor): Cursor object of psycopg2 library to work with PostgreSQL.
+        cursor (cursor): Cursor object of psycopg library to work with PostgreSQL.
 
     Attributes:
         module (AnsibleModule): Object of AnsibleModule class.
-        cursor (cursor): Cursor object of psycopg2 library to work with PostgreSQL.
+        cursor (cursor): Cursor object of psycopg library to work with PostgreSQL.
         executed_queries (list): List of executed queries.
         info (dict): Statistics dictionary.
         obj_func_mapping (dict): Mapping of object types to corresponding functions.
@@ -316,13 +310,13 @@ def main():
     if not module.params["trust_input"]:
         check_input(module, module.params['session_role'])
 
-    # Ensure psycopg2 libraries are available before connecting to DB:
+    # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)
     # Connect to DB and make cursor object:
     pg_conn_params = get_conn_params(module, module.params)
     # We don't need to commit anything, so, set it to False:
     db_connection, dummy = connect_to_db(module, pg_conn_params, autocommit=False)
-    cursor = db_connection.cursor(cursor_factory=DictCursor)
+    cursor = db_connection.cursor(**pg_cursor_args)
 
     ############################
     # Create object and do work:


### PR DESCRIPTION
##### SUMMARY
Moved psycopg cursor arguments to the common postgres.py. 

This will help with #499, when we decide to add Psycopg 3 support most modules won't need any changes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
All modules

##### ADDITIONAL INFORMATION
This PR is based on #517 where these changes are tested with both Psycopg 2 and 3.
