### PR TITLE
Fedora 38 test target

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -115,8 +115,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 37
-              test: fedora37
+            - name: Fedora 38
+              test: fedora38
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 - RHEL 8: 10
 - Fedora 34/35: 13
 - Fedora 36/37: 14
+- Fedora 38: 15
 - Ubuntu 20.04/22.04: 15
 
 ## Included content

--- a/tests/integration/targets/setup_postgresql_db/vars/Fedora-38-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Fedora-38-py3.yml
@@ -1,0 +1,8 @@
+postgresql_packages:
+  - "postgresql-server"
+  - "python3-psycopg2"
+  - "python3-psycopg3"
+
+pg_hba_location: "/var/lib/pgsql/data/pg_hba.conf"
+pg_dir: "/var/lib/pgsql/data"
+pg_auto_conf: "{{ pg_dir }}/postgresql.auto.conf"


### PR DESCRIPTION
##### SUMMARY
Added Fedora 38 test target

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
New test target

##### ADDITIONAL INFORMATION
Fedora 38 comes with psycopg2 and psycopg3.1 packages, and we install both.
Current testing will use the psycopg2 library. 
When we add Psycopg 3 support the psycopg3 library will get used.
