### PR TITLE
postgresql_ext - Added idempotence always both in standard and in check mode

### DIFF
--- a/changelogs/fragments/504_postgresql_ext.yml
+++ b/changelogs/fragments/504_postgresql_ext.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "postgresql_privs - added idempotence when version=latest (https://github.com/ansible-collections/community.postgresql/pull/504)."
+- "postgresql_ext - added idempotence when version=latest (https://github.com/ansible-collections/community.postgresql/pull/504)."

--- a/changelogs/fragments/_postgresql_ext.yml
+++ b/changelogs/fragments/_postgresql_ext.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "postgresql_ext - added idempotence always both in standard and in check mode (https://github.com/ansible-collections/community.postgresql/pull/)."
+- "postgresql_ext - improved error messages (https://github.com/ansible-collections/community.postgresql/pull/)."

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -77,7 +77,7 @@ options:
         path exists.
       - Downgrading is only supported if the extension provides a downgrade path otherwise
         the extension must be removed and a lower version of the extension must be made available.
-      - Set I(version=latest) to always update the extension to the latest available version.
+      - Set I(version=latest) to update the extension to the latest available version if necessary.
     type: str
   trust_input:
     description:
@@ -249,6 +249,7 @@ def ext_create(cursor, ext, schema, cascade, version):
       cursor (cursor) -- cursor object of psycopg library
       ext (str) -- extension name
       schema (str) -- target schema for extension objects
+      cascade (boolean) -- Pass the CASCADE flag to the CREATE commmand
       version (str) -- extension version
     """
     query = "CREATE EXTENSION \"%s\"" % ext
@@ -270,10 +271,10 @@ def ext_create(cursor, ext, schema, cascade, version):
 def ext_get_versions(cursor, ext):
     """
     Get the currently created extension version if it is installed
-    in the database and versions that are available if it is
-    installed on the system.
+    in the database, its default version (used to update to 'latest'),
+    and versions that are available if it is installed on the system.
 
-    Return tuple (current_version, [list of available versions]).
+    Return tuple (current_version, default_version, [list of available versions]).
 
     Note: the list of available versions contains only versions
           that higher than the current created version.
@@ -286,6 +287,7 @@ def ext_get_versions(cursor, ext):
     """
 
     current_version = None
+    default_version = None
     params = {}
     params['ext'] = ext
 
@@ -299,8 +301,18 @@ def ext_get_versions(cursor, ext):
     if res:
         current_version = res["extversion"]
 
-    # 2. Get available versions:
-    query = ("SELECT version FROM pg_available_extension_versions "
+    # 2. Get the extension default version:
+    query = ("SELECT default_version FROM pg_catalog.pg_available_extensions "
+             "WHERE name = %(ext)s")
+
+    cursor.execute(query, params)
+
+    res = cursor.fetchone()
+    if res:
+        default_version = res["default_version"]
+
+    # 3. Get extension available versions:
+    query = ("SELECT version FROM pg_catalog.pg_available_extension_versions "
              "WHERE name = %(ext)s")
 
     cursor.execute(query, params)
@@ -309,42 +321,42 @@ def ext_get_versions(cursor, ext):
 
     if current_version is None:
         current_version = False
+    if default_version is None:
+        default_version = False
 
-    return (current_version, available_versions)
+    return (current_version, default_version, available_versions)
 
 
 def ext_valid_update_path(cursor, ext, current_version, version):
     """
     Check to see if the installed extension version has a valid update
-    path to the given version. A version of 'latest' is always a valid path.
+    path to the given version.
 
     Return True if a valid path exists. Otherwise return False.
+
+    Note: 'latest' is not a valid value for version here as it can be
+          replaced with default_version specificed in extension control file.
 
     Args:
       cursor (cursor) -- cursor object of psycopg library
       ext (str) -- extension name
       current_version (str) -- installed version of the extension.
       version (str) -- target extension version to update to.
-        A value of 'latest' is always a valid path and will result
-        in the extension update command always being run.
     """
 
     valid_path = False
     params = {}
-    if version != 'latest':
-        query = ("SELECT path FROM pg_extension_update_paths(%(ext)s) "
-                 "WHERE source = %(cv)s "
-                 "AND target = %(ver)s")
+    query = ("SELECT path FROM pg_extension_update_paths(%(ext)s) "
+              "WHERE source = %(cv)s "
+              "AND target = %(ver)s")
 
-        params['ext'] = ext
-        params['cv'] = current_version
-        params['ver'] = version
+    params['ext'] = ext
+    params['cv'] = current_version
+    params['ver'] = version
 
-        cursor.execute(query, params)
-        res = cursor.fetchone()
-        if res is not None:
-            valid_path = True
-    else:
+    cursor.execute(query, params)
+    res = cursor.fetchone()
+    if res is not None:
         valid_path = True
 
     return (valid_path)
@@ -396,41 +408,59 @@ def main():
 
     try:
         # Get extension info and available versions:
-        curr_version, available_versions = ext_get_versions(cursor, ext)
+        curr_version, default_version, available_versions = ext_get_versions(cursor, ext)
+
+        # Decode version 'latest' if passed
+        # Note: real_version used for checks but not in CREATE/DROP/ALTER EXTENSION commands
+        if version == 'latest':
+            if default_version:
+                # 'latest' version matches default_version specificed in extension control file
+                real_version = default_version
+            else:
+                # If version is 'latest' and no default_version is specificed in extension
+                # control file (extension is buggy) CREATE/ALTER EXTENSION commands fail
+                module.fail_json(msg="Passed version 'latest' but no default_version available "
+                                     "in extension control file")
+        else:
+            real_version = version
 
         if state == "present":
 
-            # If version passed
+            # If version passed:
             if version:
                 # If extension is installed, update to passed version if a valid path exists
                 if curr_version:
-                    # Given version already installed
-                    if curr_version == version:
+                    # Given/Latest version already installed
+                    if curr_version == real_version:
                         changed = False
-                    # Attempt to update to given version or latest version defined in extension control file
-                    # ALTER EXTENSION is actually run if valid, so check if installed version is changed
-                    # when update to latest version is requested
+                    # Attempt to update to given/latest version
                     else:
-                        valid_update_path = ext_valid_update_path(cursor, ext, curr_version, version)
+                        valid_update_path = ext_valid_update_path(cursor, ext, curr_version, real_version)
                         if valid_update_path:
                             if module.check_mode:
                                 changed = True
                             else:
-                                update_cmd_executed = ext_update_version(cursor, ext, version)
-                                if version == 'latest':
-                                    new_curr_version, new_available_versions = ext_get_versions(cursor, ext)
-                                    changed = curr_version != new_curr_version
-                                else:
-                                    changed = update_cmd_executed
+                                changed = ext_update_version(cursor, ext, version)
                         else:
-                            module.fail_json(msg="Passed version '%s' has no valid update path from "
-                                                 "the currently installed version '%s' or "
-                                                 "the passed version is not available" % (version, curr_version))
+                            if version == 'latest':
+                                # No valid update path from curr_version to latest extension version
+                                # (extension is buggy or no direct update supported)
+                                module.fail_json(msg="Latest version '%s' has no valid update path from "
+                                                     "the currently installed version '%s'" % (real_version, curr_version))
+                            else:
+                                module.fail_json(msg="Passed version '%s' has no valid update path from "
+                                                     "the currently installed version '%s' or "
+                                                     "the passed version is not available" % (version, curr_version))
+                # If extension is not installed, install passed version
                 else:
-                    # If not requesting latest version and passed version not available
-                    if version != 'latest' and version not in available_versions:
-                        module.fail_json(msg="Passed version '%s' is not available" % version)
-                    # Else install the passed version when available
+                    # If passed version not available fail
+                    if real_version not in available_versions:
+                        if version == 'latest':
+                            # Latest version not available (extension is buggy)
+                            module.fail_json(msg="Latest version '%s' is not available" % real_version)
+                        else:
+                            module.fail_json(msg="Passed version '%s' is not available" % real_version)
+                    # Else install the passed version
                     else:
                         if module.check_mode:
                             changed = True
@@ -449,7 +479,6 @@ def main():
                             changed = True
                         else:
                             changed = ext_create(cursor, ext, schema, cascade, 'latest')
-
                     # If the ext doesn't exist and is not available:
                     else:
                         module.fail_json(msg="Extension %s is not available" % ext)

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -187,6 +187,31 @@
       that:
       - result.rowcount == 1
 
+  - name: postgresql_ext_version - update the extension to the latest version in check_mode
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: "{{ test_ext }}"
+      schema: "{{ test_schema }}"
+      version: latest
+      trust_input: false
+    check_mode: true
+
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ["ALTER EXTENSION \"{{ test_ext }}\" UPDATE"]
+
+  - name: postgresql_ext_version - check, the version must be 2.0
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '2.0'"
+
+  - assert:
+      that:
+      - result.rowcount == 1
+
   - name: postgresql_ext_version - update the extension to the latest version
     <<: *task_parameters
     postgresql_ext:
@@ -211,7 +236,31 @@
       that:
       - result.rowcount == 1
 
-  - name: postgresql_ext_version - try to update the extension to the latest version again which always runs an update
+  - name: postgresql_ext_version - update the extension to the latest version again in check_mode
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: "{{ test_ext }}"
+      schema: "{{ test_schema }}"
+      version: latest
+      trust_input: false
+    check_mode: true
+
+  - assert:
+      that:
+      - result is not changed
+
+  - name: postgresql_ext_version - check, the version must be 4.0 (latest)
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT 1 FROM pg_extension WHERE extname = '{{ test_ext }}' AND extversion = '4.0'"
+
+  - assert:
+      that:
+      - result.rowcount == 1
+
+  - name: postgresql_ext_version - update the extension to the latest version again
     <<: *task_parameters
     postgresql_ext:
       <<: *pg_parameters
@@ -224,7 +273,7 @@
       that:
       - result is not changed
 
-  - name: postgresql_ext_version - check that version number did not change even though update ran
+  - name: postgresql_ext_version - check, the version must be 4.0 (latest)
     <<: *task_parameters
     postgresql_query:
       <<: *pg_parameters
@@ -293,6 +342,19 @@
       that:
       - result.rowcount == 0
 
+  - name: postgresql_ext_version - try to drop the non-existent extension again in check_mode
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: "{{ test_ext }}"
+      state: absent
+      trust_input: false
+    check_mode: true
+
+  - assert:
+      that:
+      - result is not changed
+
   - name: postgresql_ext_version - try to drop the non-existent extension again
     <<: *task_parameters
     postgresql_ext:
@@ -326,6 +388,17 @@
   - assert:
       that:
       - result.rowcount == 1
+
+  - name: postgresql_ext_version - create the extension without passing version again
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: "{{ test_ext }}"
+      trust_input: false
+
+  - assert:
+      that:
+      - result is not changed
 
   - name: postgresql_ext_version - try to install non-existent extension
     <<: *task_parameters


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

I figured out that my PR #504 add idempotence when version=latest in standard mode but NOT in check mode.

It is caused by missing update path check when `version=latest` but actually the check is possibile.

When latest extension version is requested (both in create and update), the `default_version` specified in extension control file is installed:

```
test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             |
(1 row)

test=# CREATE EXTENSION adminpack;
CREATE EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.1
(1 row)

test=# DROP EXTENSION adminpack;
DROP EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             |
(1 row)

test=# CREATE EXTENSION adminpack VERSION '1.0';
CREATE EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 1.0
(1 row)

test=# ALTER EXTENSION adminpack UPDATE;
ALTER EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.1
(1 row)

test=# ALTER EXTENSION adminpack UPDATE;
NOTICE:  version "2.1" of extension "adminpack" is already installed
ALTER EXTENSION

test=# SELECT name, default_version, installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'adminpack';
   name    | default_version | installed_version
-----------+-----------------+-------------------
 adminpack | 2.1             | 2.1
(1 row)
```

It is confirmed also by the source code:

https://github.com/postgres/postgres/blob/d088ba5a5aa410d39b64f013e8433ad9eb3d17f1/src/backend/commands/extension.c#L3056_L3069

My PR add idempotence when provided `version=latest` also in check mode, parsing the extension `default_version` and using it to perform all checks (become useless as has been removed).

In addiction:

- I added all necessary tests.
- I fixed module documentation.
- I fixed changelog fragment of my PR #504 as it reports the wrong module name.
- I removed some of code added in my PR #504 as become useless.
- I added error messages in module when it is sure that PostgreSQL command will fail.
- I fixed module code comments.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_ext

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The second task of following play results not changed:

```paste below
- hosts: dbs
  tasks:
    - name: Install extension adminpack at latest version
      community.postgresql.postgresql_ext:
        database: test
        state: present
        name: adminpack
        version: latest

    - name: Update extension adminpack at latest version in check_mode
      community.postgresql.postgresql_ext:
        database: test
        state: present
        name: adminpack
        version: latest
      check_mode: true
```
