### PR TITLE
Fixed 'returned' value of all returned values of all modules

### DIFF
--- a/changelogs/fragments/_fix_ret_vals_doc.yml
+++ b/changelogs/fragments/_fix_ret_vals_doc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- fixed 'returned' value of all returned values of all modules (https://github.com/ansible-collections/community.postgresql/pull/).

--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -163,17 +163,17 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: str
   sample: [ "COPY test_table FROM '/tmp/data_file.txt' (FORMAT csv, DELIMITER ',', NULL 'NULL')" ]
 src:
   description: Data source.
-  returned: always
+  returned: success
   type: str
   sample: "mytable"
 dst:
   description: Data destination.
-  returned: always
+  returned: success
   type: str
   sample: "/tmp/data.csv"
 '''

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -257,7 +257,7 @@ EXAMPLES = r'''
 RETURN = r'''
 executed_commands:
   description: List of commands which tried to run.
-  returned: always
+  returned: success
   type: list
   sample: ["CREATE DATABASE acme"]
   version_added: '0.2.0'

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -163,7 +163,7 @@ EXAMPLES = r'''
 RETURN = r'''
 query:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: list
   sample: ["DROP EXTENSION \"acme\""]
 

--- a/plugins/modules/postgresql_idx.py
+++ b/plugins/modules/postgresql_idx.py
@@ -222,37 +222,37 @@ EXAMPLES = r'''
 RETURN = r'''
 name:
   description: Index name.
-  returned: always
+  returned: success
   type: str
   sample: 'foo_idx'
 state:
   description: Index state.
-  returned: always
+  returned: success
   type: str
   sample: 'present'
 schema:
   description: Schema where index exists.
-  returned: always
+  returned: success
   type: str
   sample: 'public'
 tablespace:
   description: Tablespace where index exists.
-  returned: always
+  returned: success
   type: str
   sample: 'ssd'
 query:
   description: Query that was tried to be executed.
-  returned: always
+  returned: success
   type: str
   sample: 'CREATE INDEX CONCURRENTLY foo_idx ON test_table USING BTREE (id)'
 storage_params:
   description: Index storage parameters.
-  returned: always
+  returned: success
   type: list
   sample: [ "fillfactor=90" ]
 valid:
   description: Index validity.
-  returned: always
+  returned: success
   type: bool
   sample: true
 '''

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -109,18 +109,18 @@ EXAMPLES = r'''
 RETURN = r'''
 version:
   description: Database server version U(https://www.postgresql.org/support/versioning/).
-  returned: always
+  returned: success
   type: dict
   sample: { "version": { "major": 10, "minor": 6 } }
   contains:
     major:
       description: Major server version.
-      returned: always
+      returned: success
       type: int
       sample: 11
     minor:
       description: Minor server version.
-      returned: always
+      returned: success
       type: int
       sample: 1
     patch:
@@ -131,24 +131,24 @@ version:
       version_added: '1.2.0'
     full:
       description: Full server version.
-      returned: always
+      returned: success
       type: str
       sample: '13.2'
       version_added: '1.2.0'
     raw:
       description: Full output returned by ``SELECT version()``.
-      returned: always
+      returned: success
       type: str
       sample: 'PostgreSQL 13.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9), 64-bit'
       version_added: '1.2.0'
 in_recovery:
   description: Indicates if the service is in recovery mode or not.
-  returned: always
+  returned: success
   type: bool
   sample: false
 databases:
   description: Information about databases.
-  returned: always
+  returned: success
   type: dict
   sample:
   - { "postgres": { "access_priv": "", "collate": "en_US.UTF-8",
@@ -156,48 +156,48 @@ databases:
   contains:
     database_name:
       description: Database name.
-      returned: always
+      returned: success
       type: dict
       sample: template1
       contains:
         access_priv:
           description: Database access privileges.
-          returned: always
+          returned: success
           type: str
           sample: "=c/postgres_npostgres=CTc/postgres"
         collate:
           description:
           - Database collation U(https://www.postgresql.org/docs/current/collation.html).
-          returned: always
+          returned: success
           type: str
           sample: en_US.UTF-8
         ctype:
           description:
           - Database LC_CTYPE U(https://www.postgresql.org/docs/current/multibyte.html).
-          returned: always
+          returned: success
           type: str
           sample: en_US.UTF-8
         encoding:
           description:
           - Database encoding U(https://www.postgresql.org/docs/current/multibyte.html).
-          returned: always
+          returned: success
           type: str
           sample: UTF8
         owner:
           description:
           - Database owner U(https://www.postgresql.org/docs/current/sql-createdatabase.html).
-          returned: always
+          returned: success
           type: str
           sample: postgres
         size:
           description: Database size in bytes.
-          returned: always
+          returned: success
           type: str
           sample: 8189415
         extensions:
           description:
           - Extensions U(https://www.postgresql.org/docs/current/sql-createextension.html).
-          returned: always
+          returned: success
           type: dict
           sample:
           - { "plpgsql": { "description": "PL/pgSQL procedural language",
@@ -210,32 +210,32 @@ databases:
               sample: PL/pgSQL procedural language
             extversion:
               description: Extension description.
-              returned: always
+              returned: success
               type: dict
               contains:
                 major:
                   description: Extension major version.
-                  returned: always
+                  returned: success
                   type: int
                   sample: 1
                 minor:
                   description: Extension minor version.
-                  returned: always
+                  returned: success
                   type: int
                   sample: 0
                 raw:
                   description: Extension full version.
-                  returned: always
+                  returned: success
                   type: str
                   sample: '1.0'
             nspname:
               description: Namespace where the extension is.
-              returned: always
+              returned: success
               type: str
               sample: pg_catalog
         languages:
           description: Procedural languages U(https://www.postgresql.org/docs/current/xplang.html).
-          returned: always
+          returned: success
           type: dict
           sample: { "sql": { "lanacl": "", "lanowner": "postgres" } }
           contains:
@@ -243,32 +243,32 @@ databases:
               description:
               - Language access privileges
                 U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-              returned: always
+              returned: success
               type: str
               sample: "{postgres=UC/postgres,=U/postgres}"
             lanowner:
               description:
               - Language owner U(https://www.postgresql.org/docs/current/catalog-pg-language.html).
-              returned: always
+              returned: success
               type: str
               sample: postgres
         namespaces:
           description:
           - Namespaces (schema) U(https://www.postgresql.org/docs/current/sql-createschema.html).
-          returned: always
+          returned: success
           type: dict
           sample: { "pg_catalog": { "nspacl": "{postgres=UC/postgres,=U/postgres}", "nspowner": "postgres" } }
           contains:
             nspacl:
               description:
               - Access privileges U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-              returned: always
+              returned: success
               type: str
               sample: "{postgres=UC/postgres,=U/postgres}"
             nspowner:
               description:
               - Schema owner U(https://www.postgresql.org/docs/current/catalog-pg-namespace.html).
-              returned: always
+              returned: success
               type: str
               sample: postgres
         publications:
@@ -303,24 +303,24 @@ repl_slots:
     active:
       description:
       - True means that a receiver has connected to it, and it is currently reserving archives.
-      returned: always
+      returned: success
       type: bool
       sample: true
     database:
       description: Database name this slot is associated with, or null.
-      returned: always
+      returned: success
       type: str
       sample: acme
     plugin:
       description:
       - Base name of the shared object containing the output plugin
         this logical slot is using, or null for physical slots.
-      returned: always
+      returned: success
       type: str
       sample: pgoutput
     slot_type:
       description: The slot type - physical or logical.
-      returned: always
+      returned: success
       type: str
       sample: logical
 replications:
@@ -336,7 +336,7 @@ replications:
     usename:
       description:
       - Name of the user logged into this WAL sender process ('usename' is a column name in pg_stat_replication view).
-      returned: always
+      returned: success
       type: str
       sample: replication_user
     app_name:
@@ -349,30 +349,30 @@ replications:
       - IP address of the client connected to this WAL sender.
       - If this field is null, it indicates that the client is connected
         via a Unix socket on the server machine.
-      returned: always
+      returned: success
       type: str
       sample: 10.0.0.101
     client_hostname:
       description:
       - Host name of the connected client, as reported by a reverse DNS lookup of client_addr.
       - This field will only be non-null for IP connections, and only when log_hostname is enabled.
-      returned: always
+      returned: success
       type: str
       sample: dbsrv1
     backend_start:
       description: Time when this process was started, i.e., when the client connected to this WAL sender.
-      returned: always
+      returned: success
       type: str
       sample: "2019-02-03 00:14:33.908593+03"
     state:
       description: Current WAL sender state.
-      returned: always
+      returned: success
       type: str
       sample: streaming
 tablespaces:
   description:
   - Information about tablespaces U(https://www.postgresql.org/docs/current/catalog-pg-tablespace.html).
-  returned: always
+  returned: success
   type: dict
   sample:
   - { "test": { "spcacl": "{postgres=C/postgres,andreyk=C/postgres}", "spcoptions": [ "seq_page_cost=1" ],
@@ -380,23 +380,23 @@ tablespaces:
   contains:
     spcacl:
       description: Tablespace access privileges.
-      returned: always
+      returned: success
       type: str
       sample: "{postgres=C/postgres,andreyk=C/postgres}"
     spcoptions:
       description: Tablespace-level options.
-      returned: always
+      returned: success
       type: list
       sample: [ "seq_page_cost=1" ]
     spcowner:
       description: Owner of the tablespace.
-      returned: always
+      returned: success
       type: str
       sample: test_user
 roles:
   description:
   - Information about roles U(https://www.postgresql.org/docs/current/user-manag.html).
-  returned: always
+  returned: success
   type: dict
   sample:
   - { "test_role": { "canlogin": true, "member_of": [ "user_ro" ], "superuser": false,
@@ -404,37 +404,37 @@ roles:
   contains:
     canlogin:
       description: Login privilege U(https://www.postgresql.org/docs/current/role-attributes.html).
-      returned: always
+      returned: success
       type: bool
       sample: true
     member_of:
       description:
       - Role membership U(https://www.postgresql.org/docs/current/role-membership.html).
-      returned: always
+      returned: success
       type: list
       sample: [ "read_only_users" ]
     superuser:
       description: User is a superuser or not.
-      returned: always
+      returned: success
       type: bool
       sample: false
     valid_until:
       description:
       - Password expiration date U(https://www.postgresql.org/docs/current/sql-alterrole.html).
-      returned: always
+      returned: success
       type: str
       sample: "9999-12-31T23:59:59.999999+00:00"
 pending_restart_settings:
   description:
   - List of settings that are pending restart to be set.
-  returned: always
+  returned: success
   type: list
   sample: [ "shared_buffers" ]
 settings:
   description:
   - Information about run-time server parameters
     U(https://www.postgresql.org/docs/current/view-pg-settings.html).
-  returned: always
+  returned: success
   type: dict
   sample:
   - { "work_mem": { "boot_val": "4096", "context": "user", "max_val": "2147483647",
@@ -443,30 +443,30 @@ settings:
   contains:
     setting:
       description: Current value of the parameter.
-      returned: always
+      returned: success
       type: str
       sample: 49152
     unit:
       description: Implicit unit of the parameter.
-      returned: always
+      returned: success
       type: str
       sample: kB
     boot_val:
       description:
       - Parameter value assumed at server startup if the parameter is not otherwise set.
-      returned: always
+      returned: success
       type: str
       sample: 4096
     min_val:
       description:
       - Minimum allowed value of the parameter (null for non-numeric values).
-      returned: always
+      returned: success
       type: str
       sample: 64
     max_val:
       description:
       - Maximum allowed value of the parameter (null for non-numeric values).
-      returned: always
+      returned: success
       type: str
       sample: 2147483647
     sourcefile:
@@ -475,20 +475,20 @@ settings:
       - Null for values set from sources other than configuration files,
         or when examined by a user who is neither a superuser or a member of pg_read_all_settings.
       - Helpful when using include directives in configuration files.
-      returned: always
+      returned: success
       type: str
       sample: /var/lib/pgsql/10/data/postgresql.auto.conf
     context:
       description:
       - Context required to set the parameter's value.
       - For more information see U(https://www.postgresql.org/docs/current/view-pg-settings.html).
-      returned: always
+      returned: success
       type: str
       sample: user
     vartype:
       description:
       - Parameter type (bool, enum, integer, real, or string).
-      returned: always
+      returned: success
       type: str
       sample: integer
     val_in_bytes:
@@ -500,14 +500,14 @@ settings:
     pretty_val:
       description:
       - Value presented in the pretty form.
-      returned: always
+      returned: success
       type: str
       sample: 2MB
     pending_restart:
       description:
       - True if the value has been changed in the configuration file but needs a restart; or false otherwise.
       - Returns only if C(settings) is passed.
-      returned: always
+      returned: success
       type: bool
       sample: false
 '''

--- a/plugins/modules/postgresql_lang.py
+++ b/plugins/modules/postgresql_lang.py
@@ -163,7 +163,7 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: list
   sample: ['CREATE LANGUAGE "acme"']
 '''

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -143,7 +143,7 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
     description: List of executed queries.
-    returned: always
+    returned: success
     type: str
     sample: [ "GRANT \"user_ro\" TO \"alice\"" ]
 granted:
@@ -158,7 +158,7 @@ revoked:
     sample: { "ro_group": [ "alice", "bob" ] }
 state:
     description: Membership state that tried to be set.
-    returned: always
+    returned: success
     type: str
     sample: "present"
 '''

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -143,7 +143,7 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: str
   sample: [ 'REASSIGN OWNED BY "bob" TO "alice"' ]
 '''

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -221,7 +221,7 @@ EXAMPLES = '''
 RETURN = r'''
 msgs:
     description: List of textual messages what was done.
-    returned: always
+    returned: success
     type: list
     sample:
        "msgs": [
@@ -236,7 +236,7 @@ backup_file:
     sample: /tmp/pg_hba_jxobj_p
 pg_hba:
     description: List of the pg_hba rules as they are configured in the specified hba file.
-    returned: always
+    returned: success
     type: list
     sample:
       "pg_hba": [

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -76,17 +76,17 @@ EXAMPLES = r'''
 RETURN = r'''
 is_available:
   description: PostgreSQL server availability.
-  returned: always
+  returned: success
   type: bool
   sample: true
 server_version:
   description: PostgreSQL server version.
-  returned: always
+  returned: if C(is_available=true)
   type: dict
   sample: { major: 13, minor: 2, full: '13.2', raw: 'PostgreSQL 13.2 on x86_64-pc-linux-gnu' }
 conn_err_msg:
   description: Connection error message.
-  returned: always
+  returned: if C(is_available=true)
   type: str
   sample: ''
   version_added: 1.7.0

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -414,7 +414,7 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: list
   sample: ['REVOKE GRANT OPTION FOR INSERT ON TABLE "books" FROM "reader";']
 '''

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -142,12 +142,12 @@ RETURN = r'''
 exists:
   description:
   - Flag indicates the publication exists or not at the end of runtime.
-  returned: always
+  returned: success
   type: bool
   sample: true
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: str
   sample: [ 'DROP PUBLICATION "acme" CASCADE' ]
 owner:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -208,35 +208,35 @@ query:
     description:
     - Executed query.
     - When reading several queries from a file, it contains only the last one.
-    returned: always
+    returned: success
     type: str
     sample: 'SELECT * FROM bar'
 statusmessage:
     description:
     - Attribute containing the message returned by the command.
     - When reading several queries from a file, it contains a message of the last one.
-    returned: always
+    returned: success
     type: str
     sample: 'INSERT 0 1'
 query_result:
     description:
     - List of dictionaries in column:value form representing returned rows.
     - When running queries from a file, returns result of the last query.
-    returned: always
+    returned: success
     type: list
     elements: dict
     sample: [{"Column": "Value1"},{"Column": "Value2"}]
 query_list:
     description:
     - List of executed queries.
-    returned: always
+    returned: success
     type: list
     elements: str
     sample: ['SELECT * FROM foo', 'SELECT * FROM bar']
 query_all_results:
     description:
     - List containing results of all queries executed (one sublist for every query).
-    returned: always
+    returned: success
     type: list
     elements: list
     sample: [[{"Column": "Value1"},{"Column": "Value2"}], [{"Column": "Value1"},{"Column": "Value2"}]]

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -106,12 +106,12 @@ EXAMPLES = r'''
 RETURN = r'''
 schema:
   description: Name of the schema.
-  returned: success, changed
+  returned: success
   type: str
   sample: "acme"
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: list
   sample: ["CREATE SCHEMA \"acme\""]
 '''

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -180,7 +180,7 @@ query:
     - When the C(positional_args) or C(named_args) options are used,
       the query contains all variables that were substituted
       inside the database connector.
-    returned: always
+    returned: success
     type: str
     sample: 'SELECT * FROM bar'
 statusmessage:
@@ -189,7 +189,7 @@ statusmessage:
       after executing the script content.
     - When there are several statements in the script, returns a message
       related to the last statement.
-    returned: always
+    returned: success
     type: str
     sample: 'INSERT 0 1'
 query_result:
@@ -197,7 +197,7 @@ query_result:
     - List of dictionaries in the column:value form representing returned rows.
     - When there are several statements in the script,
       returns result of the last statement.
-    returned: always
+    returned: success
     type: list
     elements: dict
     sample: [{"Column": "Value1"},{"Column": "Value2"}]

--- a/plugins/modules/postgresql_sequence.py
+++ b/plugins/modules/postgresql_sequence.py
@@ -232,70 +232,70 @@ EXAMPLES = r'''
 RETURN = r'''
 state:
   description: Sequence state at the end of execution.
-  returned: always
+  returned: success
   type: str
   sample: 'present'
 sequence:
   description: Sequence name.
-  returned: always
+  returned: success
   type: str
   sample: 'foobar'
 queries:
     description: List of queries that was tried to be executed.
-    returned: always
+    returned: success
     type: str
     sample: [ "CREATE SEQUENCE \"foo\"" ]
 schema:
     description: Name of the schema of the sequence.
-    returned: always
+    returned: success
     type: str
     sample: 'foo'
 data_type:
     description: Shows the current data type of the sequence.
-    returned: always
+    returned: success
     type: str
     sample: 'bigint'
 increment:
     description: The value of increment of the sequence. A positive value will
                  make an ascending sequence, a negative one a descending
                  sequence.
-    returned: always
+    returned: success
     type: int
     sample: -1
 minvalue:
     description: The value of minvalue of the sequence.
-    returned: always
+    returned: success
     type: int
     sample: 1
 maxvalue:
     description: The value of maxvalue of the sequence.
-    returned: always
+    returned: success
     type: int
     sample: 9223372036854775807
 start:
     description: The value of start of the sequence.
-    returned: always
+    returned: success
     type: int
     sample: 12
 cycle:
     description: Shows if the sequence cycle or not.
-    returned: always
+    returned: success
     type: bool
     sample: false
 owner:
     description: Shows the current owner of the sequence
                  after the successful run of the task.
-    returned: always
+    returned: success
     type: str
     sample: 'postgres'
 newname:
     description: Shows the new sequence name after rename.
-    returned: on success
+    returned: success
     type: str
     sample: 'barfoo'
 newschema:
     description: Shows the new schema of the sequence after schema change.
-    returned: on success
+    returned: success
     type: str
     sample: 'foobar'
 '''

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -134,22 +134,22 @@ EXAMPLES = r'''
 RETURN = r'''
 name:
   description: Name of PostgreSQL server parameter.
-  returned: always
+  returned: success
   type: str
   sample: 'shared_buffers'
 restart_required:
   description: Information about parameter current state.
-  returned: always
+  returned: success
   type: bool
   sample: true
 prev_val_pretty:
   description: Information about previous state of the parameter.
-  returned: always
+  returned: success
   type: str
   sample: '4MB'
 value_pretty:
   description: Information about current state of the parameter.
-  returned: always
+  returned: success
   type: str
   sample: '64MB'
 value:
@@ -157,13 +157,13 @@ value:
   - Dictionary that contains the current parameter value (at the time of playbook finish).
   - Pay attention that for real change some parameters restart of PostgreSQL server is required.
   - Returns the current value in the check mode.
-  returned: always
+  returned: success
   type: dict
   sample: { "value": 67108864, "unit": "b" }
 context:
   description:
   - PostgreSQL setting context.
-  returned: always
+  returned: success
   type: str
   sample: user
 '''

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -136,12 +136,12 @@ EXAMPLES = r'''
 RETURN = r'''
 name:
   description: Name of the slot.
-  returned: always
+  returned: success
   type: str
   sample: "physical_one"
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: str
   sample: [ "SELECT pg_create_physical_replication_slot('physical_one', False, False)" ]
 '''

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -175,28 +175,28 @@ RETURN = r'''
 name:
   description:
   - Name of the subscription.
-  returned: always
+  returned: success
   type: str
   sample: acme
 exists:
   description:
   - Flag indicates the subscription exists or not at the end of runtime.
-  returned: always
+  returned: success
   type: bool
   sample: true
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: str
   sample: [ 'DROP SUBSCRIPTION "mysubscription"' ]
 initial_state:
   description: Subscription configuration at the beginning of runtime.
-  returned: always
+  returned: success
   type: dict
   sample: {"conninfo": {}, "enabled": true, "owner": "postgres", "slotname": "test", "synccommit": true}
 final_state:
   description: Subscription configuration at the end of runtime.
-  returned: always
+  returned: success
   type: dict
   sample: {"conninfo": {}, "enabled": true, "owner": "postgres", "slotname": "test", "synccommit": true}
 '''

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -212,32 +212,32 @@ EXAMPLES = r'''
 RETURN = r'''
 table:
   description: Name of a table.
-  returned: always
+  returned: success
   type: str
   sample: 'foo'
 state:
   description: Table state.
-  returned: always
+  returned: success
   type: str
   sample: 'present'
 owner:
   description: Table owner.
-  returned: always
+  returned: success
   type: str
   sample: 'postgres'
 tablespace:
   description: Tablespace.
-  returned: always
+  returned: success
   type: str
   sample: 'ssd_tablespace'
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: str
   sample: [ 'CREATE TABLE "test_table" (id bigint)' ]
 storage_params:
   description: Storage parameters.
-  returned: always
+  returned: success
   type: list
   sample: [ "fillfactor=100", "autovacuum_analyze_threshold=1" ]
 '''

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -143,27 +143,27 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
     description: List of queries that was tried to be executed.
-    returned: always
+    returned: success
     type: str
     sample: [ "CREATE TABLESPACE bar LOCATION '/incredible/ssd'" ]
 tablespace:
     description: Tablespace name.
-    returned: always
+    returned: success
     type: str
     sample: 'ssd'
 owner:
     description: Tablespace owner.
-    returned: always
+    returned: success
     type: str
     sample: 'Bob'
 options:
     description: Tablespace options.
-    returned: always
+    returned: success
     type: dict
     sample: { 'random_page_cost': 1, 'seq_page_cost': 1 }
 location:
     description: Path to the tablespace in the file system.
-    returned: always
+    returned: v
     type: str
     sample: '/incredible/fast/ssd'
 newname:
@@ -173,7 +173,7 @@ newname:
     sample: new_ssd
 state:
     description: Tablespace state at the end of execution.
-    returned: always
+    returned: success
     type: str
     sample: 'present'
 '''

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -277,7 +277,7 @@ EXAMPLES = r'''
 RETURN = r'''
 queries:
   description: List of executed queries.
-  returned: always
+  returned: success
   type: list
   sample: ['CREATE USER "alice"', 'GRANT CONNECT ON DATABASE "acme" TO "alice"']
 '''

--- a/plugins/modules/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/postgresql_user_obj_stat_info.py
@@ -89,17 +89,17 @@ EXAMPLES = r'''
 RETURN = r'''
 indexes:
   description: User index statistics.
-  returned: always
+  returned: success
   type: dict
   sample: {"public": {"test_id_idx": {"idx_scan": 0, "idx_tup_fetch": 0, "idx_tup_read": 0, "relname": "test", "size": 8192, ...}}}
 tables:
   description: User table statistics.
-  returned: always
+  returned: success
   type: dict
   sample: {"public": {"test": {"analyze_count": 3, "n_dead_tup": 0, "n_live_tup": 0, "seq_scan": 2, "size": 0, "total_size": 8192, ...}}}
 functions:
   description: User function statistics.
-  returned: always
+  returned: success
   type: dict
   sample: {"public": {"inc": {"calls": 1, "funcid": 26722, "self_time": 0.23, "total_time": 0.23}}}
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

In all modules returned values are described in documentation as `always` returned, but really they are returned only at modules `success`.

With my PR I fixed all modules documentation, replacing `always` with `success` when present.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

postgresql_copy
postgresql_db
postgresql_ext
postgresql_idx
postgresql_info
postgresql_lang
postgresql_membership
postgresql_owner
postgresql_pg_hba
postgresql_ping
postgresql_privs
postgresql_publication
postgresql_query
postgresql_schema
postgresql_script
postgresql_sequence
postgresql_set
postgresql_slot
postgresql_subscription
postgresql_table
postgresql_tablespace
postgresql_user
postgresql_user_obj_stat_info

