### PR TITLE
Cursor query refactor

### DIFF
--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -261,6 +261,8 @@ except ImportError:
 import re
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
 )
@@ -275,8 +277,6 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     set_search_path,
     TYPES_NEED_TO_CONVERT,
 )
-from ansible.module_utils._text import to_native
-from ansible.module_utils.six import iteritems
 
 # ===========================================
 # Module execution.
@@ -371,6 +371,7 @@ def main():
     # Execute query:
     for query in query_list:
         try:
+            current_query_txt = cursor.mogrify(query, args)
             cursor.execute(query, args)
             statusmessage = cursor.statusmessage
             if cursor.rowcount > 0:
@@ -430,7 +431,7 @@ def main():
 
     kw = dict(
         changed=changed,
-        query=cursor.query,
+        query=current_query_txt,
         query_list=query_list,
         statusmessage=statusmessage,
         query_result=query_result,

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -220,6 +220,8 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
 )
@@ -234,8 +236,6 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     set_search_path,
     TYPES_NEED_TO_CONVERT,
 )
-from ansible.module_utils._text import to_native
-from ansible.module_utils.six import iteritems
 
 # ===========================================
 # Module execution.
@@ -306,6 +306,7 @@ def main():
 
     # Execute script content:
     try:
+        current_query_txt = cursor.mogrify(script_content, args)
         cursor.execute(script_content, args)
     except Exception as e:
         cursor.close()
@@ -337,7 +338,7 @@ def main():
 
     kw = dict(
         changed=True,
-        query=cursor.query,
+        query=current_query_txt,
         statusmessage=statusmessage,
         query_result=query_result,
         rowcount=rowcount,


### PR DESCRIPTION
##### SUMMARY
The `cursor.query` attribute is no longer available in Psycopg 3. It could be replaced with `cursor._query`, but that comes with a [large warning](https://www.psycopg.org/psycopg3/docs/api/cursors.html#psycopg.Cursor._query).

Using `cursor.mogrify()` instead to return the last executed query, it works well in both Psycopg 2 and 3.
This is a small patch, but an important one, helping to unblock #499.

##### ISSUE TYPE
- Refactoring for Psycopg 3

##### COMPONENT NAME
 - postgresql_query
 - postgresql_script

##### ADDITIONAL INFORMATION
Not sure about the variable naming, let me know if you have any suggestions.
