### PR TITLE
Additional Psycopg tests

### DIFF
--- a/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
+++ b/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
@@ -41,8 +41,8 @@
       - result.query_list == ['ANALYZE test_table']
       - result.rowcount == 0
       - result.statusmessage == 'ANALYZE'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
-      - result.query_all_results == [{}] or result.query_all_results == [[]]  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
+      - result.query_all_results == [{}]
 
   - name: postgresql_query - simple select query to test_table
     become_user: '{{ pg_user }}'
@@ -121,7 +121,7 @@
       - result.query == "UPDATE test_table SET story = 'new' WHERE id = 3"
       - result.rowcount == 1
       - result.statusmessage == 'UPDATE 1'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: check the previous update
     become_user: '{{ pg_user }}'
@@ -150,7 +150,7 @@
       - result.query == "UPDATE test_table SET story = 'CHECK_MODE' WHERE id = 3"
       - result.rowcount == 1
       - result.statusmessage == 'UPDATE 1'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: check the previous update that nothing has been changed
     become_user: '{{ pg_user }}'
@@ -179,7 +179,7 @@
       - result.query == "UPDATE test_table SET story = 'new' WHERE id = 100"
       - result.rowcount == 0
       - result.statusmessage == 'UPDATE 0'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: postgresql_query - insert query
     become_user: '{{ pg_user }}'
@@ -199,7 +199,7 @@
       - result.query == "INSERT INTO test_table (id, story) VALUES (4, 'fourth')" or result.query == "INSERT INTO test_table (id, story) VALUES (4, E'fourth')"
       - result.rowcount == 1
       - result.statusmessage == 'INSERT 0 1'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: postgresql_query - truncate test_table
     become_user: '{{ pg_user }}'
@@ -216,7 +216,7 @@
       - result.query == "TRUNCATE test_table"
       - result.rowcount == 0
       - result.statusmessage == 'TRUNCATE TABLE'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: postgresql_query - alter test_table
     become_user: '{{ pg_user }}'
@@ -309,7 +309,7 @@
       - result.query == "VACUUM"
       - result.rowcount == 0
       - result.statusmessage == 'VACUUM'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: postgresql_query - create test table for issue 59955
     become_user: '{{ pg_user }}'

--- a/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
+++ b/tests/integration/targets/postgresql_query/tasks/postgresql_query_initial.yml
@@ -41,8 +41,8 @@
       - result.query_list == ['ANALYZE test_table']
       - result.rowcount == 0
       - result.statusmessage == 'ANALYZE'
-      - result.query_result == {}
-      - result.query_all_results == [{}]
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_all_results == [{}] or result.query_all_results == [[]]  # Psycopg2 or Psycopg 3
 
   - name: postgresql_query - simple select query to test_table
     become_user: '{{ pg_user }}'
@@ -121,7 +121,7 @@
       - result.query == "UPDATE test_table SET story = 'new' WHERE id = 3"
       - result.rowcount == 1
       - result.statusmessage == 'UPDATE 1'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: check the previous update
     become_user: '{{ pg_user }}'
@@ -150,7 +150,7 @@
       - result.query == "UPDATE test_table SET story = 'CHECK_MODE' WHERE id = 3"
       - result.rowcount == 1
       - result.statusmessage == 'UPDATE 1'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: check the previous update that nothing has been changed
     become_user: '{{ pg_user }}'
@@ -179,7 +179,7 @@
       - result.query == "UPDATE test_table SET story = 'new' WHERE id = 100"
       - result.rowcount == 0
       - result.statusmessage == 'UPDATE 0'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: postgresql_query - insert query
     become_user: '{{ pg_user }}'
@@ -199,7 +199,7 @@
       - result.query == "INSERT INTO test_table (id, story) VALUES (4, 'fourth')" or result.query == "INSERT INTO test_table (id, story) VALUES (4, E'fourth')"
       - result.rowcount == 1
       - result.statusmessage == 'INSERT 0 1'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: postgresql_query - truncate test_table
     become_user: '{{ pg_user }}'
@@ -216,7 +216,7 @@
       - result.query == "TRUNCATE test_table"
       - result.rowcount == 0
       - result.statusmessage == 'TRUNCATE TABLE'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: postgresql_query - alter test_table
     become_user: '{{ pg_user }}'
@@ -233,6 +233,37 @@
       - result.query == "ALTER TABLE test_table ADD COLUMN foo int"
       - result.rowcount == 0
       - result.statusmessage == 'ALTER TABLE'
+
+  - name: postgresql_query - alter test_table using encoding
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: ALTER TABLE test_table ADD COLUMN foo2 int
+      encoding: 'UTF-8'
+    register: result
+    ignore_errors: true
+
+  - assert:
+      that:
+      - result is changed
+      - result.query == "ALTER TABLE test_table ADD COLUMN foo2 int"
+      - result.rowcount == 0
+      - result.statusmessage == 'ALTER TABLE'
+
+  - name: postgresql_query - alter test_table using bad encoding
+    become_user: '{{ pg_user }}'
+    become: true
+    postgresql_query:
+      <<: *pg_parameters
+      query: ALTER TABLE test_table ADD COLUMN foo888 int
+      encoding: 'UTF-888-bad'
+    register: result
+    ignore_errors: true
+
+  - assert:
+      that:
+      - result.failed == true
 
   - name: postgresql_query - vacuum without autocommit must fail
     become_user: '{{ pg_user }}'
@@ -278,7 +309,7 @@
       - result.query == "VACUUM"
       - result.rowcount == 0
       - result.statusmessage == 'VACUUM'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: postgresql_query - create test table for issue 59955
     become_user: '{{ pg_user }}'

--- a/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
+++ b/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
@@ -56,7 +56,7 @@
       - result.query == 'ANALYZE test_table\n'
       - result.rowcount != 0
       - result.statusmessage == 'ANALYZE'
-      - result.query_result == {}
+      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
 
   - name: Run queries from SQL script using positional_args
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
+++ b/tests/integration/targets/postgresql_script/tasks/postgresql_script_initial.yml
@@ -56,7 +56,7 @@
       - result.query == 'ANALYZE test_table\n'
       - result.rowcount != 0
       - result.statusmessage == 'ANALYZE'
-      - result.query_result == {} or result.query_result == []  # Psycopg2 or Psycopg 3
+      - result.query_result == {}
 
   - name: Run queries from SQL script using positional_args
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -647,6 +647,35 @@
       that:
       - result is not changed
 
+##### Test error handling when the database is read-only
+
+  - name: Set database as read-only
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: 'default_transaction_read_only'
+      value: 'on'
+
+  - name: Try to alter role in read-only database
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      role_attr_flags: 'CREATEDB'
+    register: result
+    ignore_errors: true
+
+  - assert:
+      that:
+      - result.msg == 'ERROR:  cannot execute ALTER ROLE in a read-only transaction\n'
+
+  - name: Set database as read-write
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: 'default_transaction_read_only'
+      value: 'off'
+
   always:
   #
   # Clean up


### PR DESCRIPTION
##### SUMMARY
Modified existing tests to work with Psycopg 3 and added extra Psycopg related tests.

The postgresql_user module handles the "database is read only" error, although only when altering a user. Tests were added to verify the behaviour.

Tests were added to verify the path in postgresql_query when `encoding` is specified.

`query_result` should be a list. When the list is empty, currently using psycopg2 we return an empty dict. When psycopg3 is used the same code will return an empty list. I think it is OK to keep the current behaviour, but no need to preserve that for psycopg3.


##### ISSUE TYPE
- Additional tests

##### COMPONENT NAME
Test harness

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
