### PR TITLE
[PR #545/extract backport][stable-1] fixed ext module return parameter 'query' name in documentation

### DIFF
--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -161,7 +161,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-query:
+queries:
   description: List of executed queries.
   returned: always
   type: list


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a backport of an PR #545 extract, to only fix ext module return parameter 'query' name in documentation.
