### PR TITLE
Psycopg 2.5.1 minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Every voice is important and every idea is valuable. If you have something on yo
 ## External requirements
 
 The PostgreSQL modules rely on the [Psycopg2](https://www.psycopg.org/docs/) PostgreSQL database adapter.
-The minimum supported version of Psycopg2 is 2.8.
+The minimum supported and tested version of Psycopg2 is 2.5.1.
 
 ## Tested with ansible-core
 
@@ -81,12 +81,17 @@ Tested with the following `ansible-core` releases:
 Ansible-core versions before 2.12.0 are not supported.
 Our AZP CI includes testing with the following docker images / PostgreSQL versions:
 
-- CentOS 7: 9.2
-- RHEL 8: 10
-- Fedora 34/35: 13
-- Fedora 36/37: 14
-- Fedora 38: 15
-- Ubuntu 20.04/22.04: 15
+| Docker image | psycopg version | PostgreSQL version |
+|--------------|-----------------|--------------------|
+| CentOS 7     |           2.5.1 |                9.2 |
+| RHEL 8       |           2.7.5 |               10   |
+| Fedora 34    |           2.8.6 |               13   |
+| Fedora 35    |           2.9.1 |               13   |
+| Fedora 36    |           2.9.1 |               14   |
+| Fedora 37    |           2.9.6 |               14   |
+| Fedora 38    |           2.9.6 |               15   |
+| Ubuntu 20.04 |           2.8.6 |               15   |
+| Ubuntu 22.04 |           2.9.6 |               15   |
 
 ## Included content
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Every voice is important and every idea is valuable. If you have something on yo
 ## External requirements
 
 The PostgreSQL modules rely on the [Psycopg2](https://www.psycopg.org/docs/) PostgreSQL database adapter.
+The minimum supported version of Psycopg2 is 2.8.
 
 ## Tested with ansible-core
 

--- a/changelogs/fragments/556_psycopg251.yml
+++ b/changelogs/fragments/556_psycopg251.yml
@@ -1,0 +1,2 @@
+major_changes:
+- "postgres modules - the minimum version of psycopg2 library the collection supports is 2.5.1 (https://github.com/ansible-collections/community.postgresql/pull/556)."

--- a/changelogs/fragments/556_psycopg28.yml
+++ b/changelogs/fragments/556_psycopg28.yml
@@ -1,0 +1,2 @@
+major_changes:
+- "postgres modules - the minimum version of psycopg2 library the collection supports is 2.8 (https://github.com/ansible-collections/community.postgresql/pull/556)."

--- a/changelogs/fragments/556_psycopg28.yml
+++ b/changelogs/fragments/556_psycopg28.yml
@@ -1,2 +1,0 @@
-major_changes:
-- "postgres modules - the minimum version of psycopg2 library the collection supports is 2.8 (https://github.com/ansible-collections/community.postgresql/pull/556)."

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -88,5 +88,5 @@ notes:
   on the remote host before using this module.
 - The ca_cert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 
-requirements: [ 'psycopg2 >= 2.8' ]
+requirements: [ 'psycopg2 >= 2.5.1' ]
 '''

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -88,5 +88,5 @@ notes:
   on the remote host before using this module.
 - The ca_cert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 
-requirements: [ psycopg2 ]
+requirements: [ 'psycopg2 >= 2.8' ]
 '''

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -82,8 +82,8 @@ def ensure_required_libs(module):
     if not HAS_PSYCOPG2:
         module.fail_json(msg=missing_required_lib('psycopg2'))
 
-    elif PSYCOPG_VERSION < LooseVersion("2.8"):
-        module.warn("psycopg should be at least 2.8 to support all modules functionality")
+    elif PSYCOPG_VERSION < LooseVersion("2.5.1"):
+        module.warn("psycopg should be at least 2.5.1 to support all modules functionality")
 
     if module.params.get('ca_cert') and PSYCOPG_VERSION < LooseVersion('2.4.3'):
         module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to use the ca_cert parameter')

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -82,7 +82,10 @@ def ensure_required_libs(module):
     if not HAS_PSYCOPG2:
         module.fail_json(msg=missing_required_lib('psycopg2'))
 
-    if module.params.get('ca_cert') and LooseVersion(psycopg2.__version__) < LooseVersion('2.4.3'):
+    elif PSYCOPG_VERSION < LooseVersion("2.8"):
+        module.warn("psycopg should be at least 2.8 to support all modules functionality")
+
+    if module.params.get('ca_cert') and PSYCOPG_VERSION < LooseVersion('2.4.3'):
         module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to use the ca_cert parameter')
 
 

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -556,7 +556,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
         except psycopg2.errors.ReadOnlySqlTransaction as e:
             # ERROR:  cannot execute ALTER ROLE in a read-only transaction
             changed = False
-            module.fail_json(msg=p_error.diag.message_primary, exception=traceback.format_exc())
+            module.fail_json(msg=e.diag.message_primary, exception=traceback.format_exc())
             return changed
         except psycopg2.NotSupportedError as e:
             module.fail_json(msg=e.diag.message_primary, exception=traceback.format_exc())

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -601,7 +601,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
             executed_queries.append(statement)
 
         except psycopg2.InternalError as e:
-            if psycopg_error.diag.sqlstate == "25006":
+            if e.diag.sqlstate == "25006":
                 # Handle errors due to read-only transactions indicated by pgcode 25006
                 # ERROR:  cannot execute ALTER ROLE in a read-only transaction
                 changed = False

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -297,6 +297,8 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     pg_quote_identifier,
     SQLParseError,
@@ -310,8 +312,6 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     pg_cursor_args,
     postgres_common_argument_spec,
 )
-from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils import saslprep
 
 try:
@@ -552,17 +552,14 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
             cursor.execute(statement, query_password_data)
             changed = True
             executed_queries.append(statement)
-        except psycopg2.InternalError as e:
-            if e.pgcode == '25006':
-                # Handle errors due to read-only transactions indicated by pgcode 25006
-                # ERROR:  cannot execute ALTER ROLE in a read-only transaction
-                changed = False
-                module.fail_json(msg=e.pgerror, exception=traceback.format_exc())
-                return changed
-            else:
-                raise psycopg2.InternalError(e)
+        # psycopg.errors (and ReadOnlySqlTransaction) was added in Psycopg 2.8
+        except psycopg2.errors.ReadOnlySqlTransaction as e:
+            # ERROR:  cannot execute ALTER ROLE in a read-only transaction
+            changed = False
+            module.fail_json(msg=p_error.diag.message_primary, exception=traceback.format_exc())
+            return changed
         except psycopg2.NotSupportedError as e:
-            module.fail_json(msg=e.pgerror, exception=traceback.format_exc())
+            module.fail_json(msg=e.diag.message_primary, exception=traceback.format_exc())
 
     elif no_password_changes and role_attr_flags != '':
         # Grab role information from pg_roles instead of pg_authid
@@ -597,15 +594,13 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
             statement = ' '.join(alter)
             cursor.execute(statement)
             executed_queries.append(statement)
-        except psycopg2.InternalError as e:
-            if e.pgcode == '25006':
-                # Handle errors due to read-only transactions indicated by pgcode 25006
-                # ERROR:  cannot execute ALTER ROLE in a read-only transaction
-                changed = False
-                module.fail_json(msg=e.pgerror, exception=traceback.format_exc())
-                return changed
-            else:
-                raise psycopg2.InternalError(e)
+
+        # psycopg.errors (and ReadOnlySqlTransaction) was added in Psycopg 2.8
+        except psycopg2.errors.ReadOnlySqlTransaction as e:
+            # ERROR:  cannot execute ALTER ROLE in a read-only transaction
+            changed = False
+            module.fail_json(msg=e.diag.message_primary, exception=traceback.format_exc())
+            return changed
 
         # Grab new role attributes.
         cursor.execute(select, {"user": user})

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -124,7 +124,7 @@ def m_psycopg2():
 
     class DummyPsycopg2():
         def __init__(self):
-            self.__version__ = '2.4.3'
+            self.__version__ = "2.9.6"
             self.extras = Extras()
             self.extensions = Extensions()
 
@@ -155,7 +155,11 @@ class TestEnsureReqLibs():
         class Dummym_ansible_module():
             def __init__(self):
                 self.params = {'ca_cert': False}
+                self.warn_msg = ''
                 self.err_msg = ''
+
+            def warn(self, msg):
+                self.warn_msg = msg
 
             def fail_json(self, msg):
                 self.err_msg = msg
@@ -171,6 +175,7 @@ class TestEnsureReqLibs():
     def test_ensure_req_libs_has_psycopg2(self, m_ansible_module, monkeypatch):
         """Test ensure_required_libs() with psycopg2 is not None."""
         monkeypatch.setattr(pg, 'HAS_PSYCOPG2', True)
+        monkeypatch.setattr(pg, 'PSYCOPG_VERSION', "2.9")
 
         pg.ensure_required_libs(m_ansible_module)
         assert m_ansible_module.err_msg == ''
@@ -181,6 +186,7 @@ class TestEnsureReqLibs():
         """
         m_ansible_module.params['ca_cert'] = True
         monkeypatch.setattr(pg, 'HAS_PSYCOPG2', True)
+        monkeypatch.setattr(pg, 'PSYCOPG_VERSION', "2.9")
         monkeypatch.setattr(pg, 'psycopg2', m_psycopg2)
 
         pg.ensure_required_libs(m_ansible_module)
@@ -194,7 +200,7 @@ class TestEnsureReqLibs():
         monkeypatch.setattr(pg, 'HAS_PSYCOPG2', True)
         # Set wrong psycopg2 version number:
         psycopg2 = m_psycopg2
-        psycopg2.__version__ = '2.4.2'
+        monkeypatch.setattr(pg, 'PSYCOPG_VERSION', "2.4.2")
         monkeypatch.setattr(pg, 'psycopg2', psycopg2)
 
         pg.ensure_required_libs(m_ansible_module)


### PR DESCRIPTION
##### SUMMARY

Updated the code to clarify that Psycopg versions older than 2.5.1 aren't fully supported.

New versions of psycopg2 use the same logic as psycopg 3, and de-supporting older versions of psycopg2 will allow us to simplify the code where it has to work with both versions for #499 

##### ISSUE TYPE
- Docs Pull Request and refactoring

##### COMPONENT NAME
Documentation and postgresql_user

##### ADDITIONAL INFORMATION
Initially this PR was created to make 2.8 the minimum version, but then realised that we still use/test on 2.7.5 in RHEL 8 and 2.5.1 in CentOS 7.


