### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.codespell-exclude-file
+++ b/.codespell-exclude-file
@@ -1,0 +1,2 @@
+astroid == 2.2.5
+- A. Hart (@jtelcontar)

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+exclude-file = .codespell-exclude-file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+#
+# Should more or less follow lint and typing settings as found is tox.ini
+#
+# Once pre-commit package is installed in your environnement, install hooks
+# with `pre-commit install`
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-added-large-files
+- repo: local
+  hooks:
+  - id: autoflake
+    name: autoflake
+    entry: autoflake --check-diff
+    language: system
+    types: [python]
+  - id: flake8
+    name: flake8
+    entry: flake8 .
+    language: system
+    types: [python]
+  - id: isort
+    name: isort
+    entry: isort --check --diff .
+    language: system
+    types: [python]
+  - id: codespell
+    name: codespell
+    entry: codespell
+    language: system
+    types: [file]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -147,7 +147,7 @@ Minor Changes
 Bugfixes
 --------
 
-- postgresql_info - add support for non numeric extenstion version (https://github.com/ansible-collections/community.postgresql/issues/428).
+- postgresql_info - add support for non numeric extension version (https://github.com/ansible-collections/community.postgresql/issues/428).
 - postgresql_info - when getting information about subscriptions, check the list of available columns in the pg_subscription table (https://github.com/ansible-collections/community.postgresql/issues/429).
 - postgresql_privs - fix connect_params being ignored (https://github.com/ansible-collections/community.postgresql/issues/450).
 - postgresql_query - could crash under certain conditions because of a missing import to `psycopg2.extras` (https://github.com/ansible-collections/community.postgresql/issues/283).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,44 @@ Refer to the [review checklist](https://docs.ansible.com/ansible/devel/community
 
 ## Checking your code locally
 
-You can run flake8 with tox to verify the quality of your code. For that you can simply call tox with that command:
+### By hand
+
+You can run flake8 with tox to verify the quality of your code. For that you
+can simply call tox with that command:
 ``` console
 $ tox -e lint
 ```
 
-If you tox is missing on your environment you can probably install it through your package manager (Eg: `sudo apt
-install tox`) or with pip (within a virtualenv):
+If you tox is missing on your environment you can probably install it through
+your package manager (Eg: `sudo apt install tox`) or with pip (within a
+virtualenv):
 
 ``` console
 $ python3 -m venv .venv
 $ source .venv
-$ pip intall tox
+$ pip install tox
+```
+
+### Automatically for each commit
+
+This repo contains some pre-commit configuration to automatically check your
+code foreach commit. To use that configuration you should "install" it by
+running:
+
+``` console
+$ pre-commit install
+```
+
+Then autoflake, flake8, isort and codespell must run when you add some commits.
+You can also force them to run with this command:
+
+``` console
+$ pre-commit run --all-file
+```
+
+If pre-commit is missing on your system, you can install it (on Debian based
+system) with `apt`:
+
+``` console
+$ sudo apt install pre-commit
 ```

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -446,7 +446,7 @@ releases:
   2.4.0:
     changes:
       bugfixes:
-      - postgresql_info - add support for non numeric extenstion version (https://github.com/ansible-collections/community.postgresql/issues/428).
+      - postgresql_info - add support for non numeric extension version (https://github.com/ansible-collections/community.postgresql/issues/428).
       - postgresql_info - when getting information about subscriptions, check the
         list of available columns in the pg_subscription table (https://github.com/ansible-collections/community.postgresql/issues/429).
       - postgresql_privs - fix connect_params being ignored (https://github.com/ansible-collections/community.postgresql/issues/450).

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -208,7 +208,7 @@ def ext_delete(check_mode, cursor, ext, cascade):
     Args:
       cursor (cursor) -- cursor object of psycopg library
       ext (str) -- extension name
-      cascade (boolean) -- Pass the CASCADE flag to the DROP commmand
+      cascade (boolean) -- Pass the CASCADE flag to the DROP command
     """
     query = "DROP EXTENSION \"%s\"" % ext
 
@@ -256,7 +256,7 @@ def ext_create(check_mode, cursor, ext, schema, cascade, version):
       cursor (cursor) -- cursor object of psycopg library
       ext (str) -- extension name
       schema (str) -- target schema for extension objects
-      cascade (boolean) -- Pass the CASCADE flag to the CREATE commmand
+      cascade (boolean) -- Pass the CASCADE flag to the CREATE command
       version (str) -- extension version
     """
     query = "CREATE EXTENSION \"%s\"" % ext
@@ -344,7 +344,7 @@ def ext_valid_update_path(cursor, ext, current_version, version):
     Return True if a valid path exists. Otherwise return False.
 
     Note: 'latest' is not a valid value for version here as it can be
-          replaced with default_version specificed in extension control file.
+          replaced with default_version specified in extension control file.
 
     Args:
       cursor (cursor) -- cursor object of psycopg library
@@ -428,12 +428,12 @@ def main():
                 module.fail_json(msg="Extension %s is not available" % ext)
             # Check default_version is available
             if default_version:
-                # 'latest' version matches default_version specificed in extension control file
+                # 'latest' version matches default_version specified in extension control file
                 real_version = default_version
             else:
-                # Passed version is 'latest', versions are available, but no default_version is specificed
+                # Passed version is 'latest', versions are available, but no default_version is specified
                 # in extension control file. In this situation CREATE/ALTER EXTENSION commands fail if
-                # a specific version is not passed ('latest' cannot be determinated).
+                # a specific version is not passed ('latest' cannot be determined).
                 module.fail_json(msg="Passed version 'latest' but no default_version available "
                                      "in extension control file")
         else:

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -497,7 +497,7 @@ class PgHbaRule(dict):
     def __init__(self, contype=None, databases=None, users=None, source=None, netmask=None,
                  method=None, options=None, line=None, comment=None):
         '''
-        This function can be called with a comma seperated list of databases and a comma seperated
+        This function can be called with a comma separated list of databases and a comma separated
         list of users and it will act as a generator that returns a expanded list of rules one by
         one.
         '''

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -835,16 +835,16 @@
     - result is changed
   when: postgres_version_resp.stdout is version('11', '>=')
 
-#################################################
-# Test ALL_IN_SCHEMA for 'partioned tables type #
-#################################################
+###################################################
+# Test ALL_IN_SCHEMA for 'partitioned tables type #
+###################################################
 
 # Partitioning tables is a feature introduced in Postgresql 10.
 # (see https://www.postgresql.org/docs/10/ddl-partitioning.html )
 # The test below check for this version
 
 # Function ALL_IN_SCHEMA Setup
-- name: Create partioned table for test purpose
+- name: Create partitioned table for test purpose
   postgresql_query:
     query: CREATE TABLE public.testpt (id int not null, logdate date not null) PARTITION BY RANGE (logdate);
     db: "{{ db_name }}"

--- a/tests/integration/targets/postgresql_user_obj_stat_info/tasks/postgresql_user_obj_stat_info.yml
+++ b/tests/integration/targets/postgresql_user_obj_stat_info/tasks/postgresql_user_obj_stat_info.yml
@@ -75,7 +75,7 @@
       state: stopped
     when: (ansible_facts.distribution_major_version != '8' and ansible_facts.distribution == 'CentOS') or ansible_facts.distribution != 'CentOS'
 
-  - name: Pause between stop and start PosgreSQL
+  - name: Pause between stop and start PostgreSQL
     pause:
       seconds: 5
 

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -237,10 +237,10 @@ class TestConnectToDb():
     """
     Namespace for testing connect_to_db() function.
 
-    When some connection errors occure connect_to_db() caught any of them
+    When some connection errors occur connect_to_db() caught any of them
     and invoke fail_json() or warn() methods of AnsibleModule object
     depending on the passed parameters.
-    connect_to_db may return db_connection object or None if errors occured.
+    connect_to_db may return db_connection object or None if errors occurred.
     Therefore we must check:
     1. Values of err_msg and warn_msg attributes of m_ansible_module mock object.
     2. Types of return objects (db_connection and cursor).

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
 envlist = lint
 isolated_build = true
-
 [testenv:lint]
 skip_install = true
 commands =
   flake8 .
   isort -c .
+  codespell
 deps =
   flake8
   isort
+  codespell
 
 [pycodestyle]
 ignore = E226,E302,E71


### PR DESCRIPTION
##### SUMMARY
Add some `pre-commit` configuration to enforce usage of linter, `autoflake`, `flake8` and `codespell` .