### PR TITLE
Decode bytes object from sql_ascii databases

### DIFF
--- a/changelogs/fragments/585-decode-data-from-sql_ascii-databases.yml
+++ b/changelogs/fragments/585-decode-data-from-sql_ascii-databases.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - postgresql_user - module failed when running against an SQL_ASCII encoded
+    database as the user's current password was returned as bytes as opposed
+    to a str. Fix now checks for this case and decodes the bytes as an ascii
+    encoded string.
+    (https://github.com/ansible-collections/community.postgresql/issues/584).

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -409,24 +409,29 @@ def user_should_we_change_password(current_role_attrs, user, password, encrypted
     # Do we actually need to do anything?
     pwchanging = False
     if password is not None:
+        current_password = current_role_attrs['rolpassword']
+        # Handle SQL_ASCII encoded databases
+        if isinstance(current_password, bytes):
+            current_password = current_password.decode('ascii')
+
         # Empty password means that the role shouldn't have a password, which
         # means we need to check if the current password is None.
         if password == '':
-            if current_role_attrs['rolpassword'] is not None:
+            if current_password is not None:
                 pwchanging = True
         # If the provided password is a SCRAM hash, compare it directly to the current password
         elif re.match(SCRAM_SHA256_REGEX, password):
-            if password != current_role_attrs['rolpassword']:
+            if password != current_password:
                 pwchanging = True
 
         # SCRAM hashes are represented as a special object, containing hash data:
         # `SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>`
         # for reference, see https://www.postgresql.org/docs/current/catalog-pg-authid.html
-        elif current_role_attrs['rolpassword'] is not None \
+        elif current_password is not None \
                 and pbkdf2_found \
-                and re.match(SCRAM_SHA256_REGEX, current_role_attrs['rolpassword']):
+                and re.match(SCRAM_SHA256_REGEX, current_password):
 
-            r = re.match(SCRAM_SHA256_REGEX, current_role_attrs['rolpassword'])
+            r = re.match(SCRAM_SHA256_REGEX, current_password)
             try:
                 # extract SCRAM params from rolpassword
                 it = int(r.group(1))
@@ -456,11 +461,11 @@ def user_should_we_change_password(current_role_attrs, user, password, encrypted
         # When the provided password looks like a MD5-hash, value of
         # 'encrypted' is ignored.
         elif (password.startswith('md5') and len(password) == 32 + 3) or encrypted == 'UNENCRYPTED':
-            if password != current_role_attrs['rolpassword']:
+            if password != current_password:
                 pwchanging = True
         elif encrypted == 'ENCRYPTED':
             hashed_password = 'md5{0}'.format(md5(to_bytes(password) + to_bytes(user)).hexdigest())
-            if hashed_password != current_role_attrs['rolpassword']:
+            if hashed_password != current_password:
                 pwchanging = True
 
     return pwchanging

--- a/tests/integration/targets/postgresql_user/defaults/main.yml
+++ b/tests/integration/targets/postgresql_user/defaults/main.yml
@@ -2,3 +2,6 @@ db_name: 'ansible_db'
 db_user1: 'ansible_db_user1'
 db_user2: 'ansible_db_user2'
 dangerous_name: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+
+# The user module tests require an sql_ascii encoded db to test client decoding
+sql_ascii_db_required: true

--- a/tests/integration/targets/postgresql_user/tasks/main.yml
+++ b/tests/integration/targets/postgresql_user/tasks/main.yml
@@ -10,3 +10,7 @@
 # General tests:
 - import_tasks: postgresql_user_general.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')
+
+# SQL_ASCII database tests:
+- import_tasks: postgresql_user_sql_ascii_db.yml
+  when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_sql_ascii_db.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_sql_ascii_db.yml
@@ -1,0 +1,8 @@
+- name: Execute module with no changes
+  become_user: '{{ pg_user }}'
+  become: true
+  postgresql_user:
+    name: '{{ sql_ascii_user }}'
+    db: '{{ sql_ascii_db }}'
+    role_attr_flags: SUPERUSER
+    password: '{{ sql_ascii_pass }}'

--- a/tests/integration/targets/setup_postgresql_db/defaults/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/defaults/main.yml
@@ -30,3 +30,8 @@ ssl_key: '/etc/client.key'
 # second database, for logical replication testing
 replica_data_dir: "/var/lib/pgsql_replica"
 replica_port: 5533
+
+# defaults for test sql_ascii database
+sql_ascii_db: 'sql_ascii'
+sql_ascii_user: 'sql_ascii_user'
+sql_ascii_pass: 'sql_ascii_pass'

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -293,3 +293,8 @@
   when:
     - replica_db_required is defined and replica_db_required
     - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support 'logical'
+
+# Create an SQL_ASCII encoded database
+- import_tasks: sql_ascii.yml
+  when:
+    - sql_ascii_db_required is defined and sql_ascii_db_required

--- a/tests/integration/targets/setup_postgresql_db/tasks/sql_ascii.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/sql_ascii.yml
@@ -1,0 +1,36 @@
+- name: postgresql SQL_ASCII - create database
+  become_user: '{{ pg_user }}'
+  become: true
+  postgresql_db:
+    name: '{{ sql_ascii_db }}'
+    encoding: 'SQL_ASCII'
+    template: 'template0'
+
+- name: postgresql SQL_ASCII - ensure db exists with proper encoding
+  become_user: '{{ pg_user }}'
+  become: true
+  shell: "psql -c 'SHOW SERVER_ENCODING' --tuples-only --no-align --dbname {{ sql_ascii_db }}"
+  register: sql_ascii_db_encoding
+
+- ansible.builtin.assert:
+    that:
+      - sql_ascii_db_encoding.stdout == 'SQL_ASCII'
+
+- name: postgresql SQL_ASCII - create role
+  become_user: '{{ pg_user }}'
+  become: true
+  postgresql_user:
+    name: '{{ sql_ascii_user }}'
+    db: '{{ sql_ascii_db }}'
+    role_attr_flags: SUPERUSER
+    password: '{{ sql_ascii_pass }}'
+
+- name: postgresql SQL_ASCII - ensure role was created
+  become: true
+  become_user: "{{ pg_user }}"
+  shell: "psql -c \"select * from pg_authid where rolname='{{ sql_ascii_user }}';\" -d {{ sql_ascii_db }}"
+  register: result
+
+- ansible.builtin.assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"


### PR DESCRIPTION
##### SUMMARY
Hello!

This PR fixes #584, however, I'm not sure if it's the only code that interacts with potentially encoded bytes.

Some other options are to:
- Do something like https://github.com/psycopg/psycopg/commit/ca6db5c213ad61af1f4690339248a3a447b31ef5
    - https://github.com/psycopg/psycopg/issues/503
    - https://github.com/psycopg/psycopg/issues/561
- Set a default connection parameter `client_encoding: utf8` in `postgres_common_argument_spec`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`postgres_user`
