### PR TITLE
Clean CI because Ansible will drop python2.7 & 3.6

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -143,8 +143,6 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 38
               test: fedora38
             - name: Ubuntu 20.04
@@ -160,8 +158,6 @@ stages:
         parameters:
           testFormat: 2.16/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 38
               test: fedora38
             - name: Ubuntu 20.04
@@ -177,8 +173,6 @@ stages:
         parameters:
           testFormat: 2.15/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 37
               test: fedora37
             - name: Ubuntu 20.04
@@ -194,8 +188,6 @@ stages:
         parameters:
           testFormat: 2.14/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 36
               test: fedora36
             - name: Ubuntu 20.04
@@ -209,8 +201,6 @@ stages:
         parameters:
           testFormat: 2.13/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 35
               test: fedora35
             - name: Ubuntu 20.04
@@ -224,8 +214,6 @@ stages:
         parameters:
           testFormat: 2.12/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 34
               test: fedora34
             - name: Ubuntu 20.04
@@ -240,8 +228,8 @@ stages:
         parameters:
           testFormat: devel/{0}/1
           targets:
-            - name: RHEL 8.8
-              test: rhel/8.8
+            - name: RHEL 8.9
+              test: rhel/8.9
 
   - stage: Remote_2_16
     displayName: Remote 2.16
@@ -251,52 +239,8 @@ stages:
         parameters:
           testFormat: 2.16/{0}/1
           targets:
-            - name: RHEL 8.8
-              test: rhel/8.8
-
-  - stage: Remote_2_15
-    displayName: Remote 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.15/{0}/1
-          targets:
-            - name: RHEL 8.7
-              test: rhel/8.7
-
-  - stage: Remote_2_14
-    displayName: Remote 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}/1
-          targets:
-            - name: RHEL 8.6
-              test: rhel/8.6
-
-  - stage: Remote_2_13
-    displayName: Remote 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/{0}/1
-          targets:
-            - name: RHEL 8.5
-              test: rhel/8.5
-
-  - stage: Remote_2_12
-    displayName: Remote 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/{0}/1
-          targets:
-            - name: RHEL 8.4
-              test: rhel/8.4
+            - name: RHEL 8.9
+              test: rhel/8.9
 
 ## Finally
 


### PR DESCRIPTION
##### SUMMARY

Pretty soon Ansible will drop support for python2.7 and 3.6, so let's remove some old system from our CI (CentOS7 and RHEL8.8).

We also now try on RHEL8.9

