### PR TITLE
Ignore sanity errors

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,5 +1,6 @@
-tests/utils/shippable/timing.py shebang
 plugins/modules/postgresql_db.py use-argspec-type-path
 plugins/modules/postgresql_db.py validate-modules:use-run-command-not-popen
 plugins/modules/postgresql_tablespace.py validate-modules:mutually_exclusive-unknown
 plugins/module_utils/version.py pylint:unused-import
+tests/utils/shippable/timing.py shebang
+tests/unit/plugins/module_utils/test_postgres.py pylint:unidiomatic-typecheck


### PR DESCRIPTION
##### SUMMARY

Ignore sanity failings

Spotted the red shield in README

if i change `type` to `isinstance`, it fails with another error that the second type is not valid, so let's ignore it as it's just "not idiomatic".

