### PR TITLE
ci(azure): bump fedora to 39

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -132,8 +132,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: Fedora 38
-              test: fedora38
+            - name: Fedora 39
+              test: fedora39
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04
@@ -149,8 +149,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 38
-              test: fedora38
+            - name: Fedora 39
+              test: fedora39
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -149,8 +149,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 39
-              test: fedora39
+            - name: Fedora 38
+              test: fedora38
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04


### PR DESCRIPTION
As per https://github.com/ansible-collections/news-for-maintainers/issues/63, bump Fedora 38 to 39 for Azure pipeline