### PR TITLE
Fix psycopg2 documentation link

### DIFF
--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -19,7 +19,7 @@ options:
   query:
     description:
     - SQL query string or list of queries to run. Variables can be escaped with psycopg syntax
-      U(https://www.psycopg.org/psycopg3/docs/basic/params.html).
+      U(https://www.psycopg.org/docs/usage.html).
     type: raw
   positional_args:
     description:


### PR DESCRIPTION
Existing link to psycopg2 documentation has expired. Move to new url

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Current expired link: http://initd.org/psycopg/docs/usage.html (tcp error, connection timeout)
Changed to new found link: https://www.psycopg.org/docs/usage.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_query

##### ADDITIONAL INFORMATION
N/A
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


