### PR TITLE
AZP: remove Fedora 36, update README test matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -183,8 +183,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 36
-              test: fedora36
             - name: Ubuntu 20.04
               test: ubuntu2004
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,10 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 |--------------|-----------------|--------------------|
 | CentOS 7     |           2.5.1 |                9.2 |
 | RHEL 8       |           2.7.5 |               10   |
-| Fedora 34    |           2.8.6 |               13   |
 | Fedora 35    |           2.9.1 |               13   |
-| Fedora 36    |           2.9.1 |               14   |
 | Fedora 37    |           2.9.6 |               14   |
-| Fedora 38    |           3.1.8 |               15   |
+| Fedora 38    |           2.9.6 |               15   |
+| Fedora 39    |           2.9.6 |               15   |
 | Ubuntu 20.04 |           2.8.6 |               15   |
 | Ubuntu 22.04 |           3.1.9 |               15   |
 


### PR DESCRIPTION
##### SUMMARY
AZP: remove Fedora 36, update README test matrix

- Tests against Fedora 36 have been failing for a week because of their repo issues. Removing it as we already test against Postgres 14 and same connector version 2.9.1 in the other targets
- Removing Fedora 34 as it's absent in AZP
- Updated Fedora 38 connector version to the actual one. Probably was a copy-paste error