### PR TITLE
[stable-2] AZP: remove testing against stable-2.13 as EOL

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -92,18 +92,6 @@ stages:
             - name: Units
               test: '2.14/units/1'
 
-  - stage: Ansible_2_13
-    displayName: Sanity & Units 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.13/sanity/1'
-            - name: Units
-              test: '2.13/units/1'
-
 ## Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -167,21 +155,6 @@ stages:
             - name: Ubuntu 20.04
               test: ubuntu2004
 
-  - stage: Docker_2_13
-    displayName: Docker 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/linux/{0}/1
-          targets:
-            - name: CentOS 7
-              test: centos7
-            - name: Fedora 35
-              test: fedora35
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-
 ## Remote
   - stage: Remote_devel
     displayName: Remote devel
@@ -227,17 +200,6 @@ stages:
             - name: RHEL 8.6
               test: rhel/8.6
 
-  - stage: Remote_2_13
-    displayName: Remote 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/{0}/1
-          targets:
-            - name: RHEL 8.5
-              test: rhel/8.5
-
 ## Finally
 
   - stage: Summary
@@ -247,16 +209,13 @@ stages:
       - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
-      - Ansible_2_13
       - Docker_devel
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14
-      - Docker_2_13
       - Remote_devel
       - Remote_2_16
       - Remote_2_15
       - Remote_2_14
-      - Remote_2_13
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Here is the table for the support timeline:
 ## Tested with ansible-core
 
 Tested with the following `ansible-core` releases:
-- 2.13
 - 2.14
 - 2.15
 - 2.16
@@ -97,7 +96,6 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 |--------------|-----------------|--------------------|
 | CentOS 7     |           2.5.1 |                9.2 |
 | RHEL 8       |           2.7.5 |               10   |
-| Fedora 35    |           2.9.1 |               13   |
 | Fedora 37    |           2.9.6 |               14   |
 | Fedora 38    |           2.9.6 |               15   |
 | Fedora 39    |           2.9.6 |               15   |


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.postgresql/pull/643