### PR TITLE
postgresql_db,_schema,_tablespace,_user: add comment value to check_input function

### DIFF
--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -706,7 +706,8 @@ def main():
     # Check input
     if not trust_input:
         # Check input for potentially dangerous elements:
-        check_input(module, owner, conn_limit, encoding, db, template, tablespace, session_role)
+        check_input(module, owner, conn_limit, encoding, db,
+                    template, tablespace, session_role, comment)
 
     raw_connection = state in ("dump", "restore")
 

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -258,7 +258,7 @@ def main():
 
     if not trust_input:
         # Check input for potentially dangerous elements:
-        check_input(module, schema, owner, session_role)
+        check_input(module, schema, owner, session_role, comment)
 
     changed = False
 

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -454,7 +454,7 @@ def main():
             settings_list = ['%s = %s' % (k, v) for k, v in iteritems(settings)]
 
         check_input(module, tablespace, location, owner,
-                    rename_to, session_role, settings_list)
+                    rename_to, session_role, settings_list, comment)
 
     # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -968,7 +968,7 @@ def main():
     if not trust_input:
         # Check input for potentially dangerous elements:
         check_input(module, user, password, privs, expires,
-                    role_attr_flags, comment, session_role)
+                    role_attr_flags, comment, session_role, comment)
 
     # Ensure psycopg libraries are available before connecting to DB:
     ensure_required_libs(module)

--- a/tests/integration/targets/postgresql_db/tasks/postgresql_db_comment.yml
+++ b/tests/integration/targets/postgresql_db/tasks/postgresql_db_comment.yml
@@ -14,6 +14,7 @@
   postgresql_db:
     state: present
     name: comment_db
+    trust_input: false
     login_user: "{{ pg_user }}"
     comment: Test DB comment 1
 


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.postgresql/issues/354
Forget to do it while implementing the comment argument feature.
Note: Not adding this to every module's tests as the function used is the same. In case it changes, the whole set of test targets will be triggered anyway, so having `trust_input: false` only in one target is imo enough.