### PR TITLE
modules: fix reset comment

### DIFF
--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -420,6 +420,10 @@ def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_
         else:
             changed = False
 
+            if db_info['comment'] is None:
+                # For the resetting comment feature (comment: '') to work correctly
+                db_info['comment'] = ''
+
             if owner and owner != db_info['owner']:
                 changed = set_owner(cursor, db, owner)
 
@@ -440,6 +444,11 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn
         return False
     else:
         db_info = get_db_info(cursor, db)
+
+        if db_info['comment'] is None:
+            # For the resetting comment feature (comment: '') to work correctly
+            db_info['comment'] = ''
+
         if (encoding and get_encoding_id(cursor, encoding) != db_info['encoding_id']):
             return False
         elif lc_collate and lc_collate != db_info['lc_collate']:

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -507,11 +507,16 @@ def main():
                     else:
                         module.fail_json(msg="Extension %s is not available" % ext)
 
-            if comment is not None and comment != get_comment(cursor, 'extension', ext):
-                if module.check_mode:
-                    changed = True
-                else:
-                    changed = set_comment(cursor, comment, 'extension', ext, executed_queries)
+            if comment is not None:
+                current_comment = get_comment(cursor, 'extension', ext)
+                # For the resetting comment feature (comment: '') to work correctly
+                current_comment = current_comment if current_comment is not None else ''
+
+                if comment != current_comment:
+                    if module.check_mode:
+                        changed = True
+                    else:
+                        changed = set_comment(cursor, comment, 'extension', ext, executed_queries)
 
         elif state == "absent":
             if curr_version:

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -207,8 +207,10 @@ def schema_create(cursor, schema, owner, comment):
         if owner and owner != schema_info['owner']:
             changed = set_owner(cursor, schema, owner)
 
-        if comment is not None and comment != schema_info['comment']:
-            changed = set_comment(cursor, comment, 'schema', schema, executed_queries) or changed
+        if comment is not None:
+            current_comment = schema_info['comment'] if schema_info['comment'] is not None else ''
+            if comment != current_comment:
+                changed = set_comment(cursor, comment, 'schema', schema, executed_queries) or changed
 
         return changed
 
@@ -220,8 +222,11 @@ def schema_matches(cursor, schema, owner, comment):
         schema_info = get_schema_info(cursor, schema)
         if owner and owner != schema_info['owner']:
             return False
-        if comment is not None and comment != schema_info['comment']:
-            return False
+        if comment is not None:
+            # For the resetting comment feature (comment: '') to work correctly
+            current_comment = schema_info['comment'] if schema_info['comment'] is not None else ''
+            if comment != current_comment:
+                return False
 
         return True
 

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -295,8 +295,7 @@ class PgTablespace(object):
                 # Location exists:
                 self.location = res[0]["loc_string"]
 
-            if res[0]["comment"]:
-                self.comment = res[0]["comment"]
+            self.comment = res[0]["comment"] if res[0]["comment"] is not None else ''
 
     def create(self, location):
         """Create tablespace.

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -910,7 +910,10 @@ def get_valid_flags_by_version(srv_version):
 
 def add_comment(cursor, user, comment):
     """Add comment on user."""
-    if comment != get_comment(cursor, 'role', user):
+    current_comment = get_comment(cursor, 'role', user)
+    # For the resetting comment feature (comment: '') to work correctly
+    current_comment = current_comment if current_comment is not None else ''
+    if comment != current_comment:
         set_comment(cursor, comment, 'role', user, executed_queries)
         return True
     else:

--- a/tests/integration/targets/postgresql_db/tasks/postgresql_db_comment.yml
+++ b/tests/integration/targets/postgresql_db/tasks/postgresql_db_comment.yml
@@ -166,6 +166,21 @@
       - result.query_result[0]['comment'] == None
 
 
+- name: Reset the comment again
+  <<: *task_parameters
+  postgresql_db:
+    state: present
+    name: comment_db
+    login_user: "{{ pg_user }}"
+    comment: ''
+
+- name: Assert the result
+  assert:
+    that:
+       - result is not changed
+       - result.executed_commands == []
+
+
 - name: Clean up
   <<: *task_parameters
   postgresql_db:

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_initial.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_initial.yml
@@ -181,6 +181,23 @@
       - result.query_result[0]['comment'] == None
 
 
+- name: Reset the comment again
+  become_user: '{{ pg_user }}'
+  become: true
+  postgresql_ext:
+    login_db: postgres
+    login_port: 5432
+    name: postgis
+    comment: ''
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.queries == []
+
+
 - name: postgresql_ext - drop extension postgis
   become_user: '{{ pg_user }}'
   become: true

--- a/tests/integration/targets/postgresql_schema/tasks/postgresql_schema_initial.yml
+++ b/tests/integration/targets/postgresql_schema/tasks/postgresql_schema_initial.yml
@@ -486,6 +486,23 @@
       - result.query_result[0]['comment'] == None
 
 
+- name: Reset the comment again
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_schema:
+    login_user: "{{ pg_user }}"
+    database: "{{ db_name }}"
+    name: comment_schema
+    comment: ''
+  register: result
+
+- name: Check return values
+  assert:
+    that:
+      - result is not changed
+      - result.queries == []
+
+
 - name: Drop schema
   become_user: "{{ pg_user }}"
   become: true

--- a/tests/integration/targets/postgresql_tablespace/tasks/postgresql_tablespace_initial.yml
+++ b/tests/integration/targets/postgresql_tablespace/tasks/postgresql_tablespace_initial.yml
@@ -412,6 +412,23 @@
     - result.query_result[0]['comment'] == None
 
 
+- name: Reset the comment again
+  become_user: '{{ pg_user }}'
+  become: true
+  postgresql_tablespace:
+    db: postgres
+    login_user: '{{ pg_user }}'
+    name: acme
+    location: /ssd
+    comment: ''
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.queries == []
+
+
 # Clean up
 - name: Drop tablespace
   become_user: '{{ pg_user }}'

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -201,6 +201,18 @@
       that:
       - result.rowcount == 1
       - result.query_result[0].comment == None
+
+  - name: Reset the comment again
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      comment: ''
+
+  - assert:
+      that:
+      - result is not changed
+      - result.queries == []
 # End comment argument testing
 
   - name: Try to create role again in check_mode


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.postgresql/issues/354

Fixes a wrong behavior when you reset a comment by passing `comment: ''` which leads to always executing the `COMMENT ON OBJECT_TYPE "obj_name" IS ''`.

No fragments are needed as the feature hasn't been released.