### PR TITLE
Fix queries handling for comment feature

### DIFF
--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -552,7 +552,7 @@ def get_comment(cursor, obj_type, obj_name):
     return cursor.fetchone()['comment']
 
 
-def set_comment(cursor, comment, obj_type, obj_name, executed_queries=None):
+def set_comment(cursor, comment, obj_type, obj_name, check_mode=True, executed_queries=None):
     """Get DB object's comment.
 
     Args:
@@ -564,7 +564,8 @@ def set_comment(cursor, comment, obj_type, obj_name, executed_queries=None):
     """
     query = 'COMMENT ON %s "%s" IS ' % (obj_type.upper(), obj_name)
 
-    cursor.execute(query + '%(comment)s', {'comment': comment})
+    if not check_mode:
+        cursor.execute(query + '%(comment)s', {'comment': comment})
 
     if executed_queries is not None:
         executed_queries.append(cursor.mogrify(query + '%(comment)s', {'comment': comment}))

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -376,7 +376,7 @@ def db_delete(cursor, db, force=False):
         return False
 
 
-def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_limit, tablespace, comment):
+def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_limit, tablespace, comment, check_mode):
     params = dict(enc=encoding, collate=lc_collate, ctype=lc_ctype, conn_limit=conn_limit, tablespace=tablespace)
     if not db_exists(cursor, db):
         query_fragments = ['CREATE DATABASE "%s"' % db]
@@ -398,7 +398,7 @@ def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_
         executed_commands.append(cursor.mogrify(query, params))
         cursor.execute(query, params)
         if comment:
-            set_comment(cursor, comment, 'database', db, executed_commands)
+            set_comment(cursor, comment, 'database', db, check_mode, executed_commands)
         return True
     else:
         db_info = get_db_info(cursor, db)
@@ -434,7 +434,7 @@ def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_
                 changed = set_tablespace(cursor, db, tablespace)
 
             if comment is not None and comment != db_info['comment']:
-                changed = set_comment(cursor, comment, 'database', db, executed_commands)
+                changed = set_comment(cursor, comment, 'database', db, check_mode, executed_commands)
 
             return changed
 
@@ -765,7 +765,8 @@ def main():
 
         elif state == "present":
             try:
-                changed = db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_limit, tablespace, comment)
+                changed = db_create(cursor, db, owner, template, encoding, lc_collate,
+                                    lc_ctype, conn_limit, tablespace, comment, module.check_mode)
             except SQLParseError as e:
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -511,12 +511,8 @@ def main():
                 current_comment = get_comment(cursor, 'extension', ext)
                 # For the resetting comment feature (comment: '') to work correctly
                 current_comment = current_comment if current_comment is not None else ''
-
                 if comment != current_comment:
-                    if module.check_mode:
-                        changed = True
-                    else:
-                        changed = set_comment(cursor, comment, 'extension', ext, executed_queries)
+                    changed = set_comment(cursor, comment, 'extension', ext, module.check_mode, executed_queries)
 
         elif state == "absent":
             if curr_version:

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -345,8 +345,8 @@ class PgPublication():
             self.__pub_set_owner(owner, check_mode=check_mode)
 
         if comment is not None:
-            if not check_mode:
-                set_comment(self.cursor, comment, 'publication', self.name, self.executed_queries)
+            set_comment(self.cursor, comment, 'publication',
+                        self.name, check_mode, self.executed_queries)
 
         return changed
 
@@ -424,11 +424,8 @@ class PgPublication():
                 changed = self.__pub_set_owner(owner, check_mode=check_mode)
 
         if comment is not None and comment != self.attrs['comment']:
-            if not check_mode:
-                changed = set_comment(self.cursor, comment, 'publication',
-                                      self.name, self.executed_queries)
-            else:
-                changed = True
+            changed = set_comment(self.cursor, comment, 'publication',
+                                  self.name, check_mode, self.executed_queries)
 
         return changed
 

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -199,7 +199,7 @@ def schema_create(cursor, schema, owner, comment):
         cursor.execute(query)
         executed_queries.append(query)
         if comment is not None:
-            set_comment(cursor, comment, 'schema', schema, executed_queries)
+            set_comment(cursor, comment, 'schema', schema, False, executed_queries)
         return True
     else:
         schema_info = get_schema_info(cursor, schema)
@@ -210,7 +210,7 @@ def schema_create(cursor, schema, owner, comment):
         if comment is not None:
             current_comment = schema_info['comment'] if schema_info['comment'] is not None else ''
             if comment != current_comment:
-                changed = set_comment(cursor, comment, 'schema', schema, executed_queries) or changed
+                changed = set_comment(cursor, comment, 'schema', schema, False, executed_queries) or changed
 
         return changed
 

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -494,8 +494,7 @@ class PgSubscription():
         Returns:
             True if success, False otherwise.
         """
-        if not check_mode:
-            set_comment(self.cursor, comment, 'subscription', self.name, self.executed_queries)
+        set_comment(self.cursor, comment, 'subscription', self.name, check_mode, self.executed_queries)
 
         return True
 

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -329,7 +329,7 @@ class PgTablespace(object):
         query = 'ALTER TABLESPACE "%s" OWNER TO "%s"' % (self.name, new_owner)
         return exec_sql(self, query, return_bool=True)
 
-    def set_comment(self, comment):
+    def set_comment(self, comment, check_mode):
         """Set tablespace comment.
 
         Return True if success, otherwise, return False.
@@ -341,7 +341,7 @@ class PgTablespace(object):
             return False
 
         return set_comment(self.cursor, comment, 'tablespace', self.name,
-                           self.executed_queries)
+                           check_mode, self.executed_queries)
 
     def rename(self, newname):
         """Rename tablespace.
@@ -515,7 +515,7 @@ def main():
             changed = tblspace.set_settings(settings) or changed
 
         if comment is not None:
-            changed = tblspace.set_comment(comment) or changed
+            changed = tblspace.set_comment(comment, module.check_mode) or changed
 
         # Update tablespace information in the class
         tblspace.get_info()

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -908,13 +908,13 @@ def get_valid_flags_by_version(srv_version):
     ]
 
 
-def add_comment(cursor, user, comment):
+def add_comment(cursor, user, comment, check_mode):
     """Add comment on user."""
     current_comment = get_comment(cursor, 'role', user)
     # For the resetting comment feature (comment: '') to work correctly
     current_comment = current_comment if current_comment is not None else ''
     if comment != current_comment:
-        set_comment(cursor, comment, 'role', user, executed_queries)
+        set_comment(cursor, comment, 'role', user, check_mode, executed_queries)
         return True
     else:
         return False
@@ -1015,7 +1015,7 @@ def main():
 
         if comment is not None:
             try:
-                changed = add_comment(cursor, user, comment) or changed
+                changed = add_comment(cursor, user, comment, module.check_mode) or changed
             except Exception as e:
                 module.fail_json(msg='Unable to add comment on role: %s' % to_native(e),
                                  exception=traceback.format_exc())

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_initial.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_initial.yml
@@ -135,7 +135,7 @@
 - assert:
     that:
     - result is changed
-    - result.queries == []
+    - result.queries == ["COMMENT ON EXTENSION \"postgis\" IS ''"]
 
 - name: Check the comment didn't change
   become_user: '{{ pg_user }}'

--- a/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
+++ b/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
@@ -148,6 +148,7 @@
   - assert:
       that:
       - result is changed
+      - result.queries == ["COMMENT ON PUBLICATION \"{{ test_pub }}\" IS 'Made by me'"]
 
   - name: Check the comment didn't change
     <<: *task_parameters
@@ -192,6 +193,7 @@
   - assert:
       that:
       - result is not changed
+      - result.queries == []
 
   # Test
   - name: postgresql_publication - drop publication, check_mode

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -119,6 +119,7 @@
   - assert:
       that:
       - result is changed
+      - result.queries == ["COMMENT ON SUBSCRIPTION \"test\" IS ''"]
 
   - name: Check the comment is the same
     <<: *task_parameters
@@ -166,6 +167,7 @@
   - assert:
       that:
       - result is not changed
+      - result.queries == []
 
   - name: Reset the comment again in check mode
     <<: *task_parameters
@@ -179,6 +181,7 @@
   - assert:
       that:
       - result is not changed
+      - result.queries == []
 
   ###################
   # Test mode: absent

--- a/tests/integration/targets/postgresql_tablespace/tasks/postgresql_tablespace_initial.yml
+++ b/tests/integration/targets/postgresql_tablespace/tasks/postgresql_tablespace_initial.yml
@@ -337,6 +337,7 @@
 - assert:
     that:
     - result is changed
+    - result.queries == ["COMMENT ON TABLESPACE \"acme\" IS 'Test comment 2'"]
 
 - name: Check the comment didn't change
   become_user: '{{ pg_user }}'

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -76,6 +76,7 @@
   - assert:
       that:
       - result is changed
+      - result.queries == ["COMMENT ON ROLE \"{{ test_user }}\" IS '{{ test_comment1 }}'"]
 
   - name: check the comment didn't change
     <<: *task_parameters
@@ -138,6 +139,7 @@
   - assert:
       that:
       - result is changed
+      - result.queries == ["COMMENT ON ROLE \"{{ test_user }}\" IS '{{ test_comment2 }}'"]
 
   - name: check the comment didn't change
     <<: *task_parameters


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.postgresql/issues/354

- W/o this change, it doesn't return the `COMMENT ON ..` query in executed queries in check mode
- This PR doesn't touch modules that does not return queries in check mode. If we want this, we should implement it separately
- Fragments are not needed