### PR TITLE
Sanity tests: fix SC2153 error

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -59,6 +59,7 @@ else
     retry pip install "https://github.com/ansible/ansible/archive/stable-${ansible_version}.tar.gz" --disable-pip-version-check
 fi
 
+# shellcheck disable=SC2153
 if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
     export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
     SHIPPABLE_RESULT_DIR="$(pwd)/shippable"


### PR DESCRIPTION
##### SUMMARY
Sanity tests: fix SC2153 error spotted by scheduled CI runs