### PR TITLE
Restore custom format as file insted of using stdin

### DIFF
--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -628,7 +628,7 @@ def db_restore(module, target, target_opts="",
         else:
             return p2.returncode, '', stderr2, 'cmd: ****'
     else:
-        if '--format=Directory' in cmd:
+        if any(substring in cmd for substring in ['--format=Directory', '--format=Custom']):
             cmd = '{0} {1}'.format(cmd, shlex_quote(target))
         else:
             cmd = '{0} < {1}'.format(cmd, shlex_quote(target))


### PR DESCRIPTION
##### SUMMARY
Changes restore logic to pass dump as file instead of using stdin if format=Custom this allows the use of the --jobs flag fixing #594 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module/postgresql_db.py

