### PR TITLE
fix(postgresql_ext): Reconnect before upgrade

### DIFF
--- a/changelogs/fragments/689-reconnect-before-upgrade.yml
+++ b/changelogs/fragments/689-reconnect-before-upgrade.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - postgresql_ext - Reconnect before upgrade to avoid accidental load of the upgraded extension
+    (https://github.com/ansible-collections/community.postgresql/pull/689).

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -469,6 +469,11 @@ def main():
                     else:
                         valid_update_path = ext_valid_update_path(cursor, ext, curr_version, real_version)
                         if valid_update_path:
+                            # Reconnect (required by some extensions like timescaledb)
+                            if not module.check_mode:
+                                db_connection.close()
+                                db_connection, dummy = connect_to_db(module, conn_params, autocommit=True)
+                                cursor = db_connection.cursor(**pg_cursor_args)
                             changed = ext_update_version(module.check_mode, cursor, ext, version)
                         else:
                             if version == 'latest':


### PR DESCRIPTION
##### SUMMARY

The TimescaleDB extension needs a fresh connection at upgrade because the extension might be accidentally loaded. The [upgrade procedure](https://docs.timescale.com/self-hosted/latest/upgrades/minor-upgrade/) recommends using the `-X` flag of psql to ignore `.psqlrc` file that might execute some queries and load the extension.

This commit reconnects before performing the extension upgrade to fix the following error:

```
Traceback (most recent call last):
  File "/tmp/ansible_community.postgresql.postgresql_ext_payload_yi1aki7a/ansible_community.postgresql.postgresql_ext_payload.zip/ansible_collections/community/postgresql/plugins/modules/postgresql_ext.py", line 428, in main
  File "/tmp/ansible_community.postgresql.postgresql_ext_payload_yi1aki7a/ansible_community.postgresql.postgresql_ext_payload.zip/ansible_collections/community/postgresql/plugins/modules/postgresql_ext.py", line 246, in ext_update_version
  File "/usr/lib/python3/dist-packages/psycopg2/extras.py", line 146, in execute
    return super().execute(query, vars)
psycopg2.errors.FeatureNotSupported: extension "timescaledb" cannot be updated after the old version has already been loaded
HINT:  Start a new session and execute ALTER EXTENSION as the first command. Make sure to pass the "-X" flag to psql.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_ext