### PR TITLE
postgresql_privs: fix can't revoke functions from user

### DIFF
--- a/changelogs/fragments/690-revoke-functions-from-user.yaml
+++ b/changelogs/fragments/690-revoke-functions-from-user.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - postgresql_privs - could not revoke functions from user with ``community.postgresql.postgresql_privs``. This fix now enables ability to revoke functions from user (https://github.com/ansible-collections/community.postgresql/issues/687).
+  - postgresql_privs - Enables the ability to revoke functions from user (https://github.com/ansible-collections/community.postgresql/issues/687).

--- a/changelogs/fragments/690-revoke-functions-from-user.yaml
+++ b/changelogs/fragments/690-revoke-functions-from-user.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_privs - could not revoke functions from user with ``community.postgresql.postgresql_privs``. This fix now enables ability to revoke functions from user (https://github.com/ansible-collections/community.postgresql/issues/687).

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -972,7 +972,7 @@ class QueryBuilder(object):
     def build_absent(self):
         if self._obj_type == 'default_privs':
             self.query = []
-            for obj in ['TABLES', 'SEQUENCES', 'TYPES']:
+            for obj in ['TABLES', 'FUNCTIONS', 'SEQUENCES', 'TYPES']:
                 if self._as_who:
                     self.query.append(
                         'ALTER DEFAULT PRIVILEGES FOR ROLE {0}{1} REVOKE ALL ON {2} FROM {3};'.format(self._as_who,


### PR DESCRIPTION
##### SUMMARY
This PR enables ability to revoke functions from user with community.postgresql.postgresql_privs.

Fixes #687.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: postgresql_privs
