### PR TITLE
postgresql_idx: consider schema name when checking

### DIFF
--- a/changelogs/fragments/693-idx-consider-schema.yaml
+++ b/changelogs/fragments/693-idx-consider-schema.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_idx - consider schema name when checking for index (https://github.com/ansible-collections/community.postgresql/issues/692).  Index names are only unique within a schema. This allows using the same index name in multiple schemas.

--- a/plugins/modules/postgresql_idx.py
+++ b/plugins/modules/postgresql_idx.py
@@ -344,9 +344,10 @@ class Index(object):
                  "ON i.indexname = c.relname "
                  "JOIN pg_catalog.pg_index AS pi "
                  "ON c.oid = pi.indexrelid "
-                 "WHERE i.indexname = %(name)s")
+                 "WHERE i.schemaname = %(schema)s "
+                 "AND i.indexname = %(name)s")
 
-        res = exec_sql(self, query, query_params={'name': self.name}, add_to_executed=False)
+        res = exec_sql(self, query, query_params={'schema': self.schema, 'name': self.name}, add_to_executed=False)
         if res:
             self.exists = True
             self.info = dict(


### PR DESCRIPTION
##### SUMMARY
When checking to see if an index exists, the schema name needs to be taken into account.  That is, the same name can exist in multiple schemas.

Fixes #692

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.postgresql_idx