### PR TITLE
fix: enforce iso datestyle

### DIFF
--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -151,6 +151,16 @@ def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
             finally:
                 cursor.close()
 
+        # Ensure proper datestyle, only supported in psycopg 3
+        if PSYCOPG_VERSION >= LooseVersion("3.0"):
+            cursor = db_connection.cursor(row_factory=psycopg.rows.dict_row)
+            try:
+                cursor.execute('SET datestyle TO iso')
+            except Exception as e:
+                module.fail_json(msg="Could not set date style: %s" % to_native(e))
+            finally:
+                cursor.close()
+
     except TypeError as e:
         if 'sslrootcert' in e.args[0]:
             module.fail_json(msg='Postgresql server must be at least '


### PR DESCRIPTION
##### SUMMARY
Fixes #711 by enforcing iso datestyle on the connection. This is only an issue when using psycopg3 in combination with datestyles that it doesn't support. Going by the docs, psycopg2 already does this when encountering a datestyle it doesn't recognize

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`postgres.py`
