### PR TITLE
refactor(all): remove references to CentOS 7

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -162,8 +162,6 @@ stages:
         parameters:
           testFormat: 2.16/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 38
               test: fedora38
             - name: Ubuntu 20.04
@@ -179,8 +177,6 @@ stages:
         parameters:
           testFormat: 2.15/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 37
               test: fedora37
             - name: Ubuntu 20.04
@@ -196,8 +192,6 @@ stages:
         parameters:
           testFormat: 2.14/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Ubuntu 20.04
               test: ubuntu2004
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -111,18 +111,6 @@ stages:
             - name: Units
               test: '2.15/units/1'
 
-  - stage: Ansible_2_14
-    displayName: Sanity & Units 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.14/sanity/1'
-            - name: Units
-              test: '2.14/units/1'
-
 ## Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -184,17 +172,6 @@ stages:
             - name: Ubuntu 22.04
               test: ubuntu2204
 
-  - stage: Docker_2_14
-    displayName: Docker 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/linux/{0}/1
-          targets:
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-
 ## Remote
   - stage: Remote_devel
     displayName: Remote devel
@@ -240,17 +217,6 @@ stages:
             - name: RHEL 8.7
               test: rhel/8.7
 
-  - stage: Remote_2_14
-    displayName: Remote 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}/1
-          targets:
-            - name: RHEL 8.6
-              test: rhel/8.6
-
 ## Finally
 
   - stage: Summary
@@ -260,16 +226,13 @@ stages:
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
-      - Ansible_2_14
       - Docker_devel
       - Docker_2_17
       - Docker_2_16
       - Docker_2_15
-      - Docker_2_14
       - Remote_devel
       - Remote_2_17
       - Remote_2_16
       - Remote_2_15
-      - Remote_2_14
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 
 | Docker image | Psycopg version | PostgreSQL version |
 |--------------|-----------------|--------------------|
-| CentOS 7     |           2.5.1 |                9.2 |
 | RHEL 8       |           2.7.5 |               10   |
 | Fedora 37    |           2.9.6 |               14   |
 | Fedora 38    |           2.9.6 |               15   |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Here is the table for the support timeline:
 ## Tested with ansible-core
 
 Tested with the following `ansible-core` releases:
-- 2.14
 - 2.15
 - 2.16
 - 2.17

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,13 +21,9 @@ matrix:
 
     - env: T=2.9/units/1
 
-    - env: T=devel/rhel/7.8/1
     - env: T=devel/rhel/8.2/1
     - env: T=devel/freebsd/11.1/1
     - env: T=devel/freebsd/12.1/1
-    - env: T=devel/linux/centos6/1
-    - env: T=devel/linux/centos7/1
-    #- env: T=devel/linux/centos8/1
     - env: T=devel/linux/fedora33/1
     #- env: T=devel/linux/fedora34/1
     #- env: T=devel/linux/opensuse15py2/1

--- a/tests/integration/targets/postgresql_info/tasks/main.yml
+++ b/tests/integration/targets/postgresql_info/tasks/main.yml
@@ -5,10 +5,6 @@
 
 # For testing getting publication and subscription info
 - import_tasks: setup_publication.yml
-  when:
-    - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support logical replication
 
 # Initial CI tests of postgresql_info module
 - import_tasks: postgresql_info_initial.yml
-  when:
-    - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support logical replication

--- a/tests/integration/targets/postgresql_slot/tasks/postgresql_slot_initial.yml
+++ b/tests/integration/targets/postgresql_slot/tasks/postgresql_slot_initial.yml
@@ -20,19 +20,11 @@
     name: wal_level
     value: logical
 
-# To avoid CI timeouts
-- name: Kill all postgres processes
-  shell: 'pkill -u {{ pg_user }}'
-  become: true
-  when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
-  ignore_errors: true
-
 - name: postgresql_slot - stop PostgreSQL
   become: true
   service:
     name: "{{ postgresql_service }}"
     state: stopped
-  when: (ansible_facts.distribution_major_version != '8' and ansible_facts.distribution == 'CentOS') or ansible_facts.distribution != 'CentOS'
 
 - name: postgresql_slot - pause between stop and start PostgreSQL
   ansible.builtin.pause:

--- a/tests/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/main.yml
@@ -6,9 +6,5 @@
 # Initial tests of postgresql_subscription module:
 
 - import_tasks: setup_publication.yml
-  when:
-    - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support logical replication
 
 - import_tasks: postgresql_subscription_initial.yml
-  when:
-    - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support logical replication

--- a/tests/integration/targets/postgresql_user_obj_stat_info/tasks/postgresql_user_obj_stat_info.yml
+++ b/tests/integration/targets/postgresql_user_obj_stat_info/tasks/postgresql_user_obj_stat_info.yml
@@ -61,19 +61,11 @@
       name: track_functions
       value: all
 
-  # To avoid CI timeouts
-  - name: Kill all postgres processes
-    shell: 'pkill -u {{ pg_user }}'
-    become: true
-    when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
-    ignore_errors: true
-
   - name: Stop PostgreSQL
     become: true
     service:
       name: "{{ postgresql_service }}"
       state: stopped
-    when: (ansible_facts.distribution_major_version != '8' and ansible_facts.distribution == 'CentOS') or ansible_facts.distribution != 'CentOS'
 
   - name: Pause between stop and start PostgreSQL
     pause:

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -36,12 +36,6 @@
     state: started
   when: ansible_service_mgr == 'systemd' and ansible_distribution == 'Fedora'
 
-- name: Kill all postgres processes
-  shell: 'pkill -u {{ pg_user }}'
-  become: true
-  when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
-  ignore_errors: true
-
 - name: stop postgresql service
   service: name={{ postgresql_service }} state=stopped
   ignore_errors: true
@@ -201,13 +195,6 @@
   pause:
     seconds: 5
 
-- name: Kill all postgres processes
-  shell: 'pkill -u {{ pg_user }}'
-  become: true
-  when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
-  ignore_errors: true
-  register: terminate
-
 - name: Stop postgresql service
   service: name={{ postgresql_service }} state=stopped
 
@@ -218,7 +205,6 @@
     line: 'wal_level = logical'
   when:
     - replica_db_required is defined and replica_db_required
-    - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support 'logical'
 
 - name: Pause between stop and start
   pause:
@@ -292,7 +278,6 @@
 - import_tasks: replica.yml
   when:
     - replica_db_required is defined and replica_db_required
-    - ansible_distribution_major_version != "7"  # CentOS 7 with Postgres 9.2 doesn't support 'logical'
 
 # Create an SQL_ASCII encoded database
 - import_tasks: sql_ascii.yml


### PR DESCRIPTION
fixes #717 

Remove all references to CentOS 7 and RHEL 7, since both are EOL now. Additionally remove `when` conditions that are no longer needed w/ the death of CentOS 7.