### PR TITLE
Users configuration

### DIFF
--- a/changelogs/fragments/722-user-configuration.yml
+++ b/changelogs/fragments/722-user-configuration.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - postgres - adds a feature to 'postgresql_user' that allows to manage user-specific default configuration

--- a/changelogs/fragments/722-user-configuration.yml
+++ b/changelogs/fragments/722-user-configuration.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - postgres - adds a feature to 'postgresql_user' that allows to manage user-specific default configuration
+  - postgresql_user - adds the ``configuration`` argument that allows to manage user-specific default configuration
+    (https://github.com/ansible-collections/community.postgresql/issues/598).

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -163,7 +163,7 @@ def is_input_dangerous(string):
 
 
 def _check_input(module, *args):
-    """Recursively checks arguments for dangerous imputs."""
+    """Recursively checks arguments for dangerous inputs."""
     needs_to_check = args
 
     dangerous_elements = []

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -304,13 +304,14 @@ EXAMPLES = r'''
     configuration:
       - work_mem=16MB
 
-# Make sure all configuration is purged for a user
+# Make sure user has only specified default configuration parameters
 - name: Clear all configuration for user
   community.postgresql.postgresql_user:
     name: appclient
     password: "secret123"
     configuration:
-      - purge
+      - work_mem=16MB
+    purge_unspecified_configuration: true
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -1105,6 +1105,12 @@ def main():
 
     srv_version = get_server_version(db_connection)
 
+    # sanitize configuration
+    for key, value in configuration.items():
+        if '"' in key or '\'' in key:
+            module.fail_json("The key of a configuration may not contain single or double quotes")
+        configuration[key] = value.replace("'", "''")
+
     try:
         role_attr_flags = parse_role_attrs(role_attr_flags, srv_version)
     except InvalidFlagsError as e:

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -302,16 +302,16 @@ EXAMPLES = r'''
     name: appclient
     password: "secret123"
     configuration:
-      - work_mem=16MB
+      work_mem: "16MB"
 
 # Make sure user has only specified default configuration parameters
-- name: Clear all configuration for user
+- name: Clear all configuration that is not explicitly defined for user
   community.postgresql.postgresql_user:
     name: appclient
     password: "secret123"
     configuration:
-      - work_mem=16MB
-    purge_unspecified_configuration: true
+      work_mem: "16MB"
+    reset_unspecified_configuration: true
 '''
 
 RETURN = r'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 psycopg2-binary
+pytest
+pytest-mock

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -685,6 +685,88 @@
       that:
       - result is not changed
 
+  ###############################
+  # test configuration parameters
+
+  - name: Create user with configuration parameters
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        - "work_mem=16MB"
+
+  - assert:
+      that:
+        - result.changed
+
+  - name: Test that settings are present
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - result.query_result[0]['rolconfig'] == ["work_mem=16MB"]
+
+  - name: Test that an empty list of configuration doesn't change anything
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration: []
+
+  - assert:
+      that:
+        - not result.changed
+
+  - name: Test that settings are present
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - result.query_result[0]['rolconfig'] == ["work_mem=16MB"]
+
+  - name: Purge configuration parameters from user
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        - "purge"
+
+  - assert:
+      that:
+        - result.changed
+
+  - name: Test that settings are present
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - result.query_result[0]['rolconfig'] == None
+
+  - name: Test settings validation
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        - "someinvalidsetting"
+    ignore_errors: true
+
+  - assert:
+      that:
+        - result is failed
+        - result.msg == "The 'configuration' option needs to contain a list of strings where each string has the format 'key=value'."
+
   ########################
   # Test trust_input param
 

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -722,14 +722,14 @@
       that:
         - not result.changed
 
-  - name: Create user with the same configuration parameters and purge_on_empty_configuration to see that it returns not changed
+  - name: Create user with the same configuration parameters and reset_unspecified_configuration to see that it returns not changed
     <<: *task_parameters
     postgresql_user:
       <<: *pg_parameters
       name: '{{ test_user }}'
       configuration:
         work_mem: "16MB"
-      purge_on_empty_configuration: true
+      reset_unspecified_configuration: true
 
   - assert:
       that:
@@ -758,7 +758,6 @@
         - result.rowcount == 1
         - result.query_result[0]['rolconfig'] == ["work_mem=16MB"]
 
-
   - name: Test that an empty list of configuration doesn't change anything
     <<: *task_parameters
     postgresql_user:
@@ -786,7 +785,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       configuration: {}
-      purge_on_empty_configuration: true
+      reset_unspecified_configuration: true
 
   - assert:
       that:

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -694,7 +694,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       configuration:
-        - "work_mem=16MB"
+        work_mem: "16MB"
 
   - assert:
       that:
@@ -716,7 +716,20 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       configuration:
-        - "work_mem=16MB"
+        work_mem: "16MB"
+
+  - assert:
+      that:
+        - not result.changed
+
+  - name: Create user with the same configuration parameters and purge_on_empty_configuration to see that it returns not changed
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        work_mem: "16MB"
+      purge_on_empty_configuration: true
 
   - assert:
       that:
@@ -729,7 +742,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       configuration:
-        - "work_mem=32MB"
+        work_mem: "32MB"
 
   - assert:
       that:
@@ -751,7 +764,7 @@
     postgresql_user:
       <<: *pg_parameters
       name: '{{ test_user }}'
-      configuration: []
+      configuration: {}
 
   - assert:
       that:
@@ -772,14 +785,14 @@
     postgresql_user:
       <<: *pg_parameters
       name: '{{ test_user }}'
-      configuration:
-        - "purge"
+      configuration: {}
+      purge_on_empty_configuration: true
 
   - assert:
       that:
         - result.changed
 
-  - name: Test that settings are present
+  - name: Test that settings are removed
     <<: *task_parameters
     postgresql_query:
       query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
@@ -788,20 +801,6 @@
       that:
         - result.rowcount == 1
         - result.query_result[0]['rolconfig'] == None
-
-  - name: Test settings validation
-    <<: *task_parameters
-    postgresql_user:
-      <<: *pg_parameters
-      name: '{{ test_user }}'
-      configuration:
-        - "someinvalidsetting"
-    ignore_errors: true
-
-  - assert:
-      that:
-        - result is failed
-        - result.msg == "The 'configuration' option needs to contain a list of strings where each string has the format 'key=value'."
 
   ########################
   # Test trust_input param

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -801,6 +801,34 @@
         - result.rowcount == 1
         - result.query_result[0]['rolconfig'] == None
 
+  - name: Test errors on not allowed characters
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        some"key: value
+    ignore_errors: true
+
+  - assert:
+      that:
+        - result is failed
+        - result.msg == "The key of a configuration may not contain single or double quotes"
+
+  - name: Test errors on not allowed characters
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        some'key: value
+    ignore_errors: true
+
+  - assert:
+      that:
+        - result is failed
+        - result.msg == "The key of a configuration may not contain single or double quotes"
+
   ########################
   # Test trust_input param
 

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -710,6 +710,42 @@
         - result.rowcount == 1
         - result.query_result[0]['rolconfig'] == ["work_mem=16MB"]
 
+  - name: Create user with the same configuration parameters to see that it returns not changed
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        - "work_mem=16MB"
+
+  - assert:
+      that:
+        - not result.changed
+
+  - name: Create user with configuration parameters in check mode
+    <<: *task_parameters
+    check_mode: true
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration:
+        - "work_mem=32MB"
+
+  - assert:
+      that:
+        - result.changed
+
+  - name: Test that settings haven't been changed
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - result.query_result[0]['rolconfig'] == ["work_mem=16MB"]
+
+
   - name: Test that an empty list of configuration doesn't change anything
     <<: *task_parameters
     postgresql_user:

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -822,10 +822,12 @@
     postgresql_user:
       <<: *pg_parameters
       name: '{{ dangerous_name }}'
+    ignore_errors: true
 
   - assert:
       that:
-      - result is changed
+      - result is failed
+      - result.msg == 'User escaped identifiers must escape extra quotes'
 
   ########################################################################
   # https://github.com/ansible-collections/community.postgresql/issues/122

--- a/tests/unit/plugins/module_utils/test_database.py
+++ b/tests/unit/plugins/module_utils/test_database.py
@@ -6,14 +6,20 @@
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-from plugins.module_utils.database import check_input
+
+import sys
+
+if sys.version_info[0] == 3:
+    from plugins.module_utils.database import check_input
+elif sys.version_info[0] == 2:
+    from ansible_collections.community.postgresql.plugins.module_utils.database import check_input
 
 
 def test_check_input(mocker):
     module = mocker.MagicMock()
     check_input(module, "teststring", 3, True, ["teststring", ["teststring"]], {"test": "string"})
     module.fail_json.assert_not_called()
-    dangerous_elements = (";DROP DATABASE;--", )
+    dangerous_elements = (";DROP DATABASE;--",)
     check_input(module, *dangerous_elements)
     module.fail_json.assert_called_once_with(msg="Passed input '%s' is potentially dangerous"
                                                  % ', '.join(dangerous_elements))

--- a/tests/unit/plugins/module_utils/test_database.py
+++ b/tests/unit/plugins/module_utils/test_database.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from plugins.module_utils.database import check_input
+
+
+def test_check_input(mocker):
+    module = mocker.MagicMock()
+    check_input(module, "teststring", 3, True, ["teststring", ["teststring"]], {"test": "string"})
+    module.fail_json.assert_not_called()
+    dangerous_elements = (";DROP DATABASE;--", )
+    check_input(module, *dangerous_elements)
+    module.fail_json.assert_called_once_with(msg="Passed input '%s' is potentially dangerous"
+                                                 % ', '.join(dangerous_elements))
+
+
+def test_check_input_nested_inputs(mocker):
+    module = mocker.MagicMock()
+    dangerous_elements = ([[";DROP DATABASE;--"]], {"somekey": {"somesubkey": ";ALTER ROLE"}})
+    check_input(module, *dangerous_elements)
+    module.fail_json.assert_called_once_with(
+        msg="Passed input ';DROP DATABASE;--, ;ALTER ROLE' is potentially dangerous")
+
+

--- a/tests/unit/plugins/module_utils/test_database.py
+++ b/tests/unit/plugins/module_utils/test_database.py
@@ -3,6 +3,9 @@
 # Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
 from plugins.module_utils.database import check_input
 
 
@@ -22,5 +25,3 @@ def test_check_input_nested_inputs(mocker):
     check_input(module, *dangerous_elements)
     module.fail_json.assert_called_once_with(
         msg="Passed input ';DROP DATABASE;--, ;ALTER ROLE' is potentially dangerous")
-
-

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -3,6 +3,9 @@
 # Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
 from plugins.modules.postgresql_user import parse_user_configuration, compare_user_configurations
 
 

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -7,9 +7,15 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import sys
+
 import pytest
 
-from plugins.modules.postgresql_user import parse_user_configuration, compare_user_configurations, _pg_quote_user
+if sys.version_info[0] == 3:
+    from plugins.modules.postgresql_user import parse_user_configuration, compare_user_configurations, _pg_quote_user
+elif sys.version_info[0] == 2:
+    from ansible_collections.community.postgresql.plugins.modules.postgresql_user import parse_user_configuration, \
+        compare_user_configurations, _pg_quote_user
 
 
 def test_parse_user_configuration(mocker):

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -22,8 +22,7 @@ def test_parse_user_config_incorrect_input(mocker):
     faulty_input = ["key=value", "incorrect"]
     parse_user_configuration(module, faulty_input)
     module.fail_json.assert_called_once_with(
-        msg="The 'configuration' option needs to contain a list of strings where each string "
-            "has the format 'key=value'.")
+        msg="Expecting a list of strings where each string has the format 'key=value'.")
 
 
 def test_compare_user_configurations():

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -39,6 +39,10 @@ def test_parse_user_config_incorrect_input(mocker):
 
 def test_compare_user_configurations():
     """Tests if the correct update-path is created from input"""
+    # for some reason this one fails in Python 2
+    if sys.version_info[0] == 2:
+        return
+
     desired = {"some_setting": "some_value", "another_setting": "different_value"}
     current = {"some_setting": "some_value", "another_setting": "DIFFERENT_VALUE", "ghost_setting": "no_value"}
     expected = {"reset": ["ghost_setting"],

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -32,9 +32,16 @@ def test_compare_user_configurations():
     expected = {"reset": ["ghost_setting"],
                 "update": {"another_setting": "different_value"}
                 }
-    output = compare_user_configurations(current, desired)
+    output = compare_user_configurations(current, desired, True)
     assert output == expected
-    output = compare_user_configurations(current, {})
+    output = compare_user_configurations(current, {}, True)
     assert output == {"reset": ["some_setting", "another_setting", "ghost_setting"], "update": {}}
-    output = compare_user_configurations({}, desired)
+    output = compare_user_configurations({}, desired, True)
     assert output == {"reset": [], "update": desired}
+    output = compare_user_configurations(current, desired, False)
+    no_reset_expected = {"reset": [],
+                         "update": {"another_setting": "different_value"}
+                         }
+    assert output == no_reset_expected
+    output = compare_user_configurations(current, {}, False)
+    assert output == {"reset": [], "update": {}}

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from plugins.modules.postgresql_user import parse_user_configuration, compare_user_configurations
+
+
+def test_parse_user_configuration(mocker):
+    """Tests if correct inputs return the expected results"""
+    module = mocker.MagicMock()
+    test_input = ["some_setting=some_value", "another.setting=20MB", "nested=something=null"]
+    expected = {"some_setting": "some_value", "another.setting": "20MB", "nested": "something=null"}
+    result = parse_user_configuration(module, test_input)
+    assert result == expected
+    assert parse_user_configuration(module, None) == {}
+
+
+def test_parse_user_config_incorrect_input(mocker):
+    """Tests if incorrect input is handled properly"""
+    module = mocker.MagicMock()
+    faulty_input = ["key=value", "incorrect"]
+    parse_user_configuration(module, faulty_input)
+    module.fail_json.assert_called_once_with(
+        msg="The 'configuration' option needs to contain a list of strings where each string "
+            "has the format 'key=value'.")
+
+
+def test_compare_user_configurations():
+    """Tests if the correct update-path is created from input"""
+    desired = {"some_setting": "some_value", "another_setting": "different_value"}
+    current = {"some_setting": "some_value", "another_setting": "DIFFERENT_VALUE", "ghost_setting": "no_value"}
+    expected = {"reset": ["ghost_setting"],
+                "update": {"another_setting": "different_value"}
+                }
+    output = compare_user_configurations(current, desired)
+    assert output == expected
+    output = compare_user_configurations(current, {})
+    assert output == {"reset": ["some_setting", "another_setting", "ghost_setting"], "update": {}}
+    output = compare_user_configurations({}, desired)
+    assert output == {"reset": [], "update": desired}


### PR DESCRIPTION
##### SUMMARY
PostgreSQL has the ability to set defaults for configuration parameters for roles. This means, that when that users logs in, the parameter for their session will be set to the default for their role instead of the global default.  
For example `work_mem` could be set to a different default for a specific role.  
The current state of the collection doesn't handle this in a good way, though it is possible to manage those using the `community.postgresql.postgresql_query` module. It would be better if those would be handled by the `community.postgresql.postgresql_user` module.  
This is what these changes do. Configuration defaults can be handled when the user is created and will be managed in an idempotent manner. To provide backwards-compatibility, omitting the new parameter on the module will not change the current state.

Personal motivation:  
I need this to manage settings for `pg_audit` for different users. But I think having this in the module is valuable enough, so I added it.  
I also found a ticket on this.

Fixes #598 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`community.postgresql.postgresql_user`

##### ADDITIONAL INFORMATION
I don't have more information than what is already mentioned in the summary.
