### PR TITLE
Support grants and revokes on foreign tables

### DIFF
--- a/changelogs/fragments/725-privs-for-foreign-tables.yml
+++ b/changelogs/fragments/725-privs-for-foreign-tables.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - postgresql_privs - adds support for granting and revoking privileges on foreign tables 
+    (https://github.com/ansible-collections/community.postgresql/issues/724).

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -549,11 +549,11 @@ class Connection(object):
             query = """SELECT relname
                        FROM pg_catalog.pg_class c
                        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                       WHERE nspname = %s AND relkind in ('r', 'v', 'm', 'p')"""
+                       WHERE nspname = %s AND relkind in ('r', 'v', 'm', 'p', 'f')"""
             self.execute(query, (schema,))
         else:
             query = ("SELECT relname FROM pg_catalog.pg_class "
-                     "WHERE relkind in ('r', 'v', 'm', 'p')")
+                     "WHERE relkind in ('r', 'v', 'm', 'p', 'f')")
             self.execute(query)
         return [t["relname"] for t in self.cursor.fetchall()]
 
@@ -621,12 +621,12 @@ class Connection(object):
             query = """SELECT relacl::text
                        FROM pg_catalog.pg_class c
                        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                       WHERE nspname = %s AND relkind in ('r','p','v','m') AND relname = ANY (%s)
+                       WHERE nspname = %s AND relkind in ('r','p','v','m','f') AND relname = ANY (%s)
                        ORDER BY relname"""
             self.execute(query, (schema, tables))
         else:
             query = ("SELECT relacl::text FROM pg_catalog.pg_class "
-                     "WHERE relkind in ('r','p','v','m') AND relname = ANY (%s) "
+                     "WHERE relkind in ('r','p','v','m','f') AND relname = ANY (%s) "
                      "ORDER BY relname")
             self.execute(query)
         return [t["relacl"] for t in self.cursor.fetchall()]

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -47,7 +47,7 @@ options:
     - The C(type) choice is available since Ansible version 2.10.
     - The C(procedure) is supported since collection version 1.3.0 and PostgreSQL 11.
     - The C(parameter) is supported since collection version 3.1.0 and PostgreSQL 15.
-    - The C(table) is inclusive of foreign tables since colleciton version 3.6.0
+    - The C(table) is inclusive of foreign tables since collection version 3.6.0
     type: str
     default: table
     choices: [ database, default_privs, foreign_data_wrapper, foreign_server, function,

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -47,6 +47,7 @@ options:
     - The C(type) choice is available since Ansible version 2.10.
     - The C(procedure) is supported since collection version 1.3.0 and PostgreSQL 11.
     - The C(parameter) is supported since collection version 3.1.0 and PostgreSQL 15.
+    - The C(table) is inclusive of foreign tables since colleciton version 3.6.0
     type: str
     default: table
     choices: [ database, default_privs, foreign_data_wrapper, foreign_server, function,

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -47,7 +47,7 @@ options:
     - The C(type) choice is available since Ansible version 2.10.
     - The C(procedure) is supported since collection version 1.3.0 and PostgreSQL 11.
     - The C(parameter) is supported since collection version 3.1.0 and PostgreSQL 15.
-    - The C(table) is inclusive of foreign tables since collection version 3.6.0
+    - The C(table) is inclusive of foreign tables since collection version 3.6.0.
     type: str
     default: table
     choices: [ database, default_privs, foreign_data_wrapper, foreign_server, function,

--- a/tests/integration/targets/postgresql_privs/tasks/main.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/main.yml
@@ -17,3 +17,7 @@
 # Tests default_privs with target_role:
 - include_tasks: test_target_role.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')
+
+# Tests involving foreign tables:
+- include_tasks: postgresql_privs_foreign_tables.yml
+  when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_foreign_tables.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_foreign_tables.yml
@@ -1,0 +1,111 @@
+#
+# Test settings privileges for foreign tables
+#
+- name: Create db
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_db:
+    name: "{{ db_name }}"
+    state: "present"
+    login_user: "{{ pg_user }}"
+
+- name: Create some tables on the db
+  become_user: "{{ pg_user }}"
+  become: true
+  shell: echo "create table test_table1 (field text);" | psql {{ db_name }}
+
+- vars:
+    db_password: 'secretù' # use UTF-8
+  block:
+    - name: Create a user with some permissions on the db
+      become_user: "{{ pg_user }}"
+      become: true
+      postgresql_user:
+        name: "{{ db_user1 }}"
+        encrypted: 'true'
+        password: "md5{{ (db_password ~ db_user1) | hash('md5')}}"
+        db: "{{ db_name }}"
+        login_user: "{{ pg_user }}"
+
+- name: Install foreign data wrapper extension
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_query:
+    login_db: "{{ db_name }}"
+    query: "CREATE EXTENSION IF NOT EXISTS postgres_fdw"
+
+- name: Create foreign server
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_query:
+    login_db: "{{ db_name }}"
+    query: "CREATE SERVER IF NOT EXISTS self FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost',dbname '{{ db_name }}')"
+
+- name: Create user mapping
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_query:
+    login_db: "{{ db_name }}"
+    query: "CREATE USER MAPPING IF NOT EXISTS FOR CURRENT_USER SERVER self OPTIONS (user '{{ pg_user }}')"
+
+- name: Create foreign table
+  become: yes
+  become_user: "{{ pg_user }}"
+  postgresql_query:
+    login_db: "{{ db_name }}"
+    query: "CREATE FOREIGN TABLE IF NOT EXISTS foreign_table1 (field text) SERVER self OPTIONS (table_name 'test_table1')"
+
+- name: Grant a single privilege on foreign table
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_privs:
+    state: "present"
+    roles: "{{ db_user1 }}"
+    privs: "INSERT"
+    objs: "foreign_table1"
+    login_db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+    trust_input: false
+
+- name: Check that permissions were added (foreign_table1)
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_query:
+    login_db: '{{ db_name }}'
+    query: "select privilege_type from information_schema.role_table_grants where grantee='{{ db_user1 }}' and table_name='foreign_table1'"
+  register: result_table1
+
+- assert:
+    that:
+      - result_table1.rowcount == 1
+      - result_table1.query_result[0]['privilege_type'] == 'INSERT'
+
+- name: Revoke privileges on foreign table
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_privs:
+    state: "absent"
+    roles: "{{ db_user1 }}"
+    privs: "INSERT"
+    objs: "foreign_table1"
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+    trust_input: false
+  register: result
+
+- name: Check that ansible reports it changed the user
+  assert:
+    that:
+      - result is changed
+
+- name: Check that permissions were revoked (foreign_table1)
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_query:
+    login_db: '{{ db_name }}'
+    query: "select privilege_type from information_schema.role_table_grants where grantee='{{ db_user1 }}' and table_name='foreign_table1'"
+  register: result_table1
+
+- assert:
+    that:
+      - result_table1.rowcount == 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #724 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`postgresql_privs`

##### ADDITIONAL INFORMATION
See #724 for reproduction steps and the nature of the issue. The fix is straight-forward, we simply need to include `relkind='f'` in our acls check in order for foreign tables to be considered by the privs module