### PR TITLE
Handles subscriptions when subconninfo column is unavailable

### DIFF
--- a/changelogs/fragments/727-subscriptions-with-limited-columns.yml
+++ b/changelogs/fragments/727-subscriptions-with-limited-columns.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - postgresql_subscription - adds support for managing subscriptions in the situation
+    where the ``subconninfo`` column is unavailable (such as in CloudSQL)
+    (https://github.com/ansible-collections/community.postgresql/issues/726).

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -62,6 +62,7 @@ options:
     - The connection dict param-value to connect to the publisher.
     - For more information see U(https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
     - Ignored when I(state) is not C(present).
+    - Ignored when an existing subscription's connection parameters are not available from the server (such as in CloudSQL).
     type: dict
   cascade:
     description:
@@ -748,7 +749,7 @@ def main():
                                               subsparams,
                                               check_mode=module.check_mode)
             else:
-                module.warn("'connparams' is ignored when existing subscription connparms are unknowable")
+                module.warn("'connparams' is ignored because pg_subscription.subconninfo is not accessible in your instance.")
                 changed = subscription.update(False,
                                               publications,
                                               subsparams,

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -595,14 +595,13 @@ class PgSubscription():
         columns_result = exec_sql(self, columns_sub_table, query_params={'name': self.name, 'db': self.db}, add_to_executed=False)
         columns = ", ".join(["s.%s" % column['column_name'] for column in columns_result])
         query = ("SELECT obj_description(s.oid, 'pg_subscription') AS comment, "
-                 "d.datname, r.rolname,"
-                 "%(columns)s "
+                 "d.datname, r.rolname," + columns + " "
                  "FROM pg_catalog.pg_subscription s "
                  "JOIN pg_catalog.pg_database d "
                  "ON s.subdbid = d.oid "
                  "JOIN pg_catalog.pg_roles AS r "
                  "ON s.subowner = r.oid "
-                 "WHERE s.subname = '%(name)s' AND d.datname = '%(db)s'" % {'columns': columns, 'name': self.name, 'db': self.db})
+                 "WHERE s.subname = %(name)s AND d.datname = %(db)s")
 
         result = exec_sql(self, query, query_params={'name': self.name, 'db': self.db}, add_to_executed=False)
         if result:

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -739,7 +739,7 @@ def main():
                                           check_mode=module.check_mode)
 
         else:
-            if hasattr(subscription, 'connparams'):
+            if subscription.attrs['conninfo'] != {}:
                 if connparams:
                     connparams = cast_connparams(connparams)
 

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -591,7 +591,7 @@ class PgSubscription():
                              "WHERE table_schema = 'pg_catalog' "
                              "AND table_name = 'pg_subscription'"
                              "AND column_name IN ('subenabled','subconninfo','subslotname','subsynccommit','subpublications')")
-        columns_result = exec_sql(self,columns_sub_table,query_params={'name': self.name, 'db': self.db}, add_to_executed=False)
+        columns_result = exec_sql(self, columns_sub_table, query_params={'name': self.name, 'db': self.db}, add_to_executed=False)
         columns = ", ".join(["s.%s" % column['column_name'] for column in columns_result])
         query = ("SELECT obj_description(s.oid, 'pg_subscription') AS comment, "
                  "d.datname, r.rolname,"
@@ -739,20 +739,20 @@ def main():
                                           check_mode=module.check_mode)
 
         else:
-            if hasattr(subscription,'connparams'):
+            if hasattr(subscription, 'connparams'):
                 if connparams:
                     connparams = cast_connparams(connparams)
 
                 changed = subscription.update(connparams,
-                                            publications,
-                                            subsparams,
-                                            check_mode=module.check_mode)
+                                              publications,
+                                              subsparams,
+                                              check_mode=module.check_mode)
             else:
                 module.warn("'connparams' is ignored when existing subscription connparms are unknowable")
                 changed = subscription.update(False,
-                                            publications,
-                                            subsparams,
-                                            check_mode=module.check_mode)
+                                              publications,
+                                              subsparams,
+                                              check_mode=module.check_mode)
 
         if owner and subscription.attrs['owner'] != owner:
             changed = subscription.set_owner(owner, check_mode=module.check_mode) or changed

--- a/tests/integration/targets/postgresql_subscription/defaults/main.yml
+++ b/tests/integration/targets/postgresql_subscription/defaults/main.yml
@@ -1,4 +1,5 @@
 pg_user: postgres
+pg_limited_user: postgres_limited
 db_default: postgres
 
 test_table1: acme1

--- a/tests/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/main.yml
@@ -8,3 +8,5 @@
 - import_tasks: setup_publication.yml
 
 - import_tasks: postgresql_subscription_initial.yml
+
+- import_tasks: postgresql_subscription_limited_role.yml

--- a/tests/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/main.yml
@@ -10,3 +10,4 @@
 - import_tasks: postgresql_subscription_initial.yml
 
 - import_tasks: postgresql_subscription_limited_role.yml
+  when: postgres_version_resp.stdout is version('16.0', '>=')

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
@@ -1,0 +1,182 @@
+- vars:
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: true
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: '{{ test_db }}'
+    pg_limited_parameters: &pg_limited_parameters
+      login_user: '{{ pg_limited_user }}'
+      login_db: '{{ test_db }}'
+
+  block:
+
+  - name: Create limited postgres role
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ pg_limited_user }}'
+      role_attr_flags: LOGIN
+  - name: Grant database usage to limited role
+    <<: *task_parameters
+    postgresql_privs:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      state: present
+      type: database
+      privs: CONNECT,CREATE
+      role: "{{ pg_limited_user }}"
+  - name: Revoke existing select for pg_subscription
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      query: "REVOKE SELECT ON pg_catalog.pg_subscription FROM {{ pg_limited_user }}"
+  - name: Set limited postgres select permissions to simulate CloudSQL
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      query: "GRANT SELECT (subenabled,subslotname,subsynccommit,subpublications,subdbid,subowner,subname) ON pg_catalog.pg_subscription TO {{ pg_limited_user }}"
+
+  # this built-in role only exists in PG 16 or above
+  - name: Set pg_create_subscription membership for limited postgres role
+    <<: *task_parameters
+    postgresql_membership:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      group: "pg_create_subscription"
+      target_role: "{{ pg_limited_user }}"
+      state: present
+
+
+  ####################
+  # Test mode: present
+  ####################
+  - name: Create subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_limited_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications: '{{ test_pub }}'
+      comment: Made by Ansible
+      connparams:
+        host: 127.0.0.1
+        port: '{{ primary_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+      trust_input: false
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["CREATE SUBSCRIPTION test CONNECTION 'host=127.0.0.1 port={{ primary_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }}", "COMMENT ON SUBSCRIPTION \"test\" IS 'Made by Ansible'"]
+      - result.exists == true
+      - result.initial_state == {}
+      - result.final_state.owner == '{{ pg_limited_user }}'
+      - result.final_state.enabled == true
+      - result.final_state.publications == ["{{ test_pub }}"]
+      - result.final_state.synccommit == true
+      - result.final_state.slotname == '{{ test_subscription }}'
+      - result.final_state.conninfo == {}
+  
+  - name: Check the comment
+    <<: *task_parameters
+    postgresql_query: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      query: "SELECT obj_description(s.oid, 'pg_subscription') AS comment FROM pg_subscription AS s WHERE s.subname = 'test'"
+
+  - assert:
+      that:
+      - result.query_result[0]['comment'] == 'Made by Ansible'
+
+
+  # attempt to update the subscription conn params. this should throw a warning and not actually change the subscription
+  - name: Update subscription with connparams
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_limited_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications: '{{ test_pub }}'
+      comment: Made by Ansible
+      connparams:
+        host: 127.0.0.1
+        port: '{{ primary_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+      trust_input: false
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+      - result.final_state.owner == '{{ pg_limited_user }}'
+      - result.final_state.enabled == true
+      - result.final_state.publications == ["{{ test_pub }}"]
+      - result.final_state.synccommit == true
+      - result.final_state.slotname == '{{ test_subscription }}'
+      - result.final_state.conninfo == {}
+
+  - name: Update subscription comment
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_limited_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications: '{{ test_pub }}'
+      comment: Updated by Ansible
+      connparams:
+        host: 127.0.0.1
+        port: '{{ primary_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+      trust_input: false
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+      - result.final_state.owner == '{{ pg_limited_user }}'
+      - result.final_state.enabled == true
+      - result.final_state.publications == ["{{ test_pub }}"]
+      - result.final_state.synccommit == true
+      - result.final_state.slotname == '{{ test_subscription }}'
+      - result.final_state.conninfo == {}
+  
+  - name: Check the comment
+    <<: *task_parameters
+    postgresql_query: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      query: "SELECT obj_description(s.oid, 'pg_subscription') AS comment FROM pg_subscription AS s WHERE s.subname = 'test'"
+
+  - assert:
+      that:
+      - result.query_result[0]['comment'] == 'Updated by Ansible'
+
+  ##########
+  # Clean up
+  ##########
+  - name: Drop subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: absent
+  
+  when: postgres_version_resp.stdout is version('16.0', '>=')

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
@@ -179,4 +179,3 @@
       name: '{{ test_subscription }}'
       state: absent
   
-  when: postgres_version_resp.stdout is version('16.0', '>=')

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
@@ -178,4 +178,3 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: absent
-  

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_limited_role.yml
@@ -85,10 +85,10 @@
       - result.final_state.synccommit == true
       - result.final_state.slotname == '{{ test_subscription }}'
       - result.final_state.conninfo == {}
-  
+
   - name: Check the comment
     <<: *task_parameters
-    postgresql_query: 
+    postgresql_query:
       <<: *pg_parameters
       login_port: '{{ replica_port }}'
       query: "SELECT obj_description(s.oid, 'pg_subscription') AS comment FROM pg_subscription AS s WHERE s.subname = 'test'"
@@ -156,10 +156,10 @@
       - result.final_state.synccommit == true
       - result.final_state.slotname == '{{ test_subscription }}'
       - result.final_state.conninfo == {}
-  
+
   - name: Check the comment
     <<: *task_parameters
-    postgresql_query: 
+    postgresql_query:
       <<: *pg_parameters
       login_port: '{{ replica_port }}'
       query: "SELECT obj_description(s.oid, 'pg_subscription') AS comment FROM pg_subscription AS s WHERE s.subname = 'test'"

--- a/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-20-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-20-py3.yml
@@ -1,4 +1,4 @@
-pg_ver: 15
+pg_ver: 16
 
 postgresql_packages:
   - "apt-utils"

--- a/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-22-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-22-py3.yml
@@ -1,4 +1,4 @@
-pg_ver: 15
+pg_ver: 16
 
 postgresql_packages:
   - "apt-utils"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #726 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`postgresql_subscription`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Using https://github.com/ansible-collections/community.postgresql/pull/437 as a bit of an example of how to address this limitation. I've modified the module to first check to see which columns are available (per the information schema) and then adjusting the query accordingly. If the `subconninfo` column is not available, we deal with that by allowing the subscription to be created, but then logging a warning on subsequent runs if we are looking at a subscription that already exists. Without access to `subconninfo`, we have no way to compare the connection info provided to the module versus what exists in the database, so we simply skip.

I am having a hell of a time devising tests that will prove out that this fix works. I've tested it in an actual CloudSQL environment, where there lack of access to the `subconninfo` - but in the integration tests, I haven't been able to devise a way to replicate this restriction because creating a subscription requires superuser access in Postgres versions prior to 16. Using the superuser then bypasses all ACL checks, which renders the test moot (i.e. the problem cannot be reproduced). It should be possible to reproduce and test this with Postgres 16 by using the lesser built-in `pg_create_subscription` role - but the test harness as of now is on PG 15.

Google must have come up with some way to work around this restriction, since they do not give you superuser access yet you can still create subscriptions there using a lesser built-in role they provide, in all versions of Postgres that support logical replication. It's a bit beyond my understanding of Postgres internals to figure out how to replicate Google's configuration in a test scenario. EDIT: Looking at the Postgres source code where the ACL check lives for creating subscriptions, and Google must be running their own slightly customized version of Postgres to support their pseudo-superuser permissions scheme.

Open to any suggestions on how to approach testing this.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[WARNING]: 'connparams' is ignored when existing subscription connparms are unknowable
```
