### PR TITLE
Fix postgresql_db for Postgres 17+

### DIFF
--- a/changelogs/fragments/731-db-fix-for-pg17.yml
+++ b/changelogs/fragments/731-db-fix-for-pg17.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - postgresql_db - fixe issues due to columns in pg_database changing in Postgres 17.
+    (https://github.com/ansible-collections/community.postgresql/issues/729).

--- a/changelogs/fragments/731-db-fix-for-pg17.yml
+++ b/changelogs/fragments/731-db-fix-for-pg17.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - postgresql_db - fixe issues due to columns in pg_database changing in Postgres 17.
+  - postgresql_db - fix issues due to columns in pg_database changing in Postgres 17.
     (https://github.com/ansible-collections/community.postgresql/issues/729).

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -356,7 +356,7 @@ def get_db_info(cursor, db):
         JOIN pg_tablespace ON pg_tablespace.oid = pg_database.dattablespace
         WHERE datname = %(db)s
         """
-    elif server_version >= 150000:
+    elif server_version >= 150000 and server_version < 170000:
         query = """
         SELECT rolname AS owner,
         pg_encoding_to_char(encoding) AS encoding, encoding AS encoding_id,


### PR DESCRIPTION
##### SUMMARY
Fix `postgresql_db` for Postgres 17+ due to a column name change in pg_database.

Fixes: #729

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`postgresql_db`

##### ADDITIONAL INFORMATION
This appears to be the minimum required change for `postgresql_db` to work as expected with Postgres17 or higher whilst maintaining backwards compatibility.