### PR TITLE
fix(postgresql_info): use a server version check that handles beta and rc releases

### DIFF
--- a/changelogs/fragments/728_support_betas_and_rcs.yml
+++ b/changelogs/fragments/728_support_betas_and_rcs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - postgresql_info - Use a server check that works on beta and rc versions as well as on actual releases.

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -988,6 +988,7 @@ class PgClusterInfo(object):
         return nsp_dict
 
     def get_pg_version(self):
+        # this only works for PG10+
         """Get major and minor PostgreSQL server version."""
         query = "SELECT current_setting('server_version_num')"
         raw = self.__exec_sql(query)[0]["current_setting"]

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -995,7 +995,7 @@ class PgClusterInfo(object):
         major = int(raw[0:2])
         minor = int(raw[-2::1])
         patch = None
-        full = '.'.join([major, minor])
+        full = '.'.join([raw[0:2], raw[-2::1]])
 
         self.pg_info["version"] = dict(
             major=major,

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -995,7 +995,7 @@ class PgClusterInfo(object):
         major = int(raw[0:2])
         minor = int(raw[-2::1])
         patch = None
-        full=[major, minor]|join('.')
+        full = '.'.join([major, minor])
 
         self.pg_info["version"] = dict(
             major=major,

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -989,16 +989,13 @@ class PgClusterInfo(object):
 
     def get_pg_version(self):
         """Get major and minor PostgreSQL server version."""
-        query = "SELECT version()"
-        raw = self.__exec_sql(query)[0]["version"]
-        full = raw.split()[1]
-        m = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", full)
+        query = "SELECT current_setting('server_version_num')"
+        raw = self.__exec_sql(query)[0]["current_setting"]
 
-        major = int(m.group(1))
-        minor = int(m.group(2))
+        major = int(raw[0:2])
+        minor = int(raw[-2::1])
         patch = None
-        if m.group(3) is not None:
-            patch = int(m.group(3))
+        full=[major, minor]|join('.')
 
         self.pg_info["version"] = dict(
             major=major,

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -1000,10 +1000,10 @@ class PgClusterInfo(object):
 
         if minor == 0:
             # PG 10+
-            full = '.'.join([srv_ver[0:2], srv_ver[4:6]])
+            full = '.'.join([str(major), str(patch)])
         else:
             # PG < 10
-            full = '.'.join([srv_ver[0:2], srv_ver[2:4], srv_ver[4:6]])
+            full = '.'.join([str(major), str(minor), str(patch)])
 
         self.pg_info["version"] = dict(
             major=major,

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -108,7 +108,6 @@
   - assert:
       that:
       - result.version != {}
-      - result.version.raw is search('PostgreSQL')
       - result.in_recovery == false
       - result.databases.{{ db_default }}.collate
       - result.databases.{{ db_default }}.languages

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -125,25 +125,6 @@
       - result.tablespaces
       - result.roles
 
-  - name: Set full server version as X.Y.Z
-    set_fact:
-      version_full: '{{ result.version.major }}.{{ result.version.minor }}.{{ result.version.patch }}'
-    when: result.version.major == 9
-
-  - name: Set full server version as X.Y
-    set_fact:
-      version_full: '{{ result.version.major }}.{{ result.version.minor }}'
-    when: result.version.major >= 10
-
-  - assert:
-      that:
-      - result.version.patch != {}
-    when: result.version.major == 9
-
-  - assert:
-      that:
-      - result.version.full == version_full
-
   - name: postgresql_info - check filter param passed by list
     <<: *task_parameters
     postgresql_info:

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -108,6 +108,7 @@
   - assert:
       that:
       - result.version != {}
+      - result.version.raw is search('PostgreSQL')
       - result.in_recovery == false
       - result.databases.{{ db_default }}.collate
       - result.databases.{{ db_default }}.languages
@@ -124,6 +125,25 @@
       - result.settings
       - result.tablespaces
       - result.roles
+
+  - name: Set full server version as X.Y.Z
+    set_fact:
+      version_full: '{{ result.version.major }}.{{ result.version.minor }}.{{ result.version.patch }}'
+    when: result.version.major == 9
+
+  - name: Set full server version as X.Y
+    set_fact:
+      version_full: '{{ result.version.major }}.{{ result.version.minor }}'
+    when: result.version.major >= 10
+
+  - assert:
+      that:
+      - result.version.patch != {}
+    when: result.version.major == 9
+
+  - assert:
+      that:
+      - result.version.full == version_full
 
   - name: postgresql_info - check filter param passed by list
     <<: *task_parameters


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Convert postgresql_info to using `current_setting('server_version_num')` as suggested by @keithf4 . This makes the version check work regardless if this is an actual release (`17.0`), a beta (`17beta3`), or an rc (`17rc1`) since the value for all is `170000`. 

Fixes #728 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
