### PR TITLE
postgresql_db: fails on setting transaction_timeout = 0 which is supported since PG 17

### DIFF
--- a/tests/integration/targets/postgresql_db/tasks/state_dump_restore.yml
+++ b/tests/integration/targets/postgresql_db/tasks/state_dump_restore.yml
@@ -125,6 +125,10 @@
   become_user: "{{ pg_user }}"
   become: true
 
+- name: Debug task to trigger tests
+  debug:
+    msg: Remove this task
+
 - name: assert output message restore the database
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY
Test fails because of this in https://github.com/ansible-collections/community.postgresql/pull/740