### PR TITLE
postgresql_set: forbids to reset shared_preload_libraries with empty string

### DIFF
--- a/changelogs/fragments/1-pg_set.yml
+++ b/changelogs/fragments/1-pg_set.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_set - forbids re-setting shared_preload_libraries by passing an emty string (https://github.com/ansible-collections/community.postgresql/issues/744).
+- postgresql_set - forbids re-setting shared_preload_libraries by passing an empty string (https://github.com/ansible-collections/community.postgresql/issues/744).

--- a/changelogs/fragments/1-pg_set.yml
+++ b/changelogs/fragments/1-pg_set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - forbids re-setting shared_preload_libraries by passing an emty string (https://github.com/ansible-collections/community.postgresql/issues/744).

--- a/changelogs/fragments/1-pg_set.yml
+++ b/changelogs/fragments/1-pg_set.yml
@@ -1,2 +1,3 @@
 bugfixes:
-- postgresql_set - forbids re-setting shared_preload_libraries by passing an empty string (https://github.com/ansible-collections/community.postgresql/issues/744).
+- postgresql_set - forbids resetting shared_preload_libraries by passing an empty string (https://github.com/ansible-collections/community.postgresql/issues/744).
+- "postgresql_set - fixes resetting logic to allow resetting shared_preload_libraries with ``reset: true`` (https://github.com/ansible-collections/community.postgresql/issues/744)."

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -425,6 +425,13 @@ def main():
         elif len(value) > 1 and ('b' in value[-1] and value[:-1].isdigit()):
             value = value.upper()
 
+    if name == 'shared_preload_libraries' and value == '':
+        msg = ("Due to a PostgreSQL bug in resetting shared_preload_libraries "
+               "with ALTER SYSTEM SET, setting it as an empty string is "
+               "not supported by the module to avoid crashes. "
+               "If you think the bug has been fixed, please let us know.")
+        module.fail_json(msg=msg)
+
     if value is not None and reset:
         module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -404,6 +404,37 @@
       - result is failed
       - result.msg is search('Due to a PostgreSQL bug in resetting shared_preload_libraries')
 
+  - name: Try to reset shared_preload_libraries with default
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: shared_preload_libraries
+      value: default
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: Try to reset shared_preload_libraries with reset
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: shared_preload_libraries
+      reset: true
+    register: result
+    ignore_errors: true
+
+  - assert:
+      that:
+      - result is not changed
+
+  - name: Restart PostgreSQL
+    become: true
+    service:
+      name: "{{ postgresql_service }}"
+      state: restarted
+
   #######################################################################
   # https://github.com/ansible-collections/community.postgresql/issues/48
   - name: Pass a parameter containing b in check_mode

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -388,6 +388,22 @@
       - result is failed
       - result.msg is search('No such parameter')
 
+  ########################################################################
+  # https://github.com/ansible-collections/community.postgresql/issues/744
+  - name: Try to reset shared_preload_libraries
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: shared_preload_libraries
+      value: ''
+    register: result
+    ignore_errors: true
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('Due to a PostgreSQL bug in resetting shared_preload_libraries')
+
   #######################################################################
   # https://github.com/ansible-collections/community.postgresql/issues/48
   - name: Pass a parameter containing b in check_mode


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/744

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
plugins/modules/postgresql_set.py