### PR TITLE
pg_user doesn't take password_encryption into account when checking if a password should be updated

### DIFF
--- a/changelogs/fragments/0-postgresql_user.yml
+++ b/changelogs/fragments/0-postgresql_user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_user - doesn't take password_encryption into account when checking if a password should be updated (https://github.com/ansible-collections/community.postgresql/issues/688).

--- a/tests/integration/targets/postgresql_user/tasks/test_password.yml
+++ b/tests/integration/targets/postgresql_user/tasks/test_password.yml
@@ -391,6 +391,52 @@
 
     - <<: *not_changed
 
+    # https://github.com/ansible-collections/community.postgresql/issues/688
+    - name: Create a user with MD5 password
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: 'md55f4dcc3b5aa765d61d8327deb882cf99'
+
+    - <<: *changed
+
+    - name: Create a user with MD5 password again
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: 'md55f4dcc3b5aa765d61d8327deb882cf99'
+
+    - <<: *not_changed
+
+    - name: Pass the same password as plain text 
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: 'password'
+      environment:
+        PGOPTIONS: "-c password_encryption=scram-sha-256"
+
+    - <<: *changed
+
+    - name: Pass the same password as plain text 
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: 'password'
+      environment:
+        PGOPTIONS: "-c password_encryption=scram-sha-256"
+
+    - <<: *not_changed
+    # end of https://github.com/ansible-collections/community.postgresql/issues/688
+
+    - name: 'Using cleartext password with scram-sha-256: check that password is not changed when clearing the password again'
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: ''
+        encrypted: "{{ encrypted }}"
+      environment:
+
   # end of block scram-sha-256
 
   - name: Remove user

--- a/tests/integration/targets/postgresql_user/tasks/test_password.yml
+++ b/tests/integration/targets/postgresql_user/tasks/test_password.yml
@@ -391,12 +391,27 @@
 
     - <<: *not_changed
 
+
+    - name: 'Using cleartext password with scram-sha-256: check that password is not changed when clearing the password again'
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: ''
+        encrypted: "{{ encrypted }}"
+      environment:
+
+    # end of block scram-sha-256
+
     # https://github.com/ansible-collections/community.postgresql/issues/688
+    - name: Generate md5 hashed password
+      set_fact:
+        md5_hashed_password: "md5{{ 'password' | hash('md5')}}"
+
     - name: Create a user with MD5 password
       <<: *task_parameters
       postgresql_user:
         <<: *parameters
-        password: 'md55f4dcc3b5aa765d61d8327deb882cf99'
+        password: '{{ md5_hashed_password }}'
 
     - <<: *changed
 
@@ -404,9 +419,20 @@
       <<: *task_parameters
       postgresql_user:
         <<: *parameters
-        password: 'md55f4dcc3b5aa765d61d8327deb882cf99'
+        password: '{{ md5_hashed_password }}'
 
     - <<: *not_changed
+
+    - name: Check password in DB
+      <<: *task_parameters
+      postgresql_query:
+        <<: *query_parameters
+        query: "SELECT rolpassword FROM pg_authid WHERE rolname = '{{ db_user1 }}'"
+
+    - name: Check the password
+      assert:
+        that:
+        - result.query_result[0]['rolpassword'] == md5_hashed_password
 
     - name: Pass the same password as plain text 
       <<: *task_parameters
@@ -417,6 +443,17 @@
         PGOPTIONS: "-c password_encryption=scram-sha-256"
 
     - <<: *changed
+
+    - name: Check password in DB
+      <<: *task_parameters
+      postgresql_query:
+        <<: *query_parameters
+        query: "SELECT rolpassword FROM pg_authid WHERE rolname = '{{ db_user1 }}'"
+
+    - name: Check the password
+      assert:
+        that:
+        - result.query_result[0]['rolpassword'] is search('SCRAM-SHA-256')
 
     - name: Pass the same password as plain text 
       <<: *task_parameters
@@ -428,16 +465,6 @@
 
     - <<: *not_changed
     # end of https://github.com/ansible-collections/community.postgresql/issues/688
-
-    - name: 'Using cleartext password with scram-sha-256: check that password is not changed when clearing the password again'
-      <<: *task_parameters
-      postgresql_user:
-        <<: *parameters
-        password: ''
-        encrypted: "{{ encrypted }}"
-      environment:
-
-  # end of block scram-sha-256
 
   - name: Remove user
     <<: *task_parameters


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/688

IMPORTANT:
- The tests I added passed w/o any code change, so I failed to reproduce the bug
- But the tests check that the password is actually stored as MD5
- I carefully debugged and the tests poke the code I added, the code determines correctly that there's `scram-sha-256` on the server by default and executes pwchage = True
- If you think it's risky to add this code, say it, if we agree that it is, I'll close the PR

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request