### PR TITLE
Fix 420 comments parsing

### DIFF
--- a/changelogs/fragments/420-pg_hba-fix-hash-symbol-in-quotes.yml
+++ b/changelogs/fragments/420-pg_hba-fix-hash-symbol-in-quotes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "postgresql_pg_hba - fixes #420 by properly handling hash-symbols in quotes (https://github.com/ansible-collections/community.postgresql/pull/766)"
+minor_changes:
+  - "postgresql_pg_hba - show the number of the line with the issue if parsing a file fails (https://github.com/ansible-collections/community.postgresql/pull/766)"

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -81,6 +81,7 @@
   - { address: "", contype: "local", method: "ldap", options: "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\"" }
   - { address: "red", contype: "hostssl", method: "cert", options: "clientcert=1 map=mymap" }
   - { address: "blue", contype: "hostssl", method: "cert", options: "clientcert=1 map=mymap" }
+  - { address: "green", contype: "hostssl", method: "ldap", options: "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\" ldapbindpasswd=\"#BROKEN\"" }
   register: pg_hba_options
 
 - name: read pg_hba rules
@@ -154,6 +155,7 @@
            { "db": "all", "method": "md5", "type": "local", "usr": "all" },
            { "db": "all", "method": "md5", "src": "2001:db8::1/128", "type": "hostgssenc", "usr": "postgres" },
            { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
+           { "db": "all", "method": "ldap", "src": "green", "type": "hostssl", "usr": "+some", "options": "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\" ldapbindpasswd=\"#BROKEN\"" },
            { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "md5", "src": "127.0.0.1/32", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "2001:db8::1/128", "type": "hostnogssenc", "usr": "all" },

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -271,3 +271,88 @@
     state: present
     contype: host
     create: true
+
+- name: create file that contains edge-cases
+  copy:
+    dest: /tmp/edgecase_test_pg_hba.conf
+    content: |
+      # full line comment
+      local all all ident # comment
+
+      hostssl all all 192.168.0.0/24 md5
+      hostssl all all \
+      10.10.0.0/16 md5
+      hostssl all all 10.11.0.0/16 md5#comment
+      hostssl all all 10.12.0.0/16 ldap ldapserver=example.com ldapport=389 ldapprefix="cn=" ldapbindpasswd="#BROKEN"
+      hostssl all all 10.13.0.0/16 radius radiusservers="server1,server2" radiussecrets="""secret one"",""secret two"""
+
+- name: check that there are no errors while parsing the file
+  postgresql_pg_hba:
+    dest: /tmp/edgecase_test_pg_hba.conf
+  register: pg_hba
+
+- debug:
+    var: pg_hba.pg_hba
+
+- assert:
+    that:
+      - 'pg_hba.pg_hba == [
+              {"db": "all", "method": "ident", "type": "local", "usr": "all"},
+              {"db": "all", "method": "md5", "src": "192.168.0.0/24", "type": "hostssl", "usr": "all"},
+              {"db": "all", "method": "md5", "src": "10.10.0.0/16",  "type": "hostssl", "usr": "all"},
+              {"db": "all", "method": "md5", "src": "10.11.0.0/16", "type": "hostssl", "usr": "all"},
+              {"db": "all", "method": "ldap", "options": "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\" ldapbindpasswd=\"#BROKEN\"", "src": "10.12.0.0/16", "type": "hostssl", "usr": "all"},
+              {"db": "all", "method": "radius", "options": "radiusservers=\"server1,server2\" radiussecrets=\"\"\"secret one\"\",\"\"secret two\"\"\"", "src": "10.13.0.0/16", "type": "hostssl", "usr": "all"}
+        ]'
+
+- name: create faulty file
+  copy:
+    dest: /tmp/faulty_test_pg_hba.conf
+    content: |-
+      local all all ident # comment
+      hostssl all all \
+
+- name: check that parsing failed (invalid continuation)
+  postgresql_pg_hba:
+    dest: /tmp/faulty_test_pg_hba.conf
+  register: faulty_pg_hba
+  ignore_errors: true
+
+- assert:
+    that:
+      - faulty_pg_hba is failed
+
+- name: create faulty file
+  copy:
+    dest: /tmp/faulty_test_pg_hba.conf
+    content: |
+      local all all ident # comment
+      hostssl all all 192.168.0.0/24 ldap ldapserver=example.com ldapport=389 ldapprefix="cn=" ldapbindpasswd="#BROKEN
+
+- name: check that parsing failed (unterminated quote)
+  postgresql_pg_hba:
+    dest: /tmp/faulty_test_pg_hba.conf
+  register: faulty_pg_hba
+  ignore_errors: true
+
+- assert:
+    that:
+      - faulty_pg_hba is failed
+
+- name: create faulty file
+  copy:
+    dest: /tmp/faulty_test_pg_hba.conf
+    content: |-
+      local all all ident # comment
+      hostssl all all
+      hostssl all all 192.168.0.0/24 md5
+
+- name: check that parsing failed (too few symbols)
+  postgresql_pg_hba:
+    dest: /tmp/faulty_test_pg_hba.conf
+  register: faulty_pg_hba
+  ignore_errors: true
+
+- assert:
+    that:
+      - faulty_pg_hba is failed

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -318,9 +318,12 @@
   register: faulty_pg_hba
   ignore_errors: true
 
+- debug:
+    var: faulty_pg_hba
 - assert:
     that:
       - faulty_pg_hba is failed
+      - faulty_pg_hba.msg is search("The last line ended with a '\\\\' \(line continuation\)\.")
 
 - name: create faulty file
   copy:
@@ -338,6 +341,7 @@
 - assert:
     that:
       - faulty_pg_hba is failed
+      - faulty_pg_hba.msg is search("Error in line 2")
 
 - name: create faulty file
   copy:
@@ -356,3 +360,4 @@
 - assert:
     that:
       - faulty_pg_hba is failed
+      - faulty_pg_hba.msg is search("Error in line 2")

--- a/tests/unit/plugins/modules/test_postgresql_pg_hba.py
+++ b/tests/unit/plugins/modules/test_postgresql_pg_hba.py
@@ -29,6 +29,16 @@ def test_tokenize():
     assert tokenize('one="two three" four') == ['one="two three"', "four"]
     assert tokenize('"one two"') == ['"one two"']
     assert tokenize('"one"') == ['"one"']
+    assert tokenize('one two # three four') == ['one', 'two', '# three four']
+    assert tokenize('one\ttwo\t#\tthree\tfour') == ['one', 'two', '#\tthree\tfour']
+    assert tokenize('one two# three four') == ['one', 'two', '# three four']
+    assert tokenize('one two#three four') == ['one', 'two', '#three four']
+    assert tokenize('one "two # three" four # five six') == ['one', '"two # three"', 'four', "# five six"]
+    assert tokenize('# one two') == ['# one two']
+    assert tokenize(' # one two') == ['# one two']
+    assert tokenize('one # two "three four" five') == ['one', '# two "three four" five']
+    assert tokenize('one # two "three four" five # six seven') == ['one', '# two "three four" five # six seven']
+    assert tokenize('one ##two') == ['one', "##two"]
     with pytest.raises(TokenizerException, match="Unterminated quote"):
         tokenize('one="two three four')
     with pytest.raises(TokenizerException, match="Unterminated quote"):


### PR DESCRIPTION
##### SUMMARY

- Fixes issue parsing `pg_hba.conf` files that contain a `#` in a quoted string
- When there is an issue parsing a `pg_hba.conf` file, we now print the number of the line where the issue is
- Adds tests for the modified and added functionality

Fixes #420 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_pg_hba