### PR TITLE
Fix 777

### DIFF
--- a/changelogs/fragments/779-fix-address.yaml
+++ b/changelogs/fragments/779-fix-address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "postgresql_pg_hba - fixes #777 the module will ignore the 'address' and 'netmask' options again when the contype is 'local' (https://github.com/ansible-collections/community.postgresql/pull/779)"

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -1084,12 +1084,7 @@ class PgHbaRule:
                 if self._address_type.startswith("IP") and self._prefix_len == -1:
                     raise PgHbaRuleError("If the address is a bare ip-address without a CIDR suffix, "
                                          "the rule needs to contain a netmask")
-
-        # if the contype is "local", the rule can't contain an address or netmask
-        else:
-            if (("address" in rule_dict and rule_dict["address"])
-                    or ("netmask" in rule_dict and rule_dict["netmask"])):
-                raise PgHbaRuleError("Rule can't contain an address and netmask if the connection-type is 'local'")
+        # we ignore address / netmask when contype is 'local'
 
         # verify the method
         self._auth_method = _strip_quotes(rule_dict["method"])

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -254,6 +254,29 @@
       - '"#comment1\nhost\tall\tall\t2001:db8::1/128\tmd5\nhost\tall\tall\t2001:db8::2/128\tmd5\t#comment2\nhost\tall\tall\t2001:db8::3/128\tmd5\t#comment3" == content'
 
 - community.postgresql.postgresql_pg_hba:
+    dest: /tmp/pg_hba3.conf
+    contype: local
+    method: trust
+    state: present
+    create: true
+  register: local_with_address
+
+- assert:
+    that: 'local_with_address.pg_hba == [{"db": "all", "method": "trust", "type": "local", "usr": "all"}]'
+
+- community.postgresql.postgresql_pg_hba:
+    dest: /tmp/pg_hba3.conf
+    contype: local
+    method: trust
+    address: 127.0.0.0
+    netmask: 255.0.0.0
+    state: present
+  register: local_with_address
+
+- assert:
+    that: 'local_with_address.pg_hba == [{"db": "all", "method": "trust", "type": "local", "usr": "all"}]'
+
+- community.postgresql.postgresql_pg_hba:
     dest: pg_hba.conf
     users: '{ "oh": "no" }'
     state: present

--- a/tests/unit/plugins/modules/test_postgresql_pg_hba.py
+++ b/tests/unit/plugins/modules/test_postgresql_pg_hba.py
@@ -195,20 +195,18 @@ def test_rule_validation_from_dict():
 
     d = copy.copy(base_dict)
     d['address'] = '127.0.0.1/32'
-    with pytest.raises(PgHbaRuleError,
-                       match="Rule can't contain an address and netmask if the connection-type is 'local'"):
-        PgHbaRule(rule_dict=d)
+    assert not PgHbaRule(rule_dict=d).address
+
     d = copy.copy(base_dict)
-    d['address'] = '255.255.255.255'
-    with pytest.raises(PgHbaRuleError,
-                       match="Rule can't contain an address and netmask if the connection-type is 'local'"):
-        PgHbaRule(rule_dict=d)
+    d['netmask'] = '255.255.255.255'
+    assert not PgHbaRule(rule_dict=d).netmask
+
     d = copy.copy(base_dict)
     d['address'] = '127.0.0.1/32'
     d['address'] = '255.255.255.255'
-    with pytest.raises(PgHbaRuleError,
-                       match="Rule can't contain an address and netmask if the connection-type is 'local'"):
-        PgHbaRule(rule_dict=d)
+    rule = PgHbaRule(rule_dict=d)
+    assert (not rule.address) and (not rule.netmask)
+
     base_dict['contype'] = 'host'
     with pytest.raises(PgHbaRuleError, match="If the contype isn't 'local', the rule needs to contain an address"):
         PgHbaRule(rule_dict=base_dict)


### PR DESCRIPTION
##### SUMMARY
In the last PR we introduced a bug that would cause an error if address wasn't explicitly set to an empty string when using `contype: local`. This one fixes that and restores the previous behavior.

Fixes #777 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`postgresql_pg_hba`
