### PR TITLE
Fix error: Cannot execute SQL 'SELECT proacl::text FROM pg_catalog.pg…

### DIFF
--- a/changelogs/fragments/783-fix-postgresql-privs-not-specified-schema.yml
+++ b/changelogs/fragments/783-fix-postgresql-privs-not-specified-schema.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "postgresql_privs - #783 fix error: Cannot execute SQL 'SELECT proacl::text FROM pg_catalog.pg_proc WHERE proname = ANY (%s) ORDER BY proname, proargtypes': syntax error at or near %, when trying to grant a function execution and set the schema to not-specified"
+  - postgresql_privs -  fix the error occurring when trying to grant a function execution and set the schema to not-specified (https://github.com/ansible-collections/community.postgresql/pull/783).

--- a/changelogs/fragments/783-fix-postgresql-privs-not-specified-schema.yml
+++ b/changelogs/fragments/783-fix-postgresql-privs-not-specified-schema.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "postgresql_privs - #783 fix error: Cannot execute SQL 'SELECT proacl::text FROM pg_catalog.pg_proc WHERE proname = ANY (%s) ORDER BY proname, proargtypes': syntax error at or near %, when trying to grant a function execution and set the schema to not-specified"

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -658,7 +658,7 @@ class Connection(object):
         else:
             query = ("SELECT proacl::text FROM pg_catalog.pg_proc WHERE proname = ANY (%s) "
                      "ORDER BY proname, proargtypes")
-            self.execute(query)
+            self.execute(query, (funcnames))
         return [t["proacl"] for t in self.cursor.fetchall()]
 
     def get_schema_acls(self, schemas):


### PR DESCRIPTION
Fix error: Cannot execute SQL 'SELECT proacl::text FROM pg_catalog.pg_proc WHERE proname = ANY (%s) ORDER BY proname, proargtypes': syntax error at or near "%"
