### PR TITLE
Reconnect to the default database after gathering databases info

### DIFF
--- a/changelogs/fragments/788-fix-postresql-info-db-connection.yml
+++ b/changelogs/fragments/788-fix-postresql-info-db-connection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_info - fix issue when gathering information fails if user doesn't have access to all databases (https://github.com/ansible-collections/community.postgresql/pull/788)

--- a/changelogs/fragments/788-fix-postresql-info-db-connection.yml
+++ b/changelogs/fragments/788-fix-postresql-info-db-connection.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - postgresql_info - fix issue when gathering information fails if user doesn't have access to all databases (https://github.com/ansible-collections/community.postgresql/pull/788)
+  - postgresql_info - fix issue when gathering information fails if user doesn't have access to all databases (https://github.com/ansible-collections/community.postgresql/pull/788).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -704,7 +704,6 @@ class PgClusterInfo(object):
         self.pg_info["databases"] = db_dict
         self.cursor = self.db_obj.reconnect(default_db)
 
-
     def __get_pretty_val(self, setting):
         """Get setting's value represented by SHOW command."""
         return self.__exec_sql('SHOW "%s"' % setting)[0][setting]

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -669,6 +669,8 @@ class PgClusterInfo(object):
 
         res = self.__exec_sql(query)
 
+        default_db = self.__exec_sql("SELECT current_database()")[0]["current_database"]
+
         db_dict = {}
         for i in res:
             db_dict[i["datname"]] = dict(
@@ -700,6 +702,8 @@ class PgClusterInfo(object):
                 db_dict[datname]['subscriptions'] = subscr_info.get(datname, {})
 
         self.pg_info["databases"] = db_dict
+        self.cursor = self.db_obj.reconnect(default_db)
+
 
     def __get_pretty_val(self, setting):
         """Get setting's value represented by SHOW command."""

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -230,6 +230,7 @@ class PgClusterInfo(object):
         self.module = module
         self.db_obj = db_conn_obj
         self.cursor = db_conn_obj.connect()
+        self.default_db = module.params['login_db']
         self.pg_info = {
             "version": {},
             "in_recovery": None,
@@ -669,8 +670,6 @@ class PgClusterInfo(object):
 
         res = self.__exec_sql(query)
 
-        default_db = self.__exec_sql("SELECT current_database()")[0]["current_database"]
-
         db_dict = {}
         for i in res:
             db_dict[i["datname"]] = dict(
@@ -702,7 +701,8 @@ class PgClusterInfo(object):
                 db_dict[datname]['subscriptions'] = subscr_info.get(datname, {})
 
         self.pg_info["databases"] = db_dict
-        self.cursor = self.db_obj.reconnect(default_db)
+        # Reconnect to the default DB after gathering info in other DBs
+        self.cursor = self.db_obj.reconnect(self.default_db)
 
     def __get_pretty_val(self, setting):
         """Get setting's value represented by SHOW command."""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`postgresql_info` module fails if the user used for connection doesn't have permission to connect to last database from returned database list.

Fix:
After gathering the information about databases, connection is restored to the database specified in module parameters.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_info module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Issue with `postgresql_info` module:
When using AWS RDS, you never has access to `rdsadmin` database. If `rdsadmin` databases is return as a last one when listing databases, it keeps trying to connect th `rdsadmin` db when collecting other data, which fails, since you can't connect to the database.

How to reproduce:
Since the database list doesn't have fixed order, it is not that easy to reproduce.
