### PR TITLE
AZP: replace Fedora40 -> Fedora41, RHEL9.4 -> RHEL9.5 in devel tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,8 +120,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: Fedora 40
-              test: fedora40
+            - name: Fedora 41
+              test: fedora41
             - name: Ubuntu 24.04
               test: ubuntu2404
             - name: Ubuntu 22.04
@@ -189,8 +189,8 @@ stages:
         parameters:
           testFormat: devel/{0}/1
           targets:
-            - name: RHEL 9.4
-              test: rhel/9.4
+            - name: RHEL 9.5
+              test: rhel/9.5
 
   - stage: Remote_2_18
     displayName: Remote devel

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 | Fedora 37    |           2.9.6 |               14   |
 | Fedora 39    |           2.9.6 |               15   |
 | Ubuntu 22.04 |           3.1.9 |               16   |
-| Fedora 40    |           2.9.9 |               16   |
+| Fedora 40/41 |           2.9.9 |               16   |
 | Ubuntu 24.04 |           3.2.2 |               17   |
 
 ## Included content


### PR DESCRIPTION
##### SUMMARY
AZP: replace Fedora40 -> Fedora41, RHEL9.4 -> RHEL9.5 in devel tests

Relates to https://github.com/ansible/ansible/pull/84281