### PR TITLE
postgresql_info: fix SQL error of issue #790

### DIFF
--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -327,7 +327,7 @@ class PgClusterInfo(object):
 
     def get_subscr_info(self):
         """Get subscription statistics."""
-        columns_sub_table = ("SELECT column_name "
+        columns_sub_table = ("SELECT quote_ident(column_name) "
                              "FROM information_schema.columns "
                              "WHERE table_schema = 'pg_catalog' "
                              "AND table_name = 'pg_subscription'")


### PR DESCRIPTION
fixing #790 

The dynamic query construction fails because the column type is `bytes` in python, but the code expects `str`. The python conversion from `bytes` to `str` addess extra characters which break the SQL syntax of the following query.
I guess psycopg 2 vs 3 behave different regarding types, which was unexpected in the code.

This fix using the `quote_ident` function converts the type in SQL which should result in `str` in python. By the way it adds support for arbitrary column names (although this is rather unlikely to become relevant in a table of `pg_catalog`).

```sql
postgres=# SELECT pg_typeof(quote_ident(column_name)), pg_typeof(column_name) FROM information_schema.columns WHERE table_schema = 'pg_catalog' AND table_name = 'pg_subscription' limit 1;
 pg_typeof |             pg_typeof             
-----------+-----------------------------------
 text      | information_schema.sql_identifier
```