### PR TITLE
postgresql_info: fix when db used instead of login_db

### DIFF
--- a/changelogs/fragments/0-postgresql_info.yml
+++ b/changelogs/fragments/0-postgresql_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_info - fix module failure when the ``db`` parameter is used instead of ``login_db`` (https://github.com/ansible-collections/community.postgresql/issues/794).

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -230,7 +230,9 @@ class PgClusterInfo(object):
         self.module = module
         self.db_obj = db_conn_obj
         self.cursor = db_conn_obj.connect()
-        self.default_db = module.params['login_db']
+        self.default_db = module.params['db'] or \
+            module.params['login_db'] or \
+            module.params['database']
         self.pg_info = {
             "version": {},
             "in_recovery": None,

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -215,10 +215,12 @@
   - name: postgresql_info - test return publication info
     <<: *task_parameters
     postgresql_info:
-      <<: *pg_parameters
-      login_db: '{{ test_db }}'
+      login_user: '{{ pg_user }}'
+      db: '{{ db_default }}'
       login_port: '{{ primary_port }}'
       trust_input: true
+      connect_params:
+        connect_timeout: 30
 
   - assert:
       that:


### PR DESCRIPTION
##### SUMMARY
postgresql_info: fix when db used instead of login_db
fixes https://github.com/ansible-collections/community.postgresql/issues/794