### PR TITLE
postgresql_info: deprecated db alias in favor of login_db

### DIFF
--- a/changelogs/fragments/0-postgresql_info.yml
+++ b/changelogs/fragments/0-postgresql_info.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- postgresql_info - the ``db`` alias is deprecated and will be removed in the next major release, use the ``login_db`` argument instead.

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -28,12 +28,12 @@ options:
       the excluding values will be ignored.
     type: list
     elements: str
-  db:
+  login_db:
     description:
     - Name of database to connect.
     type: str
     aliases:
-    - login_db
+    - db
   session_role:
     description:
     - Switch to session_role after connecting. The specified session_role must
@@ -94,7 +94,7 @@ EXAMPLES = r'''
   become: true
   become_user: pgsql
   community.postgresql.postgresql_info:
-    db: postgres
+    login_db: postgres
     filter:
     - tablesp*
     - repl_sl*
@@ -735,7 +735,13 @@ class PgClusterInfo(object):
 def main():
     argument_spec = postgres_common_argument_spec()
     argument_spec.update(
-        db=dict(type='str', aliases=['login_db']),
+        login_db=dict(type='str', aliases=['db'], deprecated_aliases=[
+            {
+                'name': 'db',
+                'version': '4.0.0',
+                'collection_name': 'community.postgresql',
+            }],
+        ),
         filter=dict(type='list', elements='str'),
         session_role=dict(type='str'),
         trust_input=dict(type='bool', default=True),


### PR DESCRIPTION
##### SUMMARY
postgresql_info: deprecated db alias in favor of login_db

as multiple aliases can actually cause bugs like https://github.com/ansible-collections/community.postgresql/issues/794
i suggest deprecating and removing the `db` one in favor of `login_db`.
`db` is inconsistent with the other login arguments like `login_user`, `login_password`, etc. and it's even misleading. That's why the `login_db` alias was introduced.
I suggest deprecating it now and removing it in the next major release.

Created an [issue](https://github.com/ansible-collections/community.postgresql/issues/801) for milestone 4.0.0.