### PR TITLE
allow non-string settings in user-specific configuration

### DIFF
--- a/changelogs/fragments/802-unquoted-config-values.yml
+++ b/changelogs/fragments/802-unquoted-config-values.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "postgresql_user - now there is a ``quote_configuration_values`` parameter that allows to turn off quoting for values which when set to ``false`` allows to set ``search_path`` (https://github.com/ansible-collections/community.postgresql/pull/806)"

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -328,7 +328,6 @@ EXAMPLES = r'''
       work_mem: "16MB"
     reset_unspecified_configuration: true
 
-# Set the search_path
 - name: Set search_path for user
   community.postgresql.postgresql_user:
     name: postgres_exporter

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -188,6 +188,7 @@ options:
       - Set this only to C(false) if you know what you are doing!
     type: bool
     default: true
+    version_added: '3.11.0'
 notes:
 - The module creates a user (role) with login privilege by default.
   Use C(NOLOGIN) I(role_attr_flags) to change this behaviour.

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -829,6 +829,65 @@
         - result is failed
         - result.msg == "The key of a configuration may not contain single or double quotes"
 
+  - name: Test setting search_path
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      quote_configuration_values: false
+      configuration:
+        search_path: 'pg_catalog,public'
+
+  - name: Test that search_path is correct
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - result.query_result[0]['rolconfig'] == ["search_path=pg_catalog, public"]
+
+  - name: Test idempotency
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      quote_configuration_values: false
+      configuration:
+        search_path: 'pg_catalog, public'
+
+  - assert:
+      that: not result.changed
+
+  - name: Test setting search_path
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      quote_configuration_values: false
+      configuration:
+        search_path: 'pg_catalog, public'
+        work_mem: "'16MB'"
+
+  - name: Test that settings are correct is correct
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - result.query_result[0]['rolconfig'] == ["search_path=pg_catalog, public", "work_mem=16MB"]
+
+  - name: Purge configuration parameters from user
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      configuration: {}
+      reset_unspecified_configuration: true
+
   ########################
   # Test trust_input param
 


### PR DESCRIPTION
##### SUMMARY

Adds a flag to turn off string-quoting for user-specific configuration, so settings like `search_path` can be set using the module.

Fixes #802 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql_user

##### ADDITIONAL INFORMATION

This is not optimal, but the best solution I was able to come up with. See discussion in #802 
