### PR TITLE
postgresql_table: Fix multiple schema handling (#817)

### DIFF
--- a/changelogs/fragments/818-table-consider-schema-name.yaml
+++ b/changelogs/fragments/818-table-consider-schema-name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - postgresql_table - consider schema name when checking for table (https://github.com/ansible-collections/community.postgresql/issues/817).  Table names are only unique within a schema. This allows using the same table name in multiple schemas.

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -300,7 +300,7 @@ class Table(object):
         query = ("SELECT t.tableowner, t.tablespace, c.reloptions "
                  "FROM pg_tables AS t "
                  "INNER JOIN pg_class AS c ON  c.relname = t.tablename "
-                 "INNER JOIN pg_namespace AS n ON c.relnamespace = n.oid "
+                 "INNER JOIN pg_namespace AS n ON t.schemaname = n.nspname AND c.relnamespace = n.oid "
                  "WHERE t.tablename = %(tblname)s "
                  "AND n.nspname = %(schema)s")
         res = exec_sql(self, query, query_params={'tblname': tblname, 'schema': schema},


### PR DESCRIPTION
##### SUMMARY
The `postgresql_table` command shows spurious change status (and attempts unnecessary `ALTER TABLE...OWNER TO`) when multiple schemas have tables of the same name (which is the table being operated on by the task).

This happens because the query to get the existing information does not properly limit by schema name for the `pg_tables` view. It only limits for the `pg_namespace` part of the query. As a result, this query returns multiple rows, one per schema containing a table of the specified name.

Fixes #817

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_table

##### ADDITIONAL INFORMATION

BEFORE:
```
changed: [krls1.sip.wiktel.com] => (item=office) => changed=true
  ansible_loop_var: item
  invocation:
    module_args:
      ca_cert: null
      cascade: false
      columns:
      - username                  varchar
      - domain                    varchar
      - name_path                 varchar
      - greeting_path             varchar                                                                                                - password                  varchar                                                                                                connect_params: {}
      db: freeswitch
      including: null
      like: null
      login_host: ''
      login_password: ''
      login_unix_socket: ''
      login_user: postgres
      name: freeswitch_office.voicemail_prefs
      owner: freeswitch_office
      port: 5432
      rename: null
      session_role: null
      ssl_cert: null
      ssl_key: null
      ssl_mode: prefer
      state: present
      storage_params: null
      table: freeswitch_office.voicemail_prefs
      tablespace: null
      truncate: false
      trust_input: true
      unlogged: false
  item: office
  owner: freeswitch_krls_pbx2
  queries:
  - ALTER TABLE "freeswitch_office"."voicemail_prefs" OWNER TO "freeswitch_office"
  state: present
  storage_params: []
  table: freeswitch_office.voicemail_prefs
  tablespace: ''
```

AFTER:
```
ok: [krls1.sip.wiktel.com] => (item=freeswitch_office) => changed=false
  ansible_loop_var: item
  invocation:
    module_args:
      ca_cert: null
      cascade: false
      columns:
      - username                  varchar
      - domain                    varchar
      - name_path                 varchar
      - greeting_path             varchar
      - password                  varchar
      connect_params: {}
      db: freeswitch
      including: null
      like: null
      login_host: ''
      login_password: ''
      login_unix_socket: ''
      login_user: postgres
      name: freeswitch_office.voicemail_prefs
      owner: freeswitch_office
      port: 5432
      rename: null
      session_role: null
      ssl_cert: null
      ssl_key: null
      ssl_mode: prefer
      state: present
      storage_params: null
      table: freeswitch_office.voicemail_prefs
      tablespace: null
      truncate: false
      trust_input: true
      unlogged: false
  item: office
  owner: freeswitch_office
  queries: []
  state: present
  storage_params: []
  table: freeswitch_office.voicemail_prefs
  tablespace: ''
```