### PR TITLE
Deprecate some login aliases

### DIFF
--- a/changelogs/fragments/4-aliases.yml
+++ b/changelogs/fragments/4-aliases.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- postgresql modules = the ``login``, ``unix_socket`` and ``host`` aliases are deprecated and will be removed in ``community.postgresql 5.0.0``, use the ``login_user``, ``login_unix_socket`` and ``login_host`` arguments instead.

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -81,11 +81,29 @@ def postgres_common_argument_spec():
     return dict(
         login_user=dict(
             default='postgres' if not env_vars.get("PGUSER") else env_vars.get("PGUSER"),
-            aliases=['login']
+            aliases=['login'], deprecated_aliases=[
+                {
+                    'name': 'login',
+                    'version': '5.0.0',
+                    'collection_name': 'community.postgresql',
+                }
+            ],
         ),
         login_password=dict(default='', no_log=True),
-        login_host=dict(default='', aliases=['host']),
-        login_unix_socket=dict(default='', aliases=['unix_socket']),
+        login_host=dict(default='', aliases=['host'], deprecated_aliases=[
+            {
+                'name': 'host',
+                'version': '5.0.0',
+                'collection_name': 'community.postgresql',
+            }],
+        ),
+        login_unix_socket=dict(default='', aliases=['unix_socket'], deprecated_aliases=[
+            {
+                'name': 'unix_socket',
+                'version': '5.0.0',
+                'collection_name': 'community.postgresql',
+            }],
+        ),
         port=dict(
             type='int',
             default=int(env_vars.get("PGPORT", 5432)),

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -57,15 +57,13 @@ class TestPostgresCommonArgSpec():
         The return and expected dictionaries must be compared.
         """
         expected_dict = dict(
-            login_user=dict(default='postgres', aliases=['login'],
-                deprecated_aliases=[
-                    {
+            login_user=dict(default='postgres', aliases=['login'], deprecated_aliases=[
+                {
                         'name': 'login',
                         'version': '5.0.0',
                         'collection_name': 'community.postgresql',
-                    }
-                ]
-            ),
+                }
+            ]),
             login_password=dict(default='', no_log=True),
             login_host=dict(default='', aliases=['host'], deprecated_aliases=[
                 {

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -59,9 +59,9 @@ class TestPostgresCommonArgSpec():
         expected_dict = dict(
             login_user=dict(default='postgres', aliases=['login'], deprecated_aliases=[
                 {
-                        'name': 'login',
-                        'version': '5.0.0',
-                        'collection_name': 'community.postgresql',
+                    'name': 'login',
+                    'version': '5.0.0',
+                    'collection_name': 'community.postgresql',
                 }
             ]),
             login_password=dict(default='', no_log=True),

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -57,10 +57,30 @@ class TestPostgresCommonArgSpec():
         The return and expected dictionaries must be compared.
         """
         expected_dict = dict(
-            login_user=dict(default='postgres', aliases=['login']),
+            login_user=dict(default='postgres', aliases=['login'],
+                deprecated_aliases=[
+                    {
+                        'name': 'login',
+                        'version': '5.0.0',
+                        'collection_name': 'community.postgresql',
+                    }
+                ]
+            ),
             login_password=dict(default='', no_log=True),
-            login_host=dict(default='', aliases=['host']),
-            login_unix_socket=dict(default='', aliases=['unix_socket']),
+            login_host=dict(default='', aliases=['host'], deprecated_aliases=[
+                {
+                    'name': 'host',
+                    'version': '5.0.0',
+                    'collection_name': 'community.postgresql',
+                }
+            ]),
+            login_unix_socket=dict(default='', aliases=['unix_socket'], deprecated_aliases=[
+                {
+                    'name': 'unix_socket',
+                    'version': '5.0.0',
+                    'collection_name': 'community.postgresql',
+                }
+            ]),
             port=dict(type='int', default=5432, aliases=['login_port']),
             ssl_mode=dict(
                 default='prefer',


### PR DESCRIPTION
##### SUMMARY
Deprecate some login aliases

FYI there's also ``port`` (with ``login_port`` alias), but as it's not an alias I would tackle it in a separate PR later (no rush with it).