### PR TITLE
postgresql_alter_system: fix values returned in scientific notation (#854)

### DIFF
--- a/changelogs/fragments/0-alter_system.yml
+++ b/changelogs/fragments/0-alter_system.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_alter_system - fix failure when max_val contains a huge number written in scientific notation (https://github.com/ansible-collections/community.postgresql/issues/853).

--- a/plugins/modules/postgresql_alter_system.py
+++ b/plugins/modules/postgresql_alter_system.py
@@ -572,7 +572,16 @@ def convert_ret_vals(attrs):
         if str_contains_float(attrs[elem]):
             attrs[elem] = float(attrs[elem])
         else:
-            attrs[elem] = int(attrs[elem])
+            try:
+                attrs[elem] = int(attrs[elem])
+            except ValueError:
+                # Leave the attrs[elem] as-is, i.e. a string
+                # This can happen when max_value of type real
+                # is huge and written in scientific notation
+                # e.g., 1.79769e+308 (as of 2025-05-14, this is the only one)
+                # and it doesn't make sense to convert it as it'll be really huge
+                # https://github.com/ansible-collections/community.postgresql/issues/853
+                pass
 
     return attrs
 

--- a/tests/integration/targets/postgresql_alter_system/tasks/test_reals.yml
+++ b/tests/integration/targets/postgresql_alter_system/tasks/test_reals.yml
@@ -108,3 +108,17 @@
       - result["diff"]["before"]["setting"] == 1
       - result["diff"]["after"]["pending_restart"] == False
       - result["diff"]["after"]["setting"] == 1
+
+  # http://github.com/ansible-collections/community.postgresql/issues/853
+  # it should just pass w/o any error
+  - name: Set value of type real with a max val in scientific notation
+    <<: *task_parameters
+    postgresql_alter_system:
+      <<: *pg_parameters
+      param: random_page_cost
+      value: 4
+
+  - name: Check max_val
+    assert:
+      that:
+      - result["attrs"]["max_val"] == "1.79769e+308"


### PR DESCRIPTION

(cherry picked from commit f32de83d2c4fda21ef214a5e385edaa83cf64a1b)

##### SUMMARY
backport of https://github.com/ansible-collections/community.postgresql/pull/854

As it's just a backport as-is (same changes that in main) and i didn't do any edits, merging w/o approval