### PR TITLE
fix: report change in check mode when schema exists and state is absent

### DIFF
--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -288,7 +288,7 @@ def main():
     try:
         if module.check_mode:
             if state == "absent":
-                changed = not schema_exists(cursor, schema)
+                changed = schema_exists(cursor, schema)
             elif state == "present":
                 changed = not schema_matches(cursor, schema, owner, comment)
             module.exit_json(changed=changed, schema=schema)


### PR DESCRIPTION
##### SUMMARY

Removing an existing schema in check mode does not report changes.
However removing a non-existing schema in check mode does.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

postgresql_schema

##### ADDITIONAL INFORMATION

Example

```yaml
- name: Remove londiste schema from database
  become: true
  become_user: postgres
  community.postgresql.postgresql_schema:
    name: londisteee
    login_db: "{{ item.db }}"
    port: "{{ item.port }}"
    state: absent
    cascade_drop: true
  loop: "{{ londiste_cleanup }}"
```
