### PR TITLE
postgresql_privs: add suport for MAINTAIN privilege

### DIFF
--- a/changelogs/fragments/888-postgresql-priv-maintain.yml
+++ b/changelogs/fragments/888-postgresql-priv-maintain.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_privs - support MAINTAIN privilege on tables (added in PostgreSQL 17) (https://github.com/ansible-collections/community.postgresql/pull/888).

--- a/changelogs/fragments/nnn-postgresql-priv-maintain.yml
+++ b/changelogs/fragments/nnn-postgresql-priv-maintain.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - postgresql_privs - support MAINTAIN privilege on tables (added in PostgreSQL 17) (https://github.com/ansible-collections/community.postgresql/pulls/NNN).


### PR DESCRIPTION
PostgreSQL 17 added the MAINTAIN privilege for tables to allow VACUUM, ANALYZE, REINDEX, REFRESH MATERIALIZED VIEW, CLUSTER, and LOCK TABLE. See
https://www.postgresql.org/docs/17/release-17.html#RELEASE-17-PRIVILEGES
The MAINTAIN privilege had not been added to the postgres_privs yet, so here it is.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
postgresql_privs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
