### PR TITLE
ci: add stable-2.20 to matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -73,6 +73,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_20
+    displayName: Sanity & Units 2.20
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.20/sanity/1'
+            - name: Units
+              test: '2.20/units/1'
+
   - stage: Ansible_2_19
     displayName: Sanity & Units 2.19
     dependsOn: []
@@ -117,6 +129,21 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 42
+              test: fedora42
+            - name: Ubuntu 24.04
+              test: ubuntu2404
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+
+  - stage: Docker_2_20
+    displayName: Docker 2.20
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.20/linux/{0}/1
           targets:
             - name: Fedora 42
               test: fedora42
@@ -180,6 +207,19 @@ stages:
             - name: RHEL 9.6
               test: rhel/9.6
 
+  - stage: Remote_2_20
+    displayName: Remote 2.20
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.20/{0}/1
+          targets:
+            - name: RHEL 10.0
+              test: rhel/10.0
+            - name: RHEL 9.6
+              test: rhel/9.6
+
   - stage: Remote_2_19
     displayName: Remote 2.19
     dependsOn: []
@@ -237,14 +277,17 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_20
       - Ansible_2_19
       - Ansible_2_18
       - Ansible_2_17
       - Docker_devel
+      - Docker_2_20
       - Docker_2_19
       - Docker_2_18
       - Docker_2_17
       - Remote_devel
+      - Remote_2_20
       - Remote_2_19
       - Remote_2_18
       - Remote_2_17

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Tested with the following `ansible-core` releases:
 - 2.17
 - 2.18
 - 2.19
+- 2.20
 - current development version
 
 Ansible-core versions before 2.12.0 are not supported.

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,5 @@
+plugins/modules/postgresql_db.py use-argspec-type-path
+plugins/modules/postgresql_db.py validate-modules:use-run-command-not-popen
+plugins/module_utils/version.py pylint:unused-import
+tests/utils/shippable/timing.py shebang
+tests/unit/plugins/module_utils/test_postgres.py pylint:unidiomatic-typecheck


### PR DESCRIPTION
##### SUMMARY
ci: add stable-2.20 to matrix

as was announced in https://forum.ansible.com/t/ansible-core-devel-and-milestone-bumped-to-2-21-0-dev0/44684