### PR TITLE
postgresql_privs: enhance type=table documentation

### DIFF
--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -48,7 +48,7 @@ options:
     - The C(type) choice is available since Ansible version 2.10.
     - The C(procedure) is supported since collection version 1.3.0 and PostgreSQL 11.
     - The C(parameter) is supported since collection version 3.1.0 and PostgreSQL 15.
-    - The C(table) is inclusive of foreign tables since collection version 3.6.0.
+    - The C(table) also includes views and materialized views. It is inclusive of foreign tables since collection version 3.6.0.
     type: str
     default: table
     choices: [ database, default_privs, foreign_data_wrapper, foreign_server, function,


### PR DESCRIPTION
##### SUMMARY
`type=table` in postgresql_privs can be used to manage view or materialized view privileges.
Make this behavior explicit in `postgresql_privs` in documentation.

Fixes #841

##### ISSUE TYPE
- Docs Pull Reques

##### COMPONENT NAME
community.postgresql / postgresql_privs