### PR TITLE
chore: Remove RHEL 8.8,9.3 from AZP matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -242,35 +242,6 @@ stages:
             - name: RHEL 9.4
               test: rhel/9.4
 
-  - stage: Remote_2_17
-    displayName: Remote 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.17/{0}/1
-          targets:
-            - name: RHEL 9.3
-              test: rhel/9.3
-
-  # Keep this as long as the tests work.
-  # It allows us to test against PostgreSQL 10.
-  # PostgreSQL 13 is still supported, but the closest
-  # version we test against is 14.
-  # Keeping testing against 10 and 14 covers 13 as well.
-  # When these tests stop working and it's hard to fix
-  # remove this target and update the documentation.
-  - stage: Remote_2_16
-    displayName: Remote 2.16
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.16/{0}/1
-          targets:
-            - name: RHEL 8.8
-              test: rhel/8.8
-
 ## Finally
 
   - stage: Summary
@@ -290,7 +261,5 @@ stages:
       - Remote_2_20
       - Remote_2_19
       - Remote_2_18
-      - Remote_2_17
-      - Remote_2_16
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 
 | Docker image | Psycopg version | PostgreSQL version |
 |--------------|-----------------|--------------------|
-| RHEL 8       |           2.7.5 |               10   |
+| RHEL 9       |           2.9.6 |               13   |
 | Fedora 39    |           2.9.6 |               15   |
 | Ubuntu 22.04 |           3.1.9 |               16   |
 | Fedora 40/41 |           2.9.9 |               16   |


### PR DESCRIPTION
##### SUMMARY

chore: Remove RHEL 8.8,9.3 from AZP matrix

I left 9.4: PG 13 is now EOL, but costs nothing, so let's test
I missed somehow last time that it runs PG 13.

IMPORTANT: ignore the sanity failures as unrelated