### PR TITLE
Fix CI error reported by ansible-lint

### DIFF
--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -181,7 +181,6 @@ dst:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input,
     pg_quote_identifier,
@@ -296,11 +295,11 @@ class PgCopyData(object):
 
     def __transform_options(self):
         """Transform options dict into a suitable string."""
-        for (key, val) in iteritems(self.module.params['options']):
+        for (key, val) in self.module.params['options'].items():
             if key.upper() in self.opt_need_quotes:
                 self.module.params['options'][key] = "'%s'" % val
 
-        opt = ['%s %s' % (key, val) for (key, val) in iteritems(self.module.params['options'])]
+        opt = ['%s %s' % (key, val) for (key, val) in self.module.params['options'].items()]
         return '(%s)' % ', '.join(opt)
 
     def __check_table(self, table):
@@ -365,7 +364,7 @@ def main():
         # Check input for potentially dangerous elements:
         opt_list = None
         if module.params['options']:
-            opt_list = ['%s %s' % (key, val) for (key, val) in iteritems(module.params['options'])]
+            opt_list = ['%s %s' % (key, val) for (key, val) in module.params['options'].items()]
 
         check_input(module,
                     module.params['copy_to'],

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -156,7 +156,6 @@ from fnmatch import fnmatch
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import \
     check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -317,7 +316,7 @@ class PgClusterInfo(object):
             if not publications.get(elem['pubname']):
                 publications[elem['pubname']] = {}
 
-            for key, val in iteritems(elem):
+            for key, val in elem.items():
                 if key != 'pubname':
                     publications[elem['pubname']][key] = val
 
@@ -355,7 +354,7 @@ class PgClusterInfo(object):
             if not subscr_info[elem['dbname']].get(elem['subname']):
                 subscr_info[elem['dbname']][elem['subname']] = {}
 
-                for key, val in iteritems(elem):
+                for key, val in elem.items():
                     if key not in ('subname', 'dbname'):
                         subscr_info[elem['dbname']][elem['subname']][key] = val
 

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -254,7 +254,6 @@ parameters:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     check_input, pg_quote_identifier)
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -328,7 +327,7 @@ def transform_rowfilters_keys(rowfilters):
         rowfilters (dict): Changed dict.
     """
     revmap_filters = {}
-    for table, fltr in iteritems(rowfilters):
+    for table, fltr in rowfilters.items():
         fltr = fltr.strip()
         if fltr:
             if fltr[:5].lower() == 'where':
@@ -521,7 +520,7 @@ class PgPublication():
         if params:
             params_list = []
             # Make list ["param = 'value'", ...] from params dict:
-            for (key, val) in iteritems(params):
+            for (key, val) in params.items():
                 params_list.append("%s = '%s'" % (key, val))
 
             # Add the list to query_fragments:
@@ -634,7 +633,7 @@ class PgPublication():
 
         # Update pub parameters:
         if params:
-            for key, val in iteritems(params):
+            for key, val in params.items():
                 if self.attrs['parameters'].get(key):
 
                     # In PostgreSQL 10/11 only 'publish' optional parameter is presented.
@@ -875,7 +874,7 @@ class PgPublication():
             True if successful, False otherwise.
         """
         table_list = []
-        for table, columns in iteritems(columns_map):
+        for table, columns in columns_map.items():
             quoted_cols = pg_quote_column_list(table, columns)
             if table in rowfilters:
                 quoted_cols += (" WHERE %s" % rowfilters[table])
@@ -1035,7 +1034,7 @@ def main():
         if not params:
             params_list = None
         else:
-            params_list = ['%s = %s' % (k, v) for k, v in iteritems(params)]
+            params_list = ['%s = %s' % (k, v) for k, v in params.items()]
 
         check_input(module, name, tables, owner,
                     session_role, params_list, comment)

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -266,7 +266,6 @@ import time
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import \
     check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -419,7 +418,7 @@ def main():
                     # Ansible engine does not support decimals.
                     # An explicit conversion is required on the module's side
                     row = dict(row)
-                    for (key, val) in iteritems(row):
+                    for (key, val) in row.items():
                         if isinstance(val, TYPES_NEED_TO_CONVERT):
                             row[key] = convert_to_supported(val)
 

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -216,7 +216,6 @@ rowcount:
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import \
     check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -339,7 +338,7 @@ def main():
             # Ansible engine does not support decimals.
             # An explicit conversion is required on the module's side
             row = dict(row)
-            for (key, val) in iteritems(row):
+            for (key, val) in row.items():
                 if isinstance(val, TYPES_NEED_TO_CONVERT):
                     row[key] = convert_to_supported(val)
 

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -214,7 +214,6 @@ final_state:
 from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import \
     check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -247,7 +246,7 @@ def convert_conn_params(conn_dict):
         Connection string.
     """
     conn_list = []
-    for (param, val) in iteritems(conn_dict):
+    for (param, val) in conn_dict.items():
         conn_list.append('%s=%s' % (param, val))
 
     return ' '.join(conn_list)
@@ -263,7 +262,7 @@ def convert_subscr_params(params_dict):
         Parameters string.
     """
     params_list = []
-    for (param, val) in iteritems(params_dict):
+    for (param, val) in params_dict.items():
         if val is False:
             val = 'false'
         elif val is True:
@@ -280,7 +279,7 @@ def cast_connparams(connparams_dict):
     Returns:
         Dictionary
     """
-    for (param, val) in iteritems(connparams_dict):
+    for (param, val) in connparams_dict.items():
         try:
             connparams_dict[param] = int(val)
         except ValueError:
@@ -423,7 +422,7 @@ class PgSubscription():
         if subsparams:
             params_to_update = []
 
-            for (param, value) in iteritems(subsparams):
+            for (param, value) in subsparams.items():
                 if param == 'enabled':
                     if self.attrs['enabled'] and value is False:
                         changed = self.enable(enabled=False, check_mode=check_mode)

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -192,7 +192,6 @@ state:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import \
     check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -455,7 +454,7 @@ def main():
         if not settings:
             settings_list = None
         else:
-            settings_list = ['%s = %s' % (k, v) for k, v in iteritems(settings)]
+            settings_list = ['%s = %s' % (k, v) for k, v in settings.items()]
 
         check_input(module, tablespace, location, owner,
                     rename_to, session_role, settings_list, comment)

--- a/plugins/modules/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/postgresql_user_obj_stat_info.py
@@ -107,7 +107,6 @@ functions:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.community.postgresql.plugins.module_utils.database import \
     check_input
 from ansible_collections.community.postgresql.plugins.module_utils.postgres import (
@@ -252,7 +251,7 @@ class PgUserObjStatInfo():
             self.info[info_key][elem[schema_key]][elem[name_key]] = {}
 
             # Add other other attributes to a certain index:
-            for key, val in iteritems(elem):
+            for key, val in elem.items():
                 if key not in (schema_key, name_key):
                     self.info[info_key][elem[schema_key]][elem[name_key]][key] = val
 


### PR DESCRIPTION
##### SUMMARY
As discussed in #898, the CI has errors reported by ansible-lint:
https://dev.azure.com/ansible/community.postgresql/_build/results?buildId=165038&view=logs&j=df593170-0476-56b6-4a33-d8e2815d43d8&t=ed5b4094-b5e7-57c7-f236-602faf856c9f

>     01:27 ERROR: Found 9 pylint issue(s) which need to be resolved:
>     01:27 ERROR: plugins/module_utils/postgres.py:22:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (50%)
>     01:27 ERROR: plugins/modules/postgresql_copy.py:184:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (0%)
>     01:27 ERROR: plugins/modules/postgresql_info.py:159:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (50%)
>     01:27 ERROR: plugins/modules/postgresql_publication.py:257:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (0%)
>     01:27 ERROR: plugins/modules/postgresql_query.py:269:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (50%)
>     01:27 ERROR: plugins/modules/postgresql_script.py:219:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (50%)
>     01:27 ERROR: plugins/modules/postgresql_subscription.py:217:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (0%)
>     01:27 ERROR: plugins/modules/postgresql_tablespace.py:195:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (0%)
>     01:27 ERROR: plugins/modules/postgresql_user_obj_stat_info.py:110:0: ansible-bad-import-from: Import iteritems from the Python standard library equivalent instead of ansible.module_utils.six (0%)

This patch fixes these errors by removing the wrong imports and using .items() instead of iteritems()

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
It's in a lot of modules

##### ADDITIONAL INFORMATION
(I'm don't have a local full test environment for this project and could not reproduce the issue locally. I'm trusting the CI to test this properly)
