### PR TITLE
postgresql_db: fix integration test for fedora42

### DIFF
--- a/tests/integration/targets/postgresql_db/tasks/state_dump_restore_role.yml
+++ b/tests/integration/targets/postgresql_db/tasks/state_dump_restore_role.yml
@@ -87,7 +87,7 @@
   assert:
     that:
        - result is changed
-       - result.executed_commands[0] is search("/bin/pg_dump")
+       - result.executed_commands[0] is search("/s?bin/pg_dump")
        - result.executed_commands[0] is search("-n schema1")
 
 - name: pg_restore archive on dst_db with session_role
@@ -106,7 +106,7 @@
   assert:
     that:
        - result is changed
-       - result.executed_commands[0] is search("/bin/pg_restore")
+       - result.executed_commands[0] is search("/s?bin/pg_restore")
        - result.executed_commands[0] is search("--role=")
 
 - name: check restored schema1 owner is db_session_role1
@@ -166,7 +166,7 @@
   assert:
     that:
        - result is changed
-       - result.executed_commands[0] is search("/bin/pg_dump")
+       - result.executed_commands[0] is search("/s?bin/pg_dump")
        - result.executed_commands[0] is search("-n schema1")
        - result.executed_commands[0] is search("--role=")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Integration tests regarding dump/restore for `postgresql_db` were failing on Fedora42 target.
The reason was that Fedora42 has the `pg_dump`/`pg_restore` binaries under `/sbin` instead of `/bin`.
I replaced the regex pattern with one that supports both `/bin` and `/sbin` paths.