### PR TITLE
docs(CONTRIBUTING.md): Add AI policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ In this guide, you will find information relevant for code contributions, though
 
 If you have any questions after reading, please contact the community via one or more of the [available channels](https://github.com/ansible-collections/community.postgresql#communication). Any feedback on this guide is very welcome.
 
+## Using AI tools for assistance
+
+TBD: Add a link to the Ansible AI Policy once it's in place.
+
+When using AI tools to assist with contributing to this project, follow our AI policy:
+
+- You MAY use the assistance of AI tools for contributing to this project, as long as you take full responsibility for your contributions and follow the principles described in this section.
+- The use of AI tools MUST be explicitly disclosed by you when a significant part of the contribution is taken from the AI tool's output without significant changes. Grammar, spelling, and stylistic corrections do not require disclosure.
+- Contributions MUST NOT be submitted by AI agents. Maintainers of this project may reject such contributions for violating this policy.
+
+We recommend using the [AGENTS.md](https://github.com/ansible-collections/community.postgresql/blob/main/AGENTS.md) file and [skills](https://github.com/ansible-collections/community.postgresql/tree/main/.agents/skills) provided in this repository when contributing with AI tools.
+
 ## Reviewing open issue and pull requests
 
 Refer to the [review checklist](https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_reviewing.html) when triaging issues or reviewing pull requests (hereinafter PRs).


### PR DESCRIPTION
##### SUMMARY
docs(CONTRIBUTING.md): Add [our local] AI policy

- There's a placeholder `TBD: Add a link to the Ansible AI Policy once it's in place.` not to forget to add a reference to the Ansible main [AI policy](https://forum.ansible.com/t/ansible-community-ai-policy-proposal/45655) once accepted. FYI
- I use full URLs to local file to make it work in Galaxy UI (otherwise, people will get 404).
