### PR TITLE
ci(azure-pipelines.yml): Fedora 43 -> 44 in devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -130,8 +130,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 44
+              test: fedora44
             - name: Ubuntu 24.04
               test: ubuntu2404
             - name: Ubuntu 22.04

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 | Fedora 40/41 |           2.9.9 |               16   |
 | RHEL 10      |           2.9.9 |               16   |
 | Ubuntu 24.04 |           3.2.2 |               17   |
+| Fedora 44    |          2.9.10 |               18   |
 
 ## Included content
 

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -24,15 +24,22 @@
       paths:
       - '{{ role_path }}/vars'
 
+- name: Install dbus-broker (Fedora)
+  package:
+    name: dbus-broker
+    state: present
+  when:
+    - ansible_service_mgr == 'systemd'
+    - ansible_distribution == 'Fedora'
+    - ansible_distribution_major_version is version('44', '>=')
+
 - name: Make sure the dbus service is enabled under systemd
   shell: systemctl enable dbus || systemctl enable dbus-broker
   ignore_errors: true
   when: ansible_service_mgr == 'systemd' and ansible_distribution == 'Fedora'
 
 - name: Make sure the dbus service is started under systemd
-  systemd:
-    name: dbus
-    state: started
+  shell: systemctl start dbus || systemctl start dbus-broker
   when: ansible_service_mgr == 'systemd' and ansible_distribution == 'Fedora'
 
 - name: stop postgresql service


### PR DESCRIPTION
##### SUMMARY
ci(azure-pipelines.yml): Fedora 43 -> 44 in devel

There's was some package related change in Fedora 44 compared to 43.