### PR TITLE
docs: add the idempotent attribute to the description of all the modules

### DIFF
--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -77,7 +77,10 @@ options:
 attributes:
   check_mode:
     description: Can run in check_mode and return changed status prediction without modifying target.
-
+  idempotent:
+    description:
+      - When run twice in a row outside check mode, with the same arguments, the second invocation indicates no change.
+      - This assumes that the system controlled/queried by the module has not changed in a relevant way.
 notes:
 - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
 - To avoid "Peer authentication failed for user postgres" error,

--- a/plugins/modules/postgresql_alter_system.py
+++ b/plugins/modules/postgresql_alter_system.py
@@ -69,9 +69,9 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(value=_RESET) — it always runs C(ALTER SYSTEM RESET)
-        and reports RV(changed=true).
+        and reports changed=true.
       - For all other values, the module compares the desired value against the current
-        setting in C(pg_catalog.pg_settings) and reports RV(changed=false) when they match.
+        setting in C(pg_catalog.pg_settings) and reports changed=false when they match.
 
 seealso:
 - module: community.postgresql.postgresql_info

--- a/plugins/modules/postgresql_alter_system.py
+++ b/plugins/modules/postgresql_alter_system.py
@@ -65,6 +65,13 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+      - The module is not idempotent when O(value=_RESET) — it always runs C(ALTER SYSTEM RESET)
+        and reports RV(changed=true).
+      - For all other values, the module compares the desired value against the current
+        setting in C(pg_catalog.pg_settings) and reports RV(changed=false) when they match.
 
 seealso:
 - module: community.postgresql.postgresql_info

--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -91,6 +91,11 @@ attributes:
       - If i(check_mode=true) and the source has been passed as SQL, the module
         will execute it and roll the transaction back, but pay attention
         it can affect database performance (e.g., if SQL collects a lot of data).
+  idempotent:
+    support: none
+    details:
+      - The module always executes the C(COPY) command and reports RV(changed=true) on success,
+        without comparing source and destination state.
 
 seealso:
 - name: COPY command reference

--- a/plugins/modules/postgresql_copy.py
+++ b/plugins/modules/postgresql_copy.py
@@ -94,7 +94,7 @@ attributes:
   idempotent:
     support: none
     details:
-      - The module always executes the C(COPY) command and reports RV(changed=true) on success,
+      - The module always executes the C(COPY) command and reports changed=true on success,
         without comparing source and destination state.
 
 seealso:

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -175,9 +175,9 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(state=dump) — it always invokes C(pg_dump) and writes
-        the C(target) file, reporting RV(changed=true) on every invocation.
+        the C(target) file, reporting changed=true on every invocation.
       - The module is not idempotent when O(state=restore) — it always executes the contents of the
-        C(target) file against the database and reports RV(changed=true).
+        C(target) file against the database and reports changed=true.
 
 author: "Ansible Core Team"
 

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -171,6 +171,13 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+      - The module is not idempotent when O(state=dump) — it always invokes C(pg_dump) and writes
+        the C(target) file, reporting RV(changed=true) on every invocation.
+      - The module is not idempotent when O(state=restore) — it always executes the contents of the
+        C(target) file against the database and reports RV(changed=true).
 
 author: "Ansible Core Team"
 

--- a/plugins/modules/postgresql_ext.py
+++ b/plugins/modules/postgresql_ext.py
@@ -116,6 +116,8 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 author:
 - Daniel Schep (@dschep)

--- a/plugins/modules/postgresql_idx.py
+++ b/plugins/modules/postgresql_idx.py
@@ -143,6 +143,8 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 author:
 - Andrew Klychkov (@Andersson007)

--- a/plugins/modules/postgresql_info.py
+++ b/plugins/modules/postgresql_info.py
@@ -50,6 +50,8 @@ options:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 seealso:
 - module: community.postgresql.postgresql_ping

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -93,6 +93,8 @@ seealso:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 author:
 - Andrew Klychkov (@Andersson007)

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -107,7 +107,7 @@ attributes:
     support: partial
     details:
      - The module is not idempotent when O(reassign_owned_by) is used — it always executes
-        C(REASSIGN OWNED BY) and reports RV(changed=true).
+        C(REASSIGN OWNED BY) and reports changed=true.
 
 author:
 - Andrew Klychkov (@Andersson007)

--- a/plugins/modules/postgresql_owner.py
+++ b/plugins/modules/postgresql_owner.py
@@ -103,6 +103,11 @@ seealso:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+     - The module is not idempotent when O(reassign_owned_by) is used — it always executes
+        C(REASSIGN OWNED BY) and reports RV(changed=true).
 
 author:
 - Andrew Klychkov (@Andersson007)

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -161,6 +161,8 @@ attributes:
   diff_mode:
     support: full
     description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
+  idempotent:
+    support: full
 
 author:
 - Sebastiaan Mannem (@sebasmannem)

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -163,6 +163,7 @@ attributes:
     description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
   idempotent:
     support: full
+    description: When run twice in a row outside check mode, with the same values, the second run indicates no change
 
 author:
 - Sebastiaan Mannem (@sebasmannem)

--- a/plugins/modules/postgresql_ping.py
+++ b/plugins/modules/postgresql_ping.py
@@ -42,6 +42,8 @@ seealso:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment:

--- a/plugins/modules/postgresql_privs.py
+++ b/plugins/modules/postgresql_privs.py
@@ -153,6 +153,8 @@ seealso:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 extends_documentation_fragment:
 - community.postgresql.postgres

--- a/plugins/modules/postgresql_publication.py
+++ b/plugins/modules/postgresql_publication.py
@@ -113,6 +113,8 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 seealso:
 - name: CREATE PUBLICATION reference

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -88,9 +88,9 @@ attributes:
     support: none
     details:
       - The module executes arbitrary user-supplied SQL commands and cannot determine whether a given query
-        would modify state. For non-read-only queries, RV(changed) is set based on the PostgreSQL
+        would modify state. For non-read-only queries, state change is set based on the PostgreSQL
         C(statusmessage) heuristic (e.g., C(INSERT)/C(UPDATE)/C(DELETE) with non-zero affected rows
-        report RV(changed=true), regardless of the state which existed before the query execution).
+        report changed=true, regardless of the state which existed before the query execution).
 
 author:
 - Felix Archambault (@archf)

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -84,6 +84,13 @@ seealso:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: none
+    details:
+      - The module executes arbitrary user-supplied SQL commands and cannot determine whether a given query
+        would modify state. For non-read-only queries, RV(changed) is set based on the PostgreSQL
+        C(statusmessage) heuristic (e.g., C(INSERT)/C(UPDATE)/C(DELETE) with non-zero affected rows
+        report RV(changed=true), regardless of the state which existed before the query execution).
 
 author:
 - Felix Archambault (@archf)

--- a/plugins/modules/postgresql_schema.py
+++ b/plugins/modules/postgresql_schema.py
@@ -84,6 +84,8 @@ seealso:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 author:
 - Flavien Chantelot (@Dorn-) <contact@flavien.io>

--- a/plugins/modules/postgresql_script.py
+++ b/plugins/modules/postgresql_script.py
@@ -87,6 +87,8 @@ seealso:
 attributes:
   check_mode:
     support: none
+  idempotent:
+    support: none
 
 author:
 - Douglas J Hunley (@hunleyd)

--- a/plugins/modules/postgresql_sequence.py
+++ b/plugins/modules/postgresql_sequence.py
@@ -151,6 +151,8 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 seealso:
 - module: community.postgresql.postgresql_table

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -85,6 +85,12 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+      - The module is not idempotent when O(value=default) — it always executes
+        C(ALTER SYSTEM SET ... = DEFAULT) and reports RV(changed=true), regardless of whether
+        the parameter currently has an override in C(postgresql.auto.conf).
 
 seealso:
 - module: community.postgresql.postgresql_alter_system

--- a/plugins/modules/postgresql_set.py
+++ b/plugins/modules/postgresql_set.py
@@ -89,7 +89,7 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(value=default) — it always executes
-        C(ALTER SYSTEM SET ... = DEFAULT) and reports RV(changed=true), regardless of whether
+        C(ALTER SYSTEM SET ... = DEFAULT) and reports changed=true, regardless of whether
         the parameter currently has an override in C(postgresql.auto.conf).
 
 seealso:

--- a/plugins/modules/postgresql_slot.py
+++ b/plugins/modules/postgresql_slot.py
@@ -83,6 +83,8 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 seealso:
 - name: PostgreSQL pg_replication_slots view reference

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -108,6 +108,11 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+      - The module is not idempotent when O(state=refresh) — it always executes
+        C(ALTER SUBSCRIPTION ... REFRESH PUBLICATION) and reports RV(changed=true).
 
 seealso:
 - module: community.postgresql.postgresql_publication

--- a/plugins/modules/postgresql_subscription.py
+++ b/plugins/modules/postgresql_subscription.py
@@ -112,7 +112,7 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(state=refresh) — it always executes
-        C(ALTER SUBSCRIPTION ... REFRESH PUBLICATION) and reports RV(changed=true).
+        C(ALTER SUBSCRIPTION ... REFRESH PUBLICATION) and reports changed=true.
 
 seealso:
 - module: community.postgresql.postgresql_publication

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -116,6 +116,12 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+      - The module is not idempotent when O(truncate=true) — it always executes
+        C(TRUNCATE TABLE) and reports RV(changed=true) always creating
+        a new table with the same schema and dropping the old table.
 
 seealso:
 - module: community.postgresql.postgresql_sequence

--- a/plugins/modules/postgresql_table.py
+++ b/plugins/modules/postgresql_table.py
@@ -120,7 +120,7 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(truncate=true) — it always executes
-        C(TRUNCATE TABLE) and reports RV(changed=true) always creating
+        C(TRUNCATE TABLE) and reports changed=true always creating
         a new table with the same schema and dropping the old table.
 
 seealso:

--- a/plugins/modules/postgresql_tablespace.py
+++ b/plugins/modules/postgresql_tablespace.py
@@ -96,6 +96,8 @@ attributes:
       - I(state=absent) and I(state=present) (the second one if the tablespace doesn't exist) do not
         support check mode because the corresponding PostgreSQL DROP and CREATE TABLESPACE commands
         can not be run inside the transaction block.
+  idempotent:
+    support: full
 
 seealso:
 - name: PostgreSQL tablespaces

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -196,7 +196,7 @@ attributes:
     support: partial
     details:
       - On systems where C(pg_authid) is not accessible (such as AWS RDS), the module cannot compare
-        the current and desired password and reports RV(changed=true) on every invocation when a
+        the current and desired password and reports changed=true on every invocation when a
         password is specified.
 
 seealso:

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -192,6 +192,12 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: partial
+    details:
+      - On systems where C(pg_authid) is not accessible (such as AWS RDS), the module cannot compare
+        the current and desired password and reports RV(changed=true) on every invocation when a
+        password is specified.
 
 seealso:
 - module: community.postgresql.postgresql_privs

--- a/plugins/modules/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/postgresql_user_obj_stat_info.py
@@ -58,6 +58,8 @@ notes:
 attributes:
   check_mode:
     support: full
+  idempotent:
+    support: full
 
 seealso:
 - module: community.postgresql.postgresql_info


### PR DESCRIPTION
##### SUMMARY
Added the idempotent attribute to all the modules in the collection. The attribute might have one of the statuses - "full", "partial" or "none", depending on how idempotent a given module is. If the status is "partial", the details section describes the cases when the module is not idempotent. The conclusions were made based on each modules description and corresponding integration tests.

Fixes #786

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
All modules

##### ADDITIONAL INFORMATION
```
