### PR TITLE
[stable-3] ci(azure-pipelines.yml): bump test container version to 8.0.0 (#923)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:7.0.0
+      image: quay.io/ansible/azure-pipelines-test-container:8.0.0
 
 pool: Standard
 
@@ -109,18 +109,6 @@ stages:
             - name: Units
               test: '2.18/units/1'
 
-  - stage: Ansible_2_17
-    displayName: Sanity & Units 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.17/sanity/1'
-            - name: Units
-              test: '2.17/units/1'
-
 ## Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -132,6 +120,8 @@ stages:
           targets:
             - name: Fedora 44
               test: fedora44
+            - name: Ubuntu 26.04
+              test: ubuntu2604
             - name: Ubuntu 24.04
               test: ubuntu2404
 
@@ -177,7 +167,6 @@ stages:
               test: fedora43
             - name: Ubuntu 22.04
               test: ubuntu2204
-
 
 ## Remote
   - stage: Remote_devel
@@ -241,7 +230,6 @@ stages:
       - Docker_2_20
       - Docker_2_19
       - Docker_2_18
-      - Docker_2_17
       - Remote_devel
       - Remote_2_20
       - Remote_2_19

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -133,8 +133,8 @@ stages:
         parameters:
           testFormat: 2.20/linux/{0}/1
           targets:
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 42
+              test: fedora42
             - name: Ubuntu 24.04
               test: ubuntu2404
             - name: Ubuntu 22.04
@@ -148,8 +148,8 @@ stages:
         parameters:
           testFormat: 2.19/linux/{0}/1
           targets:
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 41
+              test: fedora41
             - name: Ubuntu 24.04
               test: ubuntu2404
             - name: Ubuntu 22.04
@@ -163,10 +163,11 @@ stages:
         parameters:
           testFormat: 2.18/linux/{0}/1
           targets:
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 40
+              test: fedora40
             - name: Ubuntu 22.04
               test: ubuntu2204
+
 
 ## Remote
   - stage: Remote_devel

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Our AZP CI includes testing with the following docker images / PostgreSQL versio
 | Ubuntu 22.04 |           3.1.9 |               16   |
 | Fedora 40/41 |           2.9.9 |               16   |
 | Ubuntu 24.04 |           3.2.2 |               17   |
+| Ubuntu 26.04 |           3.2.2 |               18   |
 | Fedora 44    |          2.9.10 |               18   |
 
 ## Included content

--- a/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-26-py3.yml
+++ b/tests/integration/targets/setup_postgresql_db/vars/Ubuntu-26-py3.yml
@@ -1,0 +1,18 @@
+pg_ver: 18
+
+postgresql_packages:
+  - "apt-utils"
+  - "postgresql-{{ pg_ver }}"
+  - "postgresql-common"
+  # - "python3-psycopg2"
+  - "postgresql-client-{{ pg_ver }}"
+
+pip_packages:
+  - "psycopg==3.2.2" # We need at least 3.1 for Client-side-binding cursors
+
+pg_conf_location: "/etc/postgresql/{{ pg_ver }}/main/postgresql.conf"
+pg_hba_location: "/etc/postgresql/{{ pg_ver }}/main/pg_hba.conf"
+pg_dir: "/var/lib/postgresql/{{ pg_ver }}/main"
+pg_auto_conf: "{{ pg_dir }}/postgresql.auto.conf"
+
+postgis: postgresql-{{ pg_ver }}-postgis-3

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -5,12 +5,4 @@ tests/utils/shippable/timing.py shebang
 tests/unit/plugins/module_utils/test_postgres.py pylint:unidiomatic-typecheck
 plugins/module_utils/postgres.py pylint:ansible-bad-import-from
 plugins/module_utils/saslprep.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_copy.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_info.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_publication.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_query.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_script.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_subscription.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_tablespace.py pylint:ansible-bad-import-from
 plugins/modules/postgresql_user.py pylint:ansible-bad-import-from
-plugins/modules/postgresql_user_obj_stat_info.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -3,3 +3,14 @@ plugins/modules/postgresql_db.py pylint:ansible-bad-function
 plugins/module_utils/version.py pylint:unused-import
 tests/utils/shippable/timing.py shebang
 tests/unit/plugins/module_utils/test_postgres.py pylint:unidiomatic-typecheck
+plugins/module_utils/postgres.py pylint:ansible-bad-import-from
+plugins/module_utils/saslprep.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_copy.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_info.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_publication.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_query.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_script.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_subscription.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_tablespace.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_user.py pylint:ansible-bad-import-from
+plugins/modules/postgresql_user_obj_stat_info.py pylint:ansible-bad-import-from


### PR DESCRIPTION
* ci(azure-pipelines.yml): bump test container version to 8.0.0

* fixes

* Fix

* Add vars file for Ubuntu 26.04

* Update README

(cherry picked from commit 823e76ecc01a39028d002b397433df7b65029552)

##### SUMMARY
ci(azure-pipelines.yml): bump test container version to 8.0.0 (#923)

Backport of https://github.com/ansible-collections/community.postgresql/pull/923