### PR TITLE
[stable-3] Update CI test matrix: Fedora 43 and fix deprecated modules (#911)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -143,8 +143,8 @@ stages:
         parameters:
           testFormat: 2.20/linux/{0}/1
           targets:
-            - name: Fedora 42
-              test: fedora42
+            - name: Fedora 43
+              test: fedora43
             - name: Ubuntu 24.04
               test: ubuntu2404
             - name: Ubuntu 22.04
@@ -158,8 +158,8 @@ stages:
         parameters:
           testFormat: 2.19/linux/{0}/1
           targets:
-            - name: Fedora 41
-              test: fedora41
+            - name: Fedora 43
+              test: fedora43
             - name: Ubuntu 24.04
               test: ubuntu2404
             - name: Ubuntu 22.04
@@ -173,23 +173,11 @@ stages:
         parameters:
           testFormat: 2.18/linux/{0}/1
           targets:
-            - name: Fedora 40
-              test: fedora40
+            - name: Fedora 43
+              test: fedora43
             - name: Ubuntu 22.04
               test: ubuntu2204
 
-  - stage: Docker_2_17
-    displayName: Docker 2.17
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.17/linux/{0}/1
-          targets:
-            - name: Fedora 39
-              test: fedora39
-            - name: Ubuntu 22.04
-              test: ubuntu2204
 
 ## Remote
   - stage: Remote_devel

--- a/tests/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/tests/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -237,7 +237,7 @@
         encoding: 'LATIN1'
         lc_collate: 'pt_BR{{ locale_latin_suffix }}'
         lc_ctype: 'es_ES{{ locale_latin_suffix }}'
-        icu_locale: "{{ 'es-ES-x-icu' if (ansible_facts.distribution == 'Fedora' and ansible_facts.distribution_major_version is version('40', 'ge')) else omit }}"
+        icu_locale: "{{ 'es-ES-x-icu' if (ansible_facts.distribution == 'Fedora' and ansible_facts.distribution_major_version is version('43', 'ge')) else omit }}"
         locale_provider: 'icu'
         template: 'template0'
         login_user: "{{ pg_user }}"

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -85,9 +85,10 @@
       state: 'present'
 
   - name: Import the repository signing key
-    ansible.builtin.apt_key:
-      state: present
+    ansible.builtin.get_url:
       url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+      dest: /etc/apt/trusted.gpg.d/postgresql.asc
+      mode: '0644'
 
   - name: Update the package lists
     apt:


### PR DESCRIPTION
- Upgrade Fedora docker targets to 43 across all ansible versions (devel, 2.20, 2.19, 2.18)
- Remove Docker_2_17 stage from CI pipeline
- Replace deprecated apt_key with get_url for PostgreSQL repo signing key
- Update icu_locale version check from Fedora 40 to 43

(cherry picked from commit 8cc1a8ae99f8ccfc43be26007aa9be13e5ba8b9a)

##### SUMMARY
Backport of https://github.com/ansible-collections/community.postgresql/pull/911