### PR TITLE
Allow selective unquoted user configuration values

### DIFF
--- a/changelogs/fragments/quote-configuration-values-exclude.yml
+++ b/changelogs/fragments/quote-configuration-values-exclude.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - postgresql_user - add the ``quote_configuration_values_exclude`` option to keep selected configuration values
+    unquoted while preserving default quoting for other values.

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -145,9 +145,9 @@ options:
       - Removes any parameter from the user that is not listed here.
       - Parameters that are present in the database but are not included in this list will only be reset, if
         O(reset_unspecified_configuration=true).
-      - Inputs to O(user) as well as keys and values in this parameter are quoted by the module. If you require the
-        user to contain a C("), you need to double it, otherwise the module will fail. C(") and C(') are not allowed in
-        configuration keys and any C(') in the value of a configuration will be escaped by this module.
+      - Inputs to O(user) as well as keys and values in this parameter are quoted by the module by default. If you
+        require the user to contain a C("), you need to double it, otherwise the module will fail. C(") and C(') are
+        not allowed in configuration keys and any C(') in quoted configuration values will be escaped by this module.
         Additionally, parameters and values are checked if O(trust_input) is C(false).
     type: dict
     default: {}
@@ -165,12 +165,26 @@ options:
         and setting this to C(false) leaves these options open to SQL-injections and makes the user responsible for
         properly quoting values.
       - This is required to be C(false) to modify settings like C(search_path), that need to be unquoted.
+      - To disable quoting only for selected parameters, use O(quote_configuration_values_exclude).
       - If this is C(false) you will also need to make sure that strings are properly quoted.
         For example C("'16MB'") for C(work_mem).
       - Set this only to C(false) if you know what you are doing!
     type: bool
     default: true
     version_added: '3.11.0'
+  quote_configuration_values_exclude:
+    description:
+      - List of configuration parameter names whose values are not quoted when O(quote_configuration_values=true).
+      - This is useful for settings such as C(search_path), which require an unquoted value, while keeping automatic
+        quoting for other configuration values.
+      - Values for excluded parameters are inserted into SQL unquoted, so the user is responsible for properly quoting
+        them when needed.
+      - This option has no additional effect when O(quote_configuration_values=false), because all values are already
+        unquoted.
+    type: list
+    elements: str
+    default: []
+    version_added: '4.3.0'
 notes:
 - The module creates a user (role) with login privilege by default.
   Use C(NOLOGIN) I(role_attr_flags) to change this behaviour.
@@ -285,9 +299,11 @@ EXAMPLES = r'''
 - name: Set search_path for user
   community.postgresql.postgresql_user:
     name: postgres_exporter
-    quote_configuration_values: false
+    quote_configuration_values_exclude:
+      - search_path
     configuration:
       search_path: postgres_exporter, pg_catalog, public
+      work_mem: "16MB"
 '''
 
 RETURN = r'''
@@ -786,12 +802,21 @@ def parse_user_configuration(module, configs):
         return {}
 
 
-def user_configuration(cursor, module, user, configuration, reset_unspec_config, quote_values):
+def validate_configuration(module, configuration):
+    """Validate configuration keys that are interpolated into ALTER ROLE statements."""
+    for key in configuration:
+        if '"' in key or '\'' in key:
+            module.fail_json("The key of a configuration may not contain single or double quotes")
+
+
+def user_configuration(cursor, module, user, configuration, reset_unspec_config, quote_values,
+                       quote_values_exclude):
     """Updates the user's configuration parameters if necessary."""
     current_config_query = "SELECT rolconfig FROM pg_roles WHERE rolname = %(user)s;"
     cursor.execute(current_config_query, {"user": user})
     current_config = cursor.fetchone()
     changed = False
+    quote_values_exclude = set(quote_values_exclude)
 
     if current_config is None:
         module.fail_json(msg="Can't find user %(user)s in 'pg_roles'" % {"user": user})
@@ -808,9 +833,9 @@ def user_configuration(cursor, module, user, configuration, reset_unspec_config,
             cursor.execute(query)
             changed = True
         for key, value in config_updates["update"].items():
-            if quote_values:
+            if quote_values and key not in quote_values_exclude:
                 query = ('ALTER ROLE %(user)s SET "%(key)s" TO \'%(value)s\';' %
-                         {"user": _pg_quote_user(user, module), "key": key, "value": value})
+                         {"user": _pg_quote_user(user, module), "key": key, "value": value.replace("'", "''")})
             else:
                 query = ('ALTER ROLE %(user)s SET "%(key)s" TO %(value)s;' %
                          {"user": _pg_quote_user(user, module), "key": key, "value": value})
@@ -866,6 +891,7 @@ def main():
         configuration=dict(type='dict', default={}),
         reset_unspecified_configuration=dict(type='bool', default=False),
         quote_configuration_values=dict(type='bool', default=True),
+        quote_configuration_values_exclude=dict(type='list', elements='str', default=[]),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -889,6 +915,7 @@ def main():
     configuration = module.params['configuration']
     reset_unspec_config = module.params['reset_unspecified_configuration']
     quote_configuration_values = module.params['quote_configuration_values']
+    quote_configuration_values_exclude = module.params['quote_configuration_values_exclude']
 
     trust_input = module.params['trust_input']
     if not trust_input:
@@ -904,12 +931,7 @@ def main():
 
     srv_version = get_server_version(db_connection)
 
-    # sanitize configuration
-    if quote_configuration_values:
-        for key, value in configuration.items():
-            if '"' in key or '\'' in key:
-                module.fail_json("The key of a configuration may not contain single or double quotes")
-            configuration[key] = value.replace("'", "''")
+    validate_configuration(module, configuration)
 
     try:
         role_attr_flags = parse_role_attrs(role_attr_flags, srv_version)
@@ -946,7 +968,7 @@ def main():
 
         # handle user-specific configuration-defaults
         changed = user_configuration(cursor, module, user, configuration, reset_unspec_config,
-                                     quote_configuration_values) or changed
+                                     quote_configuration_values, quote_configuration_values_exclude) or changed
 
     else:
         if user_exists(cursor, user):

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -807,6 +807,74 @@
         - result.rowcount == 1
         - result.query_result[0]['rolconfig'] == ["search_path=pg_catalog, public", "work_mem=16MB"]
 
+  - name: Test setting mixed quoted and unquoted configuration values with exclusions
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      quote_configuration_values_exclude:
+        - search_path
+      configuration:
+        search_path: 'pg_catalog, public'
+        work_mem: "16MB"
+        temp_buffers: "8MB"
+
+  - assert:
+      that:
+        - result.changed
+
+  - name: Test that mixed quoted and unquoted settings are correct
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - (result.query_result[0]['rolconfig'] | sort) == (["search_path=pg_catalog, public", "work_mem=16MB", "temp_buffers=8MB"] | sort)
+
+  - name: Test reset_unspecified_configuration with mixed quoted and unquoted configuration values
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      quote_configuration_values_exclude:
+        - search_path
+      configuration:
+        search_path: 'pg_catalog, public'
+        work_mem: "16MB"
+      reset_unspecified_configuration: true
+
+  - assert:
+      that:
+        - result.changed
+
+  - name: Test idempotency of mixed quoted and unquoted configuration values with reset_unspecified_configuration
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user }}'
+      quote_configuration_values_exclude:
+        - search_path
+      configuration:
+        search_path: 'pg_catalog, public'
+        work_mem: "16MB"
+      reset_unspecified_configuration: true
+
+  - assert:
+      that:
+        - not result.changed
+
+  - name: Test that mixed quoted and unquoted settings are still correct
+    <<: *task_parameters
+    postgresql_query:
+      query: "SELECT rolconfig from pg_roles where rolname = '{{ test_user }}'"
+
+  - assert:
+      that:
+        - result.rowcount == 1
+        - (result.query_result[0]['rolconfig'] | sort) == (["search_path=pg_catalog, public", "work_mem=16MB"] | sort)
+
   - name: Purge configuration parameters from user
     <<: *task_parameters
     postgresql_user:

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -12,10 +12,24 @@ import sys
 import pytest
 
 if sys.version_info[0] == 3:
+    import plugins.modules.postgresql_user as postgresql_user
     from plugins.modules.postgresql_user import parse_user_configuration, compare_user_configurations, _pg_quote_user
 elif sys.version_info[0] == 2:
+    import ansible_collections.community.postgresql.plugins.modules.postgresql_user as postgresql_user
     from ansible_collections.community.postgresql.plugins.modules.postgresql_user import parse_user_configuration, \
         compare_user_configurations, _pg_quote_user
+
+
+class UserConfigurationCursor(object):
+    def __init__(self, rolconfig):
+        self.rolconfig = rolconfig
+        self.queries = []
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+
+    def fetchone(self):
+        return {'rolconfig': self.rolconfig}
 
 
 def test_parse_user_configuration(mocker):
@@ -69,6 +83,50 @@ def test_compare_user_configurations():
     assert output == no_reset_expected
     output = compare_user_configurations(current, {}, False)
     assert output == {"reset": [], "update": {}}
+
+
+def test_user_configuration_quote_values_exclude(mocker):
+    """Tests if selected configuration values can be set without quotes"""
+    module = mocker.MagicMock()
+    cursor = UserConfigurationCursor(None)
+    configuration = {
+        "search_path": "pg_catalog, public",
+        "work_mem": "16MB",
+        "application_name": "some ' value",
+    }
+    postgresql_user.executed_queries[:] = []
+
+    changed = postgresql_user.user_configuration(
+        cursor, module, "someuser", configuration, False, True, ["search_path"])
+
+    assert changed
+    assert cursor.queries[1][0] == 'ALTER ROLE "someuser" SET "search_path" TO pg_catalog, public;'
+    assert cursor.queries[2][0] == 'ALTER ROLE "someuser" SET "work_mem" TO \'16MB\';'
+    assert cursor.queries[3][0] == 'ALTER ROLE "someuser" SET "application_name" TO \'some \'\' value\';'
+
+
+def test_user_configuration_quote_values_exclude_reset_unspecified(mocker):
+    """Tests if mixed quoted and unquoted values stay idempotent when resetting unspecified values"""
+    module = mocker.MagicMock()
+    cursor = UserConfigurationCursor([
+        "search_path=pg_catalog, public",
+        "work_mem=16MB",
+        "application_name=some ' value",
+        "temp_buffers=8MB",
+    ])
+    configuration = {
+        "search_path": "pg_catalog, public",
+        "work_mem": "16MB",
+        "application_name": "some ' value",
+    }
+    postgresql_user.executed_queries[:] = []
+
+    changed = postgresql_user.user_configuration(
+        cursor, module, "someuser", configuration, True, True, ["search_path"])
+
+    assert changed
+    assert len(cursor.queries) == 2
+    assert cursor.queries[1][0] == 'ALTER ROLE "someuser" RESET "temp_buffers";'
 
 
 def test__pg_quote_user(mocker):

--- a/tests/unit/plugins/modules/test_postgresql_user.py
+++ b/tests/unit/plugins/modules/test_postgresql_user.py
@@ -12,10 +12,10 @@ import sys
 import pytest
 
 if sys.version_info[0] == 3:
-    import plugins.modules.postgresql_user as postgresql_user
+    from plugins.modules import postgresql_user
     from plugins.modules.postgresql_user import parse_user_configuration, compare_user_configurations, _pg_quote_user
 elif sys.version_info[0] == 2:
-    import ansible_collections.community.postgresql.plugins.modules.postgresql_user as postgresql_user
+    from ansible_collections.community.postgresql.plugins.modules import postgresql_user
     from ansible_collections.community.postgresql.plugins.modules.postgresql_user import parse_user_configuration, \
         compare_user_configurations, _pg_quote_user
 


### PR DESCRIPTION
##### SUMMARY
Add `quote_configuration_values_exclude` to `postgresql_user` module so settings such as `search_path` can be passed unquoted while other configuration values keep the default quoting behavior. 
Preserve idempotency with enabled `reset_unspecified_configuration` by escaping quoted values only when building the `ALTER ROLE` query.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`postgresql_user`

##### ADDITIONAL INFORMATION
I've struggled with how to stick with `reset_unspecified_configuration` for ensuring inventory settings and follow the default recommended `quote_configuration_values` setting with `search_path` settings, as it must not be quoted to be correctly set.

An initial attempt was to split the configuration into two tasks, one for generic quoted settings and a special dedicated task for settings (so far I've faced only the `search_path`), but such a two steps approach doesn't work (as expected) with `reset_unspecified_configuration` option, which is what I want to use, earlier task settings were lost.

That brings me the idea of adding a parameter `quote_configuration_values_exclude` (or whatever more suitable name) that allows user configre an override for the `quote_configuration_values` for user provided list of parameters, that doesn't work (or use deceide on) with quoting so the module can still set all of them in one invocation, therefore making it "compatible" with `reset_unspecified_configuration` set to true.

Test case of the present behavior:

Create an Ansible superuser:
```sql
CREATE ROLE ansible_sup WITH password '1234' superuser login;
```
For the test on `localhost`, I've used just trust auth for local connection.

Validate connection:
```sh
psql -h /var/run/postgresql -d postgres -U ansible_sup -c "SELECT CURRENT_USER, version()"
```

Sample playbook:
```yml
---
- name: Configure PostgreSQL user search_path
  hosts: localhost
  gather_facts: false

  tasks:
    - name: Configure usr_t2 search_path
      community.postgresql.postgresql_user:
        login_host: /var/run/postgresql
        login_user: ansible_sup
        login_db: postgres
        name: usr_t1
        configuration:
          search_path: "nsp_1,nsp_2,public"
        quote_configuration_values: false
        reset_unspecified_configuration: true

    - name: Configure usr_t2 search_path
      community.postgresql.postgresql_user:
        login_host: /var/run/postgresql
        login_user: ansible_sup
        login_db: postgres
        name: usr_t2
        configuration:
          search_path: "nsp_1, nsp_2, public"
        quote_configuration_values: true
        reset_unspecified_configuration: true
```

Apply changes:
```bash
ansible-playbook -i lcoalhost, search_path_testcase.yml
```

Result:
```bash
psql -h /var/run/postgresql -d postgres -U ansible_sup -c "SELECT setrole::regrole, setconfig FROM pg_catalog.pg_db_role_setting WHERE setrole::regrole::text ~ 'usr_t?';"
Timing is on.
Null display is "«¤»".
Field separator is "|".
Output format is aligned.
Border style is 2.
Line style is unicode.
┌─────────┬──────────────────────────────────────────┐
│ setrole │                setconfig                 │
├─────────┼──────────────────────────────────────────┤
│ usr_t1  │ {"search_path=nsp_1, nsp_2, public"}     │
│ usr_t2  │ {"search_path=\"nsp_1, nsp_2, public\""} │
└─────────┴──────────────────────────────────────────┘
(2 rows)

Time: 1.025 ms
```

Hopefully, it'll be useful at least as an enhancement idea.

Kind regards Ales