### PR TITLE
docs: add SSL/TLS certificate usage examples to postgresql_query

### DIFF
--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -210,7 +210,7 @@ EXAMPLES = r'''
     query: INSERT INTO test_table (col1) VALUES (%s)
     positional_args:
     - '{{ my_var }}'
-    
+
 # SSL/TLS certificate configuration example
 - name: Query database with SSL certificate
   community.postgresql.postgresql_query:

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -210,6 +210,16 @@ EXAMPLES = r'''
     query: INSERT INTO test_table (col1) VALUES (%s)
     positional_args:
     - '{{ my_var }}'
+    
+# SSL/TLS certificate configuration example
+- name: Query database with SSL certificate
+  community.postgresql.postgresql_query:
+    login_db: acme
+    query: SELECT version()
+    ssl_mode: verify-full
+    ssl_root_cert: /etc/ssl/certs/root.crt
+    ssl_cert: /etc/ssl/certs/client.crt
+    ssl_key: /etc/ssl/certs/client.key
 '''
 
 RETURN = r'''


### PR DESCRIPTION
Added example for querying database with SSL certificate configuration.

##### SUMMARY
Added a clear SSL/TLS certificate configuration example to the `EXAMPLES` section of `postgresql_query.py`. This provides users with a copy-pasteable reference for using `ssl_mode`, `ssl_root_cert`, `ssl_cert`, and `ssl_key` when connecting to managed Postgres instances like AWS RDS.

Fixes #811

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
postgresql_query

##### ADDITIONAL INFORMATION
Users reported difficulty in finding clear documentation on how to reference PEM/certificate files for database connections. This addition resolves the documentation gap identified in issue #811 by providing a standard, secure configuration template.

##### VERIFICATION
N/A - Documentation improvement only.