### PR TITLE
fix(CI): add retry with cache cleanup for RHEL langpack installation

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -183,6 +183,19 @@ stages:
             - name: RHEL 9.7
               test: rhel/9.7
 
+  - stage: Remote_2_21
+    displayName: Remote 2.21
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.21/{0}/1
+          targets:
+            - name: RHEL 10.1
+              test: rhel/10.1
+            - name: RHEL 9.7
+              test: rhel/9.7
+
   - stage: Remote_2_20
     displayName: Remote 2.20
     dependsOn: []
@@ -232,6 +245,7 @@ stages:
       - Docker_2_19
       - Docker_2_18
       - Remote_devel
+      - Remote_2_21
       - Remote_2_20
       - Remote_2_19
       - Remote_2_18

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -150,13 +150,26 @@
   when: ansible_os_family == 'Debian'
 
 - block:
-  - name: Install langpacks (RHEL8)
-    yum:
-      name:
-      - glibc-langpack-es
-      - glibc-langpack-pt
-      - glibc-all-langpacks
-      state: present
+  - block:
+    - name: Install langpacks (RHEL >= 8)
+      yum:
+        name:
+        - glibc-langpack-es
+        - glibc-langpack-pt
+        - glibc-all-langpacks
+        state: present
+
+    rescue:
+    - name: Clean DNF cache after langpack install failure
+      command: dnf clean all
+
+    - name: Retry langpack install after cleaning cache
+      yum:
+        name:
+        - glibc-langpack-es
+        - glibc-langpack-pt
+        - glibc-all-langpacks
+        state: present
     when: ansible_distribution_major_version is version('8', '>=')
 
   - name: Check if locales need to be generated (RedHat)


### PR DESCRIPTION
## Summary

Fixes failures that showed up in https://github.com/ansible-collections/community.postgresql/pull/932

  - Wrap the RHEL langpack install in `block/rescue` to handle transient
    mirror failures during RHEL point-release transitions (e.g., 10.1 → 10.2)
  - On failure, clean the DNF cache and retry

  RHEL repos start serving newer point-release packages before all CDN
  mirrors have the actual RPM files, causing `glibc-langpack-*` downloads
  to fail and breaking CI on RHEL 10.1 and 9.7 remote targets.
