### PR TITLE
feat(postgresql_membership): add admin_option, inherit_option and set_option

### DIFF
--- a/changelogs/fragments/757-membership-options.yml
+++ b/changelogs/fragments/757-membership-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - postgresql_membership - Add arguments admin_option, inherit_option and set_option (https://github.com/ansible-collections/community.postgresql/issues/757).

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -384,7 +384,7 @@ class PgMembership(object):
         self.changed = False
         self.__check_roles_exist()
 
-    def __grant(self, group, role):
+    def __grant(self, group, role, role_obj=None):
         """Grant membership of group to role and apply the wanted options.
 
         With options (PostgreSQL 16+) only the grant made by the current role is
@@ -396,10 +396,12 @@ class PgMembership(object):
         Args:
             group (str) -- role whose membership is granted.
             role (str) -- role that receives the membership.
+            role_obj (PgRole) -- role's already-fetched membership state, to
+                avoid a redundant DB round trip when the caller already has it.
 
         Returns True when a change was made (bool).
         """
-        role_obj = PgRole(self.module, self.cursor, role)
+        role_obj = role_obj or PgRole(self.module, self.cursor, role)
         if group in role_obj.memberof:
             current = self.__current_grant_options(group, role) if self.options else {}
             if current is not None and all(current[option] == wanted
@@ -447,11 +449,12 @@ class PgMembership(object):
                     SET=rows[0]['set_option'])
 
     def grant(self):
+        role_objs = {role: PgRole(self.module, self.cursor, role) for role in self.target_roles}
         for group in self.groups:
             self.granted[group] = []
 
             for role in self.target_roles:
-                if self.__grant(group, role):
+                if self.__grant(group, role, role_objs[role]):
                     self.granted[group].append(role)
 
         return self.changed
@@ -495,7 +498,7 @@ class PgMembership(object):
             # options of memberships that already exist, so it runs for all
             # desired groups, not only the newly added ones.
             for group in desired_groups:
-                if self.__grant(group, role):
+                if self.__grant(group, role, role_obj):
                     if group in self.granted:
                         self.granted[group].append(role)
                     else:

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -348,22 +348,22 @@ class PgRole():
         self.memberof = self.__fetch_members()
 
     def __fetch_members(self):
-        query = """select p.rolname, m.* -- include option columns if available (postgres >=16)
-                   from pg_catalog.pg_auth_members m
-                   join pg_catalog.pg_roles p on m.roleid=p.oid
-                   join pg_catalog.pg_roles c on m.member=c.oid
-                   where c.rolname = %s;"""
+        """Return the set of roles self.name is a member of.
+
+        Membership is reported regardless of which role granted it. Membership
+        options are read per-grantor by PgMembership when needed.
+
+        Returns a set of role names (str).
+        """
+        query = """SELECT p.rolname
+                   FROM pg_catalog.pg_auth_members m
+                   JOIN pg_catalog.pg_roles p ON m.roleid = p.oid
+                   JOIN pg_catalog.pg_roles c ON m.member = c.oid
+                   WHERE c.rolname = %s;"""
 
         rows = exec_sql(self, query, query_params=(self.name,),
                         add_to_executed=False)
-        result = dict()
-        for row in rows:
-            result[row['rolname']] = dict(
-                ADMIN=row.get('admin_option'),
-                INHERIT=row.get('inherit_option'),
-                SET=row.get('set_option'),
-            )
-        return result
+        return set(row['rolname'] for row in rows)
 
 
 class PgMembership(object):
@@ -373,8 +373,6 @@ class PgMembership(object):
         self.target_roles = [r.strip() for r in target_roles]
         self.groups = [r.strip() for r in groups]
         self.options = dict()
-        self.wanted_options = set()
-        self.unwanted_options = set()
         for option, setting in (options or dict()).items():
             if setting is not None:
                 self.options[option.upper()] = setting
@@ -387,16 +385,26 @@ class PgMembership(object):
         self.__check_roles_exist()
 
     def __grant(self, group, role):
+        """Grant membership of group to role and apply the wanted options.
+
+        With options (PostgreSQL 16+) only the grant made by the current role is
+        compared and updated, so a membership granted by another role (for
+        example the WITH ADMIN OPTION grant PostgreSQL creates when a
+        non-superuser creates a role) does not hide the need to issue our own
+        grant (see issue #757).
+
+        Args:
+            group (str) -- role whose membership is granted.
+            role (str) -- role that receives the membership.
+
+        Returns True when a change was made (bool).
+        """
         role_obj = PgRole(self.module, self.cursor, role)
-        # If role is in a group now, pass:
         if group in role_obj.memberof:
-            options_match = True
-            for option, desired_status in self.options.items():
-                if role_obj.memberof[group][option] != desired_status:
-                    options_match = False
-                    break
-            if options_match:
-                return False  # no change necessary
+            current = self.__current_grant_options(group, role) if self.options else {}
+            if current is not None and all(current[option] == wanted
+                                           for option, wanted in self.options.items()):
+                return False
 
         query = 'GRANT "%s" TO "%s"' % (group, role)
         changed = False
@@ -407,6 +415,36 @@ class PgMembership(object):
             changed |= exec_sql(self, q, return_bool=True)
         self.changed |= changed
         return changed
+
+    def __current_grant_options(self, group, role):
+        """Return the options of the group-to-role grant made by the current role.
+
+        Only reached on PostgreSQL 16+, where these columns exist and a pair can
+        be granted by several roles independently.
+
+        Args:
+            group (str) -- granted (group) role.
+            role (str) -- member role.
+
+        Returns a dict with ADMIN, INHERIT and SET keys, or None when the
+        current role has not granted this membership.
+        """
+        query = """SELECT m.admin_option, m.inherit_option, m.set_option
+                   FROM pg_catalog.pg_auth_members m
+                   JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
+                   JOIN pg_catalog.pg_roles u ON m.member = u.oid
+                   WHERE g.rolname = %s
+                     AND u.rolname = %s
+                     AND m.grantor = (SELECT oid
+                                      FROM pg_catalog.pg_roles
+                                      WHERE rolname = CURRENT_ROLE);"""
+        rows = exec_sql(self, query, query_params=(group, role),
+                        add_to_executed=False)
+        if not rows:
+            return None
+        return dict(ADMIN=rows[0]['admin_option'],
+                    INHERIT=rows[0]['inherit_option'],
+                    SET=rows[0]['set_option'])
 
     def grant(self):
         for group in self.groups:
@@ -452,15 +490,16 @@ class PgMembership(object):
                 else:
                     self.revoked[group] = [role]
 
-            # 2. Filter out groups that in self.groups and
-            # the role is already member of and grant the rest
-            groups_to_grant = desired_groups - current_groups
-            for group in groups_to_grant:
-                self.__grant(group, role)
-                if group in self.granted:
-                    self.granted[group].append(role)
-                else:
-                    self.granted[group] = [role]
+            # 2. Ensure the role is a member of every desired group with the
+            # wanted options. __grant is idempotent and also reconciles the
+            # options of memberships that already exist, so it runs for all
+            # desired groups, not only the newly added ones.
+            for group in desired_groups:
+                if self.__grant(group, role):
+                    if group in self.granted:
+                        self.granted[group].append(role)
+                    else:
+                        self.granted[group] = [role]
 
         return self.changed
 

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -21,8 +21,6 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.community.postgresql.plugins.module_utils.version import \
     LooseVersion
-from ansible_collections.community.postgresql.plugins.module_utils.database import \
-    pg_quote_identifier
 
 psycopg = None  # This line is needed for unit tests
 psycopg2 = None  # This line is needed for unit tests
@@ -398,23 +396,24 @@ class PgMembership(object):
                     options_match = False
                     break
             if options_match:
-                return  # no change necessary
+                return False  # no change necessary
 
-        query = 'GRANT %s TO %s' % (pg_quote_identifier(group, 'role'), pg_quote_identifier(role, 'role'))
+        query = 'GRANT "%s" TO "%s"' % (group, role)
+        changed = False
         if not self.options:
-            self.changed |= exec_sql(self, query, return_bool=True)
+            changed |= exec_sql(self, query, return_bool=True)
         for option, wanted in self.options.items():
             q = '%s WITH %s %s' % (query, option, 'true' if wanted else 'false')
-            self.changed |= exec_sql(self, q, return_bool=True)
+            changed |= exec_sql(self, q, return_bool=True)
+        self.changed |= changed
+        return changed
 
     def grant(self):
         for group in self.groups:
             self.granted[group] = []
 
             for role in self.target_roles:
-                self.__grant(group, role)
-
-                if self.changed:
+                if self.__grant(group, role):
                     self.granted[group].append(role)
 
         return self.changed
@@ -429,7 +428,7 @@ class PgMembership(object):
                 if group not in role_obj.memberof:
                     continue
 
-                query = 'REVOKE %s FROM %s' % (pg_quote_identifier(group, 'role'), pg_quote_identifier(role, 'role'))
+                query = 'REVOKE "%s" FROM "%s"' % (group, role)
                 self.changed = exec_sql(self, query, return_bool=True)
 
                 if self.changed:
@@ -446,7 +445,7 @@ class PgMembership(object):
             # 1. Get groups that the role is member of but not in self.groups and revoke them
             groups_to_revoke = current_groups - desired_groups
             for group in groups_to_revoke:
-                query = 'REVOKE %s FROM %s' % (pg_quote_identifier(group, 'role'), pg_quote_identifier(role, 'role'))
+                query = 'REVOKE "%s" FROM "%s"' % (group, role)
                 self.changed = exec_sql(self, query, return_bool=True)
                 if group in self.revoked:
                     self.revoked[group].append(role)

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -21,6 +21,8 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 from ansible_collections.community.postgresql.plugins.module_utils.version import \
     LooseVersion
+from ansible_collections.community.postgresql.plugins.module_utils.database import \
+    pg_quote_identifier
 
 psycopg = None  # This line is needed for unit tests
 psycopg2 = None  # This line is needed for unit tests
@@ -348,27 +350,36 @@ class PgRole():
         self.memberof = self.__fetch_members()
 
     def __fetch_members(self):
-        query = ("SELECT ARRAY(SELECT b.rolname FROM "
-                 "pg_catalog.pg_auth_members m "
-                 "JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid) "
-                 "WHERE m.member = r.oid) "
-                 "FROM pg_catalog.pg_roles r "
-                 "WHERE r.rolname = %(dst_role)s")
+        query = """select p.rolname, m.* -- include option columns if available (postgres >=16)
+                   from pg_catalog.pg_auth_members m
+                   join pg_catalog.pg_roles p on m.roleid=p.oid
+                   join pg_catalog.pg_roles c on m.member=c.oid
+                   where c.rolname = %s;"""
 
-        res = exec_sql(self, query, query_params={'dst_role': self.name},
-                       add_to_executed=False)
-        if res:
-            return res[0]["array"]
-        else:
-            return []
+        rows = exec_sql(self, query, query_params=(self.name,),
+                        add_to_executed=False)
+        result = dict()
+        for row in rows:
+            result[row['rolname']] = dict(
+                ADMIN=row.get('admin_option'),
+                INHERIT=row.get('inherit_option'),
+                SET=row.get('set_option'),
+            )
+        return result
 
 
 class PgMembership(object):
-    def __init__(self, module, cursor, groups, target_roles, fail_on_role=True):
+    def __init__(self, module, cursor, groups, target_roles, fail_on_role=True, options=None):
         self.module = module
         self.cursor = cursor
         self.target_roles = [r.strip() for r in target_roles]
         self.groups = [r.strip() for r in groups]
+        self.options = dict()
+        self.wanted_options = set()
+        self.unwanted_options = set()
+        for option, setting in (options or dict()).items():
+            if setting is not None:
+                self.options[option.upper()] = setting
         self.executed_queries = []
         self.granted = {}
         self.revoked = {}
@@ -377,18 +388,31 @@ class PgMembership(object):
         self.changed = False
         self.__check_roles_exist()
 
+    def __grant(self, group, role):
+        role_obj = PgRole(self.module, self.cursor, role)
+        # If role is in a group now, pass:
+        if group in role_obj.memberof:
+            options_match = True
+            for option, desired_status in self.options.items():
+                if role_obj.memberof[group][option] != desired_status:
+                    options_match = False
+                    break
+            if options_match:
+                return  # no change necessary
+
+        query = 'GRANT %s TO %s' % (pg_quote_identifier(group, 'role'), pg_quote_identifier(role, 'role'))
+        if not self.options:
+            self.changed |= exec_sql(self, query, return_bool=True)
+        for option, wanted in self.options.items():
+            q = '%s WITH %s %s' % (query, option, 'true' if wanted else 'false')
+            self.changed |= exec_sql(self, q, return_bool=True)
+
     def grant(self):
         for group in self.groups:
             self.granted[group] = []
 
             for role in self.target_roles:
-                role_obj = PgRole(self.module, self.cursor, role)
-                # If role is in a group now, pass:
-                if group in role_obj.memberof:
-                    continue
-
-                query = 'GRANT "%s" TO "%s"' % (group, role)
-                self.changed = exec_sql(self, query, return_bool=True)
+                self.__grant(group, role)
 
                 if self.changed:
                     self.granted[group].append(role)
@@ -405,7 +429,7 @@ class PgMembership(object):
                 if group not in role_obj.memberof:
                     continue
 
-                query = 'REVOKE "%s" FROM "%s"' % (group, role)
+                query = 'REVOKE %s FROM %s' % (pg_quote_identifier(group, 'role'), pg_quote_identifier(role, 'role'))
                 self.changed = exec_sql(self, query, return_bool=True)
 
                 if self.changed:
@@ -422,7 +446,7 @@ class PgMembership(object):
             # 1. Get groups that the role is member of but not in self.groups and revoke them
             groups_to_revoke = current_groups - desired_groups
             for group in groups_to_revoke:
-                query = 'REVOKE "%s" FROM "%s"' % (group, role)
+                query = 'REVOKE %s FROM %s' % (pg_quote_identifier(group, 'role'), pg_quote_identifier(role, 'role'))
                 self.changed = exec_sql(self, query, return_bool=True)
                 if group in self.revoked:
                     self.revoked[group].append(role)
@@ -433,8 +457,7 @@ class PgMembership(object):
             # the role is already member of and grant the rest
             groups_to_grant = desired_groups - current_groups
             for group in groups_to_grant:
-                query = 'GRANT "%s" TO "%s"' % (group, role)
-                self.changed = exec_sql(self, query, return_bool=True)
+                self.__grant(group, role)
                 if group in self.granted:
                     self.granted[group].append(role)
                 else:

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -401,6 +401,15 @@ class PgMembership(object):
 
         Returns True when a change was made (bool).
         """
+        # Two intentionally different scopes meet here. role_obj.memberof is
+        # grantor-blind: it answers "is role a member of group at all", which is
+        # the historical meaning of membership and stays unchanged. The options
+        # comparison below is grantor-scoped (__current_grant_options only reads
+        # the grant made by the current role), because on PostgreSQL 16+ the same
+        # pair can be granted independently by several roles and we may only
+        # update our own grant. When a membership exists but was granted only by
+        # someone else, __current_grant_options returns None and we fall through
+        # to issue our own grant (see issue #757).
         role_obj = role_obj or PgRole(self.module, self.cursor, role)
         if group in role_obj.memberof:
             current = self.__current_grant_options(group, role) if self.options else {}

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -55,7 +55,7 @@ options:
     version_added: '4.3.0'
   inherit_option:
     description:
-      - This flag controls the membership option I(INHERIT). When unset (C(null)), the postgres default is used and existing configuration is preserved.
+      - This flag controls the membership option C(INHERIT). When unset (C(null)), the postgres default is used and existing configuration is preserved.
       - Requires PostgreSQL 16 or later. Setting it against an older server makes the module fail. Ignored when I(state=absent).
     default: null
     type: bool

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -172,6 +172,15 @@ EXAMPLES = r'''
     - alice
     - bob
     state: exact
+
+- name: Grant read_write to alice with SET and INHERIT but without ADMIN (PostgreSQL 16+)
+  community.postgresql.postgresql_membership:
+    group: read_write
+    target_role: alice
+    admin_option: false
+    inherit_option: true
+    set_option: true
+    state: present
 '''
 
 RETURN = r'''

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -49,21 +49,21 @@ options:
   admin_option:
     description:
       - This flag controls the membership option I(ADMIN). When unset (C(null)), the postgres default is used and existing configuration is preserved.
-      - This flag is ignored when I(state=absent) or the postgres server version is < 16.
+      - Requires PostgreSQL 16 or later. Setting it against an older server makes the module fail. Ignored when I(state=absent).
     default: null
     type: bool
     version_added: '4.3.0'
   inherit_option:
     description:
       - This flag controls the membership option I(INHERIT). When unset (C(null)), the postgres default is used and existing configuration is preserved.
-      - This flag is ignored when I(state=absent) or the postgres server version is < 16.
+      - Requires PostgreSQL 16 or later. Setting it against an older server makes the module fail. Ignored when I(state=absent).
     default: null
     type: bool
     version_added: '4.3.0'
   set_option:
     description:
       - This flag controls the membership option I(SET). When unset (C(null)), the postgres default is used and existing configuration is preserved.
-      - This flag is ignored when I(state=absent) or the postgres server version is < 16.
+      - Requires PostgreSQL 16 or later. Setting it against an older server makes the module fail. Ignored when I(state=absent).
     default: null
     type: bool
     version_added: '4.3.0'
@@ -100,6 +100,15 @@ options:
     type: bool
     default: true
     version_added: '0.2.0'
+notes:
+- Membership existence (I(state) handling without the option parameters) considers
+  the membership regardless of which role granted it, as in earlier versions.
+- When I(admin_option), I(inherit_option) or I(set_option) is used on PostgreSQL 16
+  and later, the module compares against and updates the grant made by the connecting
+  role (or I(session_role) when set). A membership of the same pair granted by another
+  role, such as the C(WITH ADMIN OPTION) grant PostgreSQL creates automatically when a
+  non-superuser creates a role, does not prevent the module from creating its own grant
+  with the requested options.
 seealso:
 - module: community.postgresql.postgresql_user
 - module: community.postgresql.postgresql_privs
@@ -253,7 +262,18 @@ def main():
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(**pg_cursor_args)
 
-    if get_server_version(db_connection) < 16000:
+    # The admin_option, inherit_option and set_option parameters rely on the
+    # GRANT ... WITH <option> syntax that only exists on PostgreSQL 16+. Fail
+    # explicitly when any of them is set against an older server rather than
+    # emitting an invalid statement. The options have no effect when revoking,
+    # so they are simply ignored for state=absent (as documented).
+    if get_server_version(db_connection) < 160000:
+        if state != 'absent':
+            used_options = [name for name in ('admin_option', 'inherit_option', 'set_option')
+                            if module.params[name] is not None]
+            if used_options:
+                module.fail_json(msg="The %s parameter(s) require PostgreSQL 16 or later"
+                                     % ", ".join(used_options))
         membership_options = None
 
     ##############

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -46,6 +46,24 @@ options:
       - If C(true), fail when group or target_role doesn't exist. If C(false), just warn and continue.
     default: true
     type: bool
+  admin_option:
+    description:
+      - This flag controls the membership option I(ADMIN). When unset (C(null)), the postgres default is used and existing configuration is preserved.
+      - This flag is ignored when I(state=absent) or the postgres server version is < 16. 
+    default: null
+    type: bool
+  inherit_option:
+    description:
+      - This flag controls the membership option I(INHERIT). When unset (C(null)), the postgres default is used and existing configuration is preserved.
+      - This flag is ignored when I(state=absent) or the postgres server version is < 16. 
+    default: null
+    type: bool
+  set_option:
+    description:
+      - This flag controls the membership option I(SET). When unset (C(null)), the postgres default is used and existing configuration is preserved.
+      - This flag is ignored when I(state=absent) or the postgres server version is < 16. 
+    default: null
+    type: bool
   state:
     description:
     - Membership state.
@@ -177,6 +195,7 @@ from ansible_collections.community.postgresql.plugins.module_utils.postgres impo
     get_conn_params,
     pg_cursor_args,
     postgres_common_argument_spec,
+    get_server_version,
 )
 
 # ===========================================
@@ -189,6 +208,9 @@ def main():
     argument_spec.update(
         groups=dict(type='list', elements='str', required=True, aliases=['group', 'source_role', 'source_roles']),
         target_roles=dict(type='list', elements='str', required=True, aliases=['target_role', 'user', 'users']),
+        admin_option=dict(type='bool', default=None),
+        inherit_option=dict(type='bool', default=None),
+        set_option=dict(type='bool', default=None),
         fail_on_role=dict(type='bool', default=True),
         state=dict(type='str', default='present', choices=['absent', 'exact', 'present']),
         login_db=dict(type='str', aliases=['db'], deprecated_aliases=[
@@ -210,6 +232,11 @@ def main():
     groups = module.params['groups']
     target_roles = module.params['target_roles']
     fail_on_role = module.params['fail_on_role']
+    membership_options = dict(
+        admin=module.params['admin_option'],
+        inherit=module.params['inherit_option'],
+        set=module.params['set_option'],
+    )
     state = module.params['state']
     session_role = module.params['session_role']
     trust_input = module.params['trust_input']
@@ -223,10 +250,12 @@ def main():
     db_connection, dummy = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(**pg_cursor_args)
 
+    if get_server_version(db_connection) < 16000:
+        membership_options = None
+
     ##############
     # Create the object and do main job:
-
-    pg_membership = PgMembership(module, cursor, groups, target_roles, fail_on_role)
+    pg_membership = PgMembership(module, cursor, groups, target_roles, fail_on_role, membership_options)
 
     if state == 'present':
         pg_membership.grant()

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -101,14 +101,18 @@ options:
     default: true
     version_added: '0.2.0'
 notes:
-- Membership existence (I(state) handling without the option parameters) considers
-  the membership regardless of which role granted it, as in earlier versions.
-- When I(admin_option), I(inherit_option) or I(set_option) is used on PostgreSQL 16
-  and later, the module compares against and updates the grant made by the connecting
-  role (or I(session_role) when set). A membership of the same pair granted by another
-  role, such as the C(WITH ADMIN OPTION) grant PostgreSQL creates automatically when a
-  non-superuser creates a role, does not prevent the module from creating its own grant
-  with the requested options.
+- Whether a role is a member of a group is checked regardless of which role granted
+  the membership, as in earlier versions. The membership options, however, are read
+  and written only for the grant made by the connecting role (or by I(session_role)
+  when set), because on PostgreSQL 16 and later the same pair can be granted
+  independently by several roles, each grant carrying its own options, and a role can
+  only change its own grant.
+- A consequence of that scope is that adding I(admin_option), I(inherit_option) or
+  I(set_option) to a task can report C(changed) and issue a C(GRANT) even when the
+  target role is already a member, if the existing membership was granted by another
+  role. This is intended, C(WITH ADMIN OPTION) memberships PostgreSQL creates
+  automatically when a non-superuser creates a role are a common example, so that the
+  connecting role obtains its own grant with the requested options (see issue #757).
 seealso:
 - module: community.postgresql.postgresql_user
 - module: community.postgresql.postgresql_privs

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -49,21 +49,24 @@ options:
   admin_option:
     description:
       - This flag controls the membership option I(ADMIN). When unset (C(null)), the postgres default is used and existing configuration is preserved.
-      - This flag is ignored when I(state=absent) or the postgres server version is < 16. 
+      - This flag is ignored when I(state=absent) or the postgres server version is < 16.
     default: null
     type: bool
+    version_added: '4.3.0'
   inherit_option:
     description:
       - This flag controls the membership option I(INHERIT). When unset (C(null)), the postgres default is used and existing configuration is preserved.
-      - This flag is ignored when I(state=absent) or the postgres server version is < 16. 
+      - This flag is ignored when I(state=absent) or the postgres server version is < 16.
     default: null
     type: bool
+    version_added: '4.3.0'
   set_option:
     description:
       - This flag controls the membership option I(SET). When unset (C(null)), the postgres default is used and existing configuration is preserved.
-      - This flag is ignored when I(state=absent) or the postgres server version is < 16. 
+      - This flag is ignored when I(state=absent) or the postgres server version is < 16.
     default: null
     type: bool
+    version_added: '4.3.0'
   state:
     description:
     - Membership state.

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -62,7 +62,7 @@ options:
     version_added: '4.3.0'
   set_option:
     description:
-      - This flag controls the membership option I(SET). When unset (C(null)), the postgres default is used and existing configuration is preserved.
+      - This flag controls the membership option C(SET). When unset (C(null)), the postgres default is used and existing configuration is preserved.
       - Requires PostgreSQL 16 or later. Setting it against an older server makes the module fail. Ignored when I(state=absent).
     default: null
     type: bool

--- a/plugins/modules/postgresql_membership.py
+++ b/plugins/modules/postgresql_membership.py
@@ -48,7 +48,7 @@ options:
     type: bool
   admin_option:
     description:
-      - This flag controls the membership option I(ADMIN). When unset (C(null)), the postgres default is used and existing configuration is preserved.
+      - This flag controls the membership option C(ADMIN). When unset (C(null)), the postgres default is used and existing configuration is preserved.
       - Requires PostgreSQL 16 or later. Setting it against an older server makes the module fail. Ignored when I(state=absent).
     default: null
     type: bool

--- a/tests/integration/targets/postgresql_membership/tasks/main.yml
+++ b/tests/integration/targets/postgresql_membership/tasks/main.yml
@@ -5,3 +5,6 @@
 
 # Initial CI tests of postgresql_membership module
 - import_tasks: postgresql_membership_initial.yml
+
+# Tests for admin_option, inherit_option and set_option (PostgreSQL >= 16):
+- import_tasks: postgresql_membership_options.yml

--- a/tests/integration/targets/postgresql_membership/tasks/postgresql_membership_options.yml
+++ b/tests/integration/targets/postgresql_membership/tasks/postgresql_membership_options.yml
@@ -1,0 +1,355 @@
+# Copyright: (c) 2024, Felix Hamme <felix.hamme@ionos.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+####################################################################
+# Tests for the admin_option, inherit_option and set_option params #
+# (https://github.com/ansible-collections/community.postgresql/issues/757).
+# The INHERIT and SET membership options require PostgreSQL >= 16,  #
+# so the option-specific assertions are gated on the server version.#
+####################################################################
+
+# Detect the server version so we can skip the option tests on PostgreSQL < 16:
+- name: postgresql_membership - get server version
+  become_user: "{{ pg_user }}"
+  become: true
+  postgresql_query:
+    login_user: "{{ pg_user }}"
+    db: postgres
+    query: "SELECT current_setting('server_version_num') AS server_version_num"
+  register: pg_ver
+
+# On PostgreSQL < 16 the options are unsupported and must fail loudly:
+- name: postgresql_membership - membership options rejected before PostgreSQL 16
+  when: pg_ver.query_result[0].server_version_num | int < 160000
+  block:
+
+  - name: postgresql_membership - create roles for the legacy rejection test
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_user:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      name: "{{ item }}"
+    ignore_errors: true
+    with_items:
+    - "opt_group"
+    - "opt_user1"
+
+  - name: postgresql_membership - set_option must fail on PostgreSQL < 16
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      set_option: true
+      state: present
+    register: result
+    ignore_errors: true
+
+  - assert:
+      that:
+      - result is failed
+      - "'require PostgreSQL 16 or later' in result.msg"
+
+  always:
+
+  - name: postgresql_membership - drop roles from the legacy rejection test
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_user:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      name: "{{ item }}"
+      state: absent
+    ignore_errors: true
+    with_items:
+    - "opt_user1"
+    - "opt_group"
+
+- name: postgresql_membership - membership option tests (PostgreSQL >= 16 only)
+  when: pg_ver.query_result[0].server_version_num | int >= 160000
+  block:
+
+  - name: postgresql_membership - create roles for the option tests
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_user:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      name: "{{ item }}"
+    ignore_errors: true
+    with_items:
+    - "opt_group"
+    - "opt_user1"
+    - "opt_user2"
+    - "opt_user3"
+    - "opt_grantor"
+
+  # Grant with all three options explicitly disabled:
+  - name: postgresql_membership - grant with options disabled
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      admin_option: false
+      inherit_option: false
+      set_option: false
+      state: present
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.granted["opt_group"] == ["opt_user1"]
+
+  - name: postgresql_membership - read back the membership options
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      query: >-
+        SELECT m.admin_option, m.inherit_option, m.set_option
+        FROM pg_catalog.pg_auth_members m
+        JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
+        JOIN pg_catalog.pg_roles u ON m.member = u.oid
+        WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user1'
+    register: opts
+
+  - assert:
+      that:
+      - opts.query_result[0].admin_option == false
+      - opts.query_result[0].inherit_option == false
+      - opts.query_result[0].set_option == false
+
+  # Granting again with the same options must be idempotent:
+  - name: postgresql_membership - grant again with the same options (idempotency)
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      admin_option: false
+      inherit_option: false
+      set_option: false
+      state: present
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+      - result.granted["opt_group"] == []
+
+  # Changing a single option must alter the existing membership:
+  - name: postgresql_membership - enable set_option on the existing membership
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      set_option: true
+      state: present
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.granted["opt_group"] == ["opt_user1"]
+
+  - name: postgresql_membership - read back set_option after the change
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      query: >-
+        SELECT m.set_option
+        FROM pg_catalog.pg_auth_members m
+        JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
+        JOIN pg_catalog.pg_roles u ON m.member = u.oid
+        WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user1'
+    register: opts
+
+  - assert:
+      that:
+      - opts.query_result[0].set_option == true
+
+  # Reporting check: grant to a role that is already a member with matching
+  # options (no change) together with a brand new role. Only the new role must
+  # appear in granted[] - this guards against over-reporting unchanged roles.
+  - name: postgresql_membership - grant to one unchanged and one new role
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_roles:
+      - "opt_user1"
+      - "opt_user2"
+      set_option: true
+      state: present
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.granted["opt_group"] == ["opt_user2"]
+
+  # Grantor isolation (issue #757): a membership granted by a different role
+  # must not hide the need to create our own grant. We let opt_grantor grant
+  # opt_group to opt_user3, then run the module as pg_user. The module must not
+  # treat the opt_grantor-granted row as its own and must issue a fresh GRANT.
+  - name: postgresql_membership - allow opt_grantor to administer opt_group
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      query: 'GRANT "opt_group" TO "opt_grantor" WITH ADMIN OPTION'
+
+  - name: postgresql_membership - pre-grant opt_group to opt_user3 as opt_grantor
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      session_role: "opt_grantor"
+      db: postgres
+      query: 'GRANT "opt_group" TO "opt_user3"'
+
+  - name: postgresql_membership - module grants opt_group to opt_user3 with set_option
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user3"
+      set_option: true
+      state: present
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.granted["opt_group"] == ["opt_user3"]
+
+  - name: postgresql_membership - verify a current-role grant now exists with set_option
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      query: >-
+        SELECT m.set_option
+        FROM pg_catalog.pg_auth_members m
+        JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
+        JOIN pg_catalog.pg_roles u ON m.member = u.oid
+        JOIN pg_catalog.pg_roles gr ON m.grantor = gr.oid
+        WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user3'
+        AND gr.rolname = current_user
+    register: gr_row
+
+  - assert:
+      that:
+      - gr_row.query_result | length == 1
+      - gr_row.query_result[0].set_option == true
+
+  - name: postgresql_membership - re-run the same grant is idempotent
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user3"
+      set_option: true
+      state: present
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+      - result.granted["opt_group"] == []
+
+  # state=exact must reconcile options on a membership that already exists,
+  # not only on newly granted ones. opt_user1 is already a member of opt_group
+  # with set_option=true at this point.
+  - name: postgresql_membership - state=exact changes an option on an existing membership
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      set_option: false
+      state: exact
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.granted["opt_group"] == ["opt_user1"]
+
+  - name: postgresql_membership - read back set_option after state=exact
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      query: >-
+        SELECT m.set_option
+        FROM pg_catalog.pg_auth_members m
+        JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
+        JOIN pg_catalog.pg_roles u ON m.member = u.oid
+        WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user1'
+    register: opts
+
+  - assert:
+      that:
+      - opts.query_result[0].set_option == false
+
+  - name: postgresql_membership - state=exact with the same option is idempotent
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      set_option: false
+      state: exact
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+      - result.granted == {}
+
+  always:
+
+  - name: postgresql_membership - drop roles created for the option tests
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_user:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      name: "{{ item }}"
+      state: absent
+    ignore_errors: true
+    with_items:
+    - "opt_user1"
+    - "opt_user2"
+    - "opt_user3"
+    - "opt_grantor"
+    - "opt_group"

--- a/tests/integration/targets/postgresql_membership/tasks/postgresql_membership_options.yml
+++ b/tests/integration/targets/postgresql_membership/tasks/postgresql_membership_options.yml
@@ -123,6 +123,7 @@
 
   - assert:
       that:
+      - opts.query_result | length == 1
       - opts.query_result[0].admin_option == false
       - opts.query_result[0].inherit_option == false
       - opts.query_result[0].set_option == false
@@ -165,23 +166,27 @@
       - result is changed
       - result.granted["opt_group"] == ["opt_user1"]
 
-  - name: postgresql_membership - read back set_option after the change
+  - name: postgresql_membership - read back all options after the change
     become_user: "{{ pg_user }}"
     become: true
     postgresql_query:
       login_user: "{{ pg_user }}"
       db: postgres
       query: >-
-        SELECT m.set_option
+        SELECT m.admin_option, m.inherit_option, m.set_option
         FROM pg_catalog.pg_auth_members m
         JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
         JOIN pg_catalog.pg_roles u ON m.member = u.oid
         WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user1'
     register: opts
 
+  # set_option flipped to true; admin_option and inherit_option must stay false.
   - assert:
       that:
+      - opts.query_result | length == 1
       - opts.query_result[0].set_option == true
+      - opts.query_result[0].admin_option == false
+      - opts.query_result[0].inherit_option == false
 
   # Reporting check: grant to a role that is already a member with matching
   # options (no change) together with a brand new role. Only the new role must
@@ -301,23 +306,27 @@
       - result is changed
       - result.granted["opt_group"] == ["opt_user1"]
 
-  - name: postgresql_membership - read back set_option after state=exact
+  - name: postgresql_membership - read back all options after state=exact
     become_user: "{{ pg_user }}"
     become: true
     postgresql_query:
       login_user: "{{ pg_user }}"
       db: postgres
       query: >-
-        SELECT m.set_option
+        SELECT m.admin_option, m.inherit_option, m.set_option
         FROM pg_catalog.pg_auth_members m
         JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
         JOIN pg_catalog.pg_roles u ON m.member = u.oid
         WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user1'
     register: opts
 
+  # set_option reconciled to false; admin_option and inherit_option must stay false.
   - assert:
       that:
+      - opts.query_result | length == 1
       - opts.query_result[0].set_option == false
+      - opts.query_result[0].admin_option == false
+      - opts.query_result[0].inherit_option == false
 
   - name: postgresql_membership - state=exact with the same option is idempotent
     become_user: "{{ pg_user }}"
@@ -335,6 +344,76 @@
       that:
       - result is not changed
       - result.granted == {}
+
+  ####################################################################
+  # check_mode: the module must predict whether an option change is  #
+  # needed and report it without writing to the database.            #
+  # opt_user1 currently has set_option=false on opt_group.           #
+  ####################################################################
+
+  # Enabling set_option in check_mode must report a change but leave the
+  # membership untouched (changes run in a transaction that is rolled back).
+  - name: postgresql_membership - enable set_option in check_mode (change needed)
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      set_option: true
+      state: present
+    register: result
+    check_mode: true
+
+  - assert:
+      that:
+      - result is changed
+      - result.granted["opt_group"] == ["opt_user1"]
+      - result.queries == ['GRANT "opt_group" TO "opt_user1" WITH SET true']
+
+  # Requesting the option value opt_user1 already has must report no change.
+  - name: postgresql_membership - keep set_option in check_mode (no change needed)
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_membership:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      group: "opt_group"
+      target_role: "opt_user1"
+      set_option: false
+      state: present
+    register: result
+    check_mode: true
+
+  - assert:
+      that:
+      - result is not changed
+      - result.granted["opt_group"] == []
+      - result.queries == []
+
+  # Confirm the change-needed check_mode run above did not actually write:
+  # every option must still hold its pre-check_mode value.
+  - name: postgresql_membership - verify check_mode left all options unchanged
+    become_user: "{{ pg_user }}"
+    become: true
+    postgresql_query:
+      login_user: "{{ pg_user }}"
+      db: postgres
+      query: >-
+        SELECT m.admin_option, m.inherit_option, m.set_option
+        FROM pg_catalog.pg_auth_members m
+        JOIN pg_catalog.pg_roles g ON m.roleid = g.oid
+        JOIN pg_catalog.pg_roles u ON m.member = u.oid
+        WHERE g.rolname = 'opt_group' AND u.rolname = 'opt_user1'
+    register: opts
+
+  - assert:
+      that:
+      - opts.query_result | length == 1
+      - opts.query_result[0].set_option == false
+      - opts.query_result[0].admin_option == false
+      - opts.query_result[0].inherit_option == false
 
   always:
 


### PR DESCRIPTION
##### SUMMARY

Adds `admin_option`, `inherit_option` and `set_option` parameters to `postgresql_membership`, letting you control the `ADMIN`, `INHERIT` and `SET` options when granting roles.

Each option is a tri-state bool:
- `true` - ensure the option is enabled
- `false` - ensure the option is disabled
- unset (`null`, default) - use the PostgreSQL default for a new grant, keep the current value for an existing one

Fixes #757.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

postgresql_membership

##### ADDITIONAL INFORMATION

The feature commit is the original work of Felix Hamme (@betanummeric) from the `membership-options` branch referenced in #757; it is preserved as-is for attribution. The follow-up commits make it pass CI and fix two regressions found while preparing it:

- Added `version_added: '4.3.0'` to the three new options (required by `validate-modules`) and removed trailing whitespace from their descriptions.
- Restored plain `"%s"` quoting of role names in `GRANT`/`REVOKE`. The original commit switched to `pg_quote_identifier(name, 'role')`, which splits on dots and raises `SQLParseError` for role names containing them (e.g. `group.with.dots`), breaking the existing dotted-role integration tests. Role names are single identifiers; this matches how `postgresql_owner` quotes roles.
- Fixed `granted[]` over-reporting: `self.changed` was accumulated with `|=` and never reset, so once any grant fired every later role was reported as granted even when unchanged.
- Made the **option** path grantor-aware on PostgreSQL 16+, without changing plain membership behaviour:
  When an option is requested, the module compares against and updates the grant made by the *current role* (`__current_grant_options`), so an existing grant by another role does not suppress issuing the module's own grant with the requested options.
  Membership *existence* (`state` handling without options) is unchanged: `__fetch_members` still reports membership regardless of grantor, exactly as before, so there is no behaviour change for existing playbooks.
  Grantor-awareness is scoped to where it is actually needed (the options, which are PostgreSQL 16+ only); on PostgreSQL 16 a pair can be granted by several roles independently, so comparing the unfiltered membership's options would be order-dependent.
- Added a PostgreSQL >= 16 gated integration test covering:
  - grant-with-options
  - read-back from `pg_auth_members`
  - idempotency
  - single-option change
  - `granted[]` reporting fix
  - `state=exact` option reconciliation
  - grantor-isolation scenario from #757: a grant by another role does not suppress the module's own grant
  - PostgreSQL <16 test asserting the new options are rejected with an error

`validate-modules`, `pep8` and `pylint` sanity pass on the changed files. (The 4 failures in `tests/unit/.../test_postgres.py` in some local environments are pre-existing on `main` and unrelated to this change.)

###### Known limitations / possible follow-ups

All three options require PostgreSQL 16+, including `admin_option`, even though `WITH ADMIN OPTION` predates 16, for simplicity.

###### AI assistance disclosure

The version_added/whitespace/quoting/reporting/grantor fixes, the integration tests, and this description were produced with AI tooling assistance. The original feature commit is the work of @betanummeric. I have reviewed everything and take full responsibility for the contribution.
