### PR TITLE
docs: update semantic markup in db, user, and query modules

### DIFF
--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -101,7 +101,7 @@ options:
   target:
     description:
     - File to back up or restore from.
-    - Used when O(state) is V(dump) or C(restore).
+    - Used when O(state) is V(dump) or V(restore).
     type: path
     default: ''
   target_opts:

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -130,7 +130,7 @@ options:
     default: ''
   dump_extra_args:
     description:
-      - Provides additional arguments when O(state) is C(dump).
+      - Provides additional arguments when O(state) is V(dump).
       - Cannot be used with dump-file-format-related arguments like ``--format=d``.
     type: str
     version_added: '0.2.0'

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -39,13 +39,13 @@ options:
   lc_collate:
     description:
       - Collation order (LC_COLLATE) to use in the database
-        must match collation order of template database unless C(template0) is used as template.
+        must match collation order of template database unless V(template0) is used as template.
     type: str
     default: ''
   lc_ctype:
     description:
       - Character classification (LC_CTYPE) to use in the database (e.g. lower, upper, ...).
-      - Must match LC_CTYPE of template database unless C(template0) is used as template.
+      - Must match LC_CTYPE of template database unless V(template0) is used as template.
     type: str
     default: ''
   icu_locale:
@@ -58,7 +58,7 @@ options:
   locale_provider:
     description:
       - Specifies the provider to use for the default collation in this database (LOCALE_PROVIDER).
-      - Possible values are icu (if the server was built with ICU support) or libc.
+      - Possible values are V(icu) (if the server was built with ICU support) or V(libc).
       - By default, the provider is the same as that of the template.
     type: str
     default: ''
@@ -73,14 +73,14 @@ options:
   state:
     description:
     - The database state.
-    - C(present) implies that the database should be created if necessary.
-    - C(absent) implies that the database should be removed if present.
-    - C(dump) requires a target definition to which the database will be backed up. (Added in Ansible 2.4)
+    - V(present) implies that the database should be created if necessary.
+    - V(absent) implies that the database should be removed if present.
+    - V(dump) requires a target definition to which the database will be backed up. (Added in Ansible 2.4)
       Note that in some PostgreSQL versions of pg_dump, which is an embedded PostgreSQL utility and is used by the module,
       returns rc 0 even when errors occurred (e.g. the connection is forbidden by pg_hba.conf, etc.),
       so the module returns changed=True but the dump has not actually been done. Please, be sure that your version of
       pg_dump returns rc 1 in this case.
-    - C(restore) also requires a target definition from which the database will be restored. (Added in Ansible 2.4).
+    - V(restore) also requires a target definition from which the database will be restored. (Added in Ansible 2.4).
     - The format of the backup will be detected based on the target name.
     - Supported compression formats for dump and restore determined by target file format C(.pgc) (custom), C(.bz2) (bzip2), C(.gz) (gzip/pigz) and C(.xz) (xz).
     - Supported formats for dump and restore determined by target file format C(.sql) (plain), C(.tar) (tar), C(.pgc) (custom) and C(.dir) (directory)
@@ -88,26 +88,26 @@ options:
     - "Restore program is selected by target file format: C(.tar), C(.pgc), and C(.dir) are handled by pg_restore, other with pgsql."
     - "."
     - DEPRECATED (see the L(discussion,https://github.com/ansible-collections/community.postgresql/issues/820)).
-      C(rename) is used to rename the database C(name) to C(target).
+      V(rename) is used to rename the database O(name) to O(target).
       To rename a database, use the M(community.postgresql.postgresql_query) module.
     type: str
     choices: [ absent, dump, present, rename, restore ]
     default: present
   force:
     description:
-    - Used to forcefully drop a database when the I(state) is C(absent), ignored otherwise.
+    - Used to forcefully drop a database when the O(state) is V(absent), ignored otherwise.
     type: bool
     default: False
   target:
     description:
     - File to back up or restore from.
-    - Used when I(state) is C(dump) or C(restore).
+    - Used when O(state) is V(dump) or C(restore).
     type: path
     default: ''
   target_opts:
     description:
     - Additional arguments for pg_dump or restore program (pg_restore or psql, depending on target's format).
-    - Used when I(state) is C(dump) or C(restore).
+    - Used when O(state) is V(dump) or V(restore).
     type: str
     default: ''
   maintenance_db:
@@ -130,15 +130,15 @@ options:
     default: ''
   dump_extra_args:
     description:
-      - Provides additional arguments when I(state) is C(dump).
+      - Provides additional arguments when O(state) is C(dump).
       - Cannot be used with dump-file-format-related arguments like ``--format=d``.
     type: str
     version_added: '0.2.0'
   trust_input:
     description:
-    - If C(false), check whether values of parameters I(owner), I(conn_limit), I(encoding),
-      I(db), I(template), I(tablespace), I(session_role) are potentially dangerous.
-    - It makes sense to use C(false) only when SQL injections via the parameters are possible.
+    - If V(false), check whether values of parameters O(owner), O(conn_limit), O(encoding),
+      O(db), O(template), O(tablespace), O(session_role) are potentially dangerous.
+    - It makes sense to use V(false) only when SQL injections via the parameters are possible.
     type: bool
     default: true
     version_added: '0.2.0'
@@ -175,9 +175,9 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(state=dump) — it always invokes C(pg_dump) and writes
-        the C(target) file, reporting changed=true on every invocation.
+        the C(target) file, reporting RV(changed=true) on every invocation.
       - The module is not idempotent when O(state=restore) — it always executes the contents of the
-        C(target) file against the database and reports changed=true.
+        C(target) file against the database and reports RV(changed=true).
 
 author: "Ansible Core Team"
 

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -175,9 +175,9 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(state=dump) — it always invokes C(pg_dump) and writes
-        the C(target) file, reporting RV(changed=true) on every invocation.
+        the C(target) file, reporting C(changed=true) on every invocation.
       - The module is not idempotent when O(state=restore) — it always executes the contents of the
-        C(target) file against the database and reports RV(changed=true).
+        C(target) file against the database and reports C(changed=true).
 
 author: "Ansible Core Team"
 

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -166,7 +166,7 @@ seealso:
 - module: community.postgresql.postgresql_ping
 
 notes:
-- State C(dump) and C(restore) don't require I(psycopg) since ansible version 2.8.
+- State V(dump) and V(restore) don't require C(psycopg) since ansible version 2.8.
 
 attributes:
   check_mode:

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -177,7 +177,7 @@ attributes:
       - The module is not idempotent when O(state=dump) — it always invokes C(pg_dump) and writes
         the C(target) file, reporting C(changed=true) on every invocation.
       - The module is not idempotent when O(state=restore) — it always executes the contents of the
-        C(target) file against the database and reports C(changed=true).
+        O(target) file against the database and reports C(changed=true).
 
 author: "Ansible Core Team"
 

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -175,7 +175,7 @@ attributes:
     support: partial
     details:
       - The module is not idempotent when O(state=dump) — it always invokes C(pg_dump) and writes
-        the C(target) file, reporting C(changed=true) on every invocation.
+        the O(target) file, reporting C(changed=true) on every invocation.
       - The module is not idempotent when O(state=restore) — it always executes the contents of the
         O(target) file against the database and reports C(changed=true).
 

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -52,7 +52,7 @@ options:
     description:
     - Execute in autocommit mode when the query can't be run inside a transaction block
       (e.g., VACUUM).
-    - Mutually exclusive with O(check_mode).
+    - Mutually exclusive with C(check_mode).
     type: bool
     default: false
   encoding:
@@ -90,7 +90,7 @@ attributes:
       - The module executes arbitrary user-supplied SQL commands and cannot determine whether a given query
         would modify state. For non-read-only queries, state change is set based on the PostgreSQL
         C(statusmessage) heuristic (e.g., C(INSERT)/C(UPDATE)/C(DELETE) with non-zero affected rows
-        report RV(changed=true), regardless of the state which existed before the query execution).
+        report C(changed=true), regardless of the state which existed before the query execution).
 
 author:
 - Felix Archambault (@archf)

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -25,14 +25,14 @@ options:
     description:
     - List of values to be passed as positional arguments to the query.
       When the value is a list, it will be converted to PostgreSQL array.
-    - Mutually exclusive with I(named_args).
+    - Mutually exclusive with O(named_args).
     type: list
     elements: raw
   named_args:
     description:
     - Dictionary of key-value arguments to pass to the query.
       When the value is a list, it will be converted to PostgreSQL array.
-    - Mutually exclusive with I(positional_args).
+    - Mutually exclusive with O(positional_args).
     type: dict
   session_role:
     description:
@@ -44,7 +44,7 @@ options:
   login_db:
     description:
     - Name of database to connect to and run queries against.
-    - The V(db) alias is deprecated and will be removed in version 5.0.0.
+    - The O(db) alias is deprecated and will be removed in version 5.0.0.
     type: str
     aliases:
     - db
@@ -52,7 +52,7 @@ options:
     description:
     - Execute in autocommit mode when the query can't be run inside a transaction block
       (e.g., VACUUM).
-    - Mutually exclusive with I(check_mode).
+    - Mutually exclusive with O(check_mode).
     type: bool
     default: false
   encoding:
@@ -63,8 +63,8 @@ options:
     version_added: '0.2.0'
   trust_input:
     description:
-    - If C(false), check whether a value of I(session_role) is potentially dangerous.
-    - It makes sense to use C(false) only when SQL injections via I(session_role) are possible.
+    - If V(false), check whether a value of O(session_role) is potentially dangerous.
+    - It makes sense to use V(false) only when SQL injections via O(session_role) are possible.
     type: bool
     default: true
     version_added: '0.2.0'
@@ -90,7 +90,7 @@ attributes:
       - The module executes arbitrary user-supplied SQL commands and cannot determine whether a given query
         would modify state. For non-read-only queries, state change is set based on the PostgreSQL
         C(statusmessage) heuristic (e.g., C(INSERT)/C(UPDATE)/C(DELETE) with non-zero affected rows
-        report changed=true, regardless of the state which existed before the query execution).
+        report RV(changed=true), regardless of the state which existed before the query execution).
 
 author:
 - Felix Archambault (@archf)

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -57,7 +57,7 @@ options:
     default: false
   encoding:
     description:
-    - Set the client encoding for the current session (e.g. C(UTF-8)).
+    - Set the client encoding for the current session (e.g. V(UTF-8)).
     - The default is the encoding defined by the database.
     type: str
     version_added: '0.2.0'

--- a/plugins/modules/postgresql_query.py
+++ b/plugins/modules/postgresql_query.py
@@ -89,7 +89,7 @@ attributes:
     details:
       - The module executes arbitrary user-supplied SQL commands and cannot determine whether a given query
         would modify state. For non-read-only queries, state change is set based on the PostgreSQL
-        C(statusmessage) heuristic (e.g., C(INSERT)/C(UPDATE)/C(DELETE) with non-zero affected rows
+        RV(statusmessage) heuristic (e.g., C(INSERT)/C(UPDATE)/C(DELETE) with non-zero affected rows
         report C(changed=true), regardless of the state which existed before the query execution).
 
 author:

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -178,7 +178,7 @@ notes:
   You may not specify password or role_attr_flags when the V(PUBLIC) user is specified.
 - SCRAM-SHA-256-hashed passwords (SASL Authentication) require PostgreSQL version 10 or newer.
   On the previous versions the whole hashed string is used as a password.
-- 'Working with SCRAM-SHA-256-hashed passwords, be sure you use the O(environment): variable
+- 'Working with SCRAM-SHA-256-hashed passwords, be sure you use the C(environment): variable
   C(PGOPTIONS: "-c password_encryption=scram-sha-256") when it is not default
   for your PostgreSQL version (see the provided example).'
 - On some systems (such as AWS RDS), C(pg_authid) is not accessible, thus, the module cannot compare

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -18,7 +18,7 @@ description:
   grants the user access to an existing database or tables.
 - A user is a role with login privilege.
 - You cannot remove a user while it still has any privileges granted to it in any database.
-- Set I(fail_on_user) to C(false) to make the module ignore failures when trying to remove a user.
+- Set O(fail_on_user) to V(false) to make the module ignore failures when trying to remove a user.
   In this case, the module reports if changes happened as usual and separately reports
   whether the user has been removed or not.
 options:
@@ -34,26 +34,26 @@ options:
     - Set the user's password, before 1.4 this was required.
     - Password can be passed unhashed or hashed (MD5-hashed).
     - An unhashed password is automatically hashed when saved into the
-      database if I(encrypted) is set, otherwise it is saved in
+      database if O(encrypted) is set, otherwise it is saved in
       plain text format.
     - When passing an MD5-hashed password, you must generate it with the format
       C('str["md5"] + md5[ password + username ]'), resulting in a total of
       35 characters. An easy way to do this is
       C(echo "md5`echo -n 'verysecretpasswordJOE' | md5sum | awk '{print $1}'`").
     - Note that if the provided password string is already in MD5-hashed
-      format, then it is used as-is, regardless of I(encrypted) option.
+      format, then it is used as-is, regardless of O(encrypted) option.
     type: str
   login_db:
     description:
     - Name of database to connect to and where user's permissions are granted.
-    - The V(db) alias is deprecated and will be removed in version 5.0.0.
+    - The O(db) alias is deprecated and will be removed in version 5.0.0.
     type: str
     default: ''
     aliases:
     - db
   fail_on_user:
     description:
-    - If C(true), fails when the user (role) cannot be removed. Otherwise just log and continue.
+    - If V(true), fails when the user (role) cannot be removed. Otherwise just log and continue.
     default: true
     type: bool
     aliases:
@@ -62,7 +62,7 @@ options:
     description:
     - "PostgreSQL user attributes string in the format: CREATEDB,CREATEROLE,SUPERUSER."
     - Note that '[NO]CREATEUSER' is deprecated.
-    - To create a simple role for using it like a group, use C(NOLOGIN) flag.
+    - To create a simple role for using it like a group, use V(NOLOGIN) flag.
     - See the full list of supported flags in documentation for your PostgreSQL version.
     type: str
     default: ''
@@ -83,22 +83,22 @@ options:
     description:
     - Whether the password is stored hashed in the database.
     - You can specify an unhashed password, and PostgreSQL ensures
-      the stored password is hashed when I(encrypted=true) is set.
+      the stored password is hashed when O(encrypted=true) is set.
       If you specify a hashed password, the module uses it as-is,
-      regardless of the setting of I(encrypted).
+      regardless of the setting of O(encrypted).
     - "Note: Postgresql 10 and newer does not support unhashed passwords."
-    - Previous to Ansible 2.6, this was C(false) by default.
+    - Previous to Ansible 2.6, this was V(false) by default.
     default: true
     type: bool
   expires:
     description:
     - The date at which the user's password is to expire.
-    - If set to C('infinity'), user's password never expires.
+    - If set to V(infinity), user's password never expires.
     - Note that this value must be a valid SQL date and time type.
     type: str
   no_password_changes:
     description:
-    - If C(true), does not inspect the database for password changes.
+    - If V(true), does not inspect the database for password changes.
       If the user already exists, skips all password related checks.
       Useful when C(pg_authid) is not accessible (such as in AWS RDS).
       Otherwise, makes password changes as necessary.
@@ -130,9 +130,9 @@ options:
     version_added: '0.2.0'
   trust_input:
     description:
-    - If C(false), checks whether values of options I(name), I(password), I(expires),
-      I(role_attr_flags), I(comment), I(session_role) are potentially dangerous.
-    - It makes sense to use C(false) only when SQL injections through the options are possible.
+    - If V(false), checks whether values of options O(name), O(password), O(expires),
+      O(role_attr_flags), O(comment), O(session_role) are potentially dangerous.
+    - It makes sense to use V(false) only when SQL injections through the options are possible.
     type: bool
     default: true
     version_added: '0.2.0'
@@ -148,45 +148,45 @@ options:
       - Inputs to O(user) as well as keys and values in this parameter are quoted by the module. If you require the
         user to contain a C("), you need to double it, otherwise the module will fail. C(") and C(') are not allowed in
         configuration keys and any C(') in the value of a configuration will be escaped by this module.
-        Additionally, parameters and values are checked if O(trust_input) is C(false).
+        Additionally, parameters and values are checked if O(trust_input) is V(false).
     type: dict
     default: {}
     version_added: '3.5.0'
   reset_unspecified_configuration:
     description:
-      - If set to C(true), the user's default configuration parameters will be reset in case they are not included in
+      - If set to V(true), the user's default configuration parameters will be reset in case they are not included in
         O(configuration), otherwise existing parameters will not be modified if not included in O(configuration).
     type: bool
     default: false
     version_added: '3.5.0'
   quote_configuration_values:
     description:
-      - Automatically quote the values of configuration variables added via I(configuration). The default is C(true)
-        and setting this to C(false) leaves these options open to SQL-injections and makes the user responsible for
+      - Automatically quote the values of configuration variables added via O(configuration). The default is V(true)
+        and setting this to V(false) leaves these options open to SQL-injections and makes the user responsible for
         properly quoting values.
-      - This is required to be C(false) to modify settings like C(search_path), that need to be unquoted.
-      - If this is C(false) you will also need to make sure that strings are properly quoted.
+      - This is required to be V(false) to modify settings like C(search_path), that need to be unquoted.
+      - If this is V(false) you will also need to make sure that strings are properly quoted.
         For example C("'16MB'") for C(work_mem).
-      - Set this only to C(false) if you know what you are doing!
+      - Set this only to V(false) if you know what you are doing!
     type: bool
     default: true
     version_added: '3.11.0'
 notes:
 - The module creates a user (role) with login privilege by default.
-  Use C(NOLOGIN) I(role_attr_flags) to change this behaviour.
-- If you specify C(PUBLIC) as the user (role), then the privilege changes apply to all users (roles).
-  You may not specify password or role_attr_flags when the C(PUBLIC) user is specified.
+  Use V(NOLOGIN) O(role_attr_flags) to change this behaviour.
+- If you specify V(PUBLIC) as the user (role), then the privilege changes apply to all users (roles).
+  You may not specify password or role_attr_flags when the V(PUBLIC) user is specified.
 - SCRAM-SHA-256-hashed passwords (SASL Authentication) require PostgreSQL version 10 or newer.
   On the previous versions the whole hashed string is used as a password.
-- 'Working with SCRAM-SHA-256-hashed passwords, be sure you use the I(environment:) variable
+- 'Working with SCRAM-SHA-256-hashed passwords, be sure you use the O(environment): variable
   C(PGOPTIONS: "-c password_encryption=scram-sha-256") when it is not default
   for your PostgreSQL version (see the provided example).'
 - On some systems (such as AWS RDS), C(pg_authid) is not accessible, thus, the module cannot compare
   the current and desired C(password). In this case, the module assumes that the passwords are
   different and changes it reporting that the state has been changed.
-  To skip all password related checks for existing users, use I(no_password_changes=true).
-- On some systems (such as AWS RDS), C(SUPERUSER) is unavailable. This means the C(SUPERUSER) and
-  C(NOSUPERUSER) I(role_attr_flags) should not be specified to preserve idempotency and avoid
+  To skip all password related checks for existing users, use O(no_password_changes=true).
+- On some systems (such as AWS RDS), V(SUPERUSER) is unavailable. This means the V(SUPERUSER) and
+  V(NOSUPERUSER) O(role_attr_flags) should not be specified to preserve idempotency and avoid
   InsufficientPrivilege errors.
 
 attributes:

--- a/plugins/modules/postgresql_user.py
+++ b/plugins/modules/postgresql_user.py
@@ -112,7 +112,7 @@ options:
     description:
       - Determines how an SSL session is negotiated with the server.
       - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for more information on the modes.
-      - Default of C(prefer) matches libpq default.
+      - Default of V(prefer) matches libpq default.
     type: str
     default: prefer
     choices: [ allow, disable, prefer, require, verify-ca, verify-full ]


### PR DESCRIPTION
##### SUMMARY
Updated the `DOCUMENTATION` and `RETURNS` blocks to use proper Ansible semantic markup across three modules. Replaced outdated `I()` option tags with `O()`, updated boolean and specific string values to `V()`, and return values to `RV()`.

Fixes #938

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`postgresql_db`, `postgresql_user`, `postgresql_query`

##### ADDITIONAL INFORMATION
Reviewed the modules to ensure compliance with the latest Ansible semantic markup guidelines (https://docs.ansible.com/projects/ansible/latest/dev_guide/ansible_markup.html). Carefully avoided nested markup to prevent `antsibull-docs` parser crashes, while ensuring literal syntax characters and SQL commands remained as `C()`.