### PR TITLE
ci(.azure-pipelines/azure-pipelines.yml): bump rhel version for devel to 10.2 and 9.8

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -205,10 +205,10 @@ stages:
         parameters:
           testFormat: devel/{0}/1
           targets:
-            - name: RHEL 10.1
-              test: rhel/10.1
-            - name: RHEL 9.7
-              test: rhel/9.7
+            - name: RHEL 10.2
+              test: rhel/10.2
+            - name: RHEL 9.8
+              test: rhel/9.8
 
   - stage: Remote_2_21
     displayName: Remote 2.21


### PR DESCRIPTION
##### SUMMARY
As was announced in https://forum.ansible.com/t/ansible-test-devel-rhel-9-7-and-10-1-remotes-replaced-by-9-8-and-10-2/45976

ci(.azure-pipelines/azure-pipelines.yml): bump rhel version for devel to 10.2 and 9.8