### PR TITLE
refactor: replace ansible.module_utils.six with stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.20 and is scheduled for removal in 2.24.

--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -2,4 +2,4 @@
 minor_changes:
   - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
     their Python standard library equivalents. ``ansible.module_utils.six`` is
-    deprecated in ansible-core 2.20 and is scheduled for removal in 2.24.
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/modules/postgresql_db.py
+++ b/plugins/modules/postgresql_db.py
@@ -284,10 +284,10 @@ executed_commands:
 import os
 import subprocess
 import traceback
+from shlex import quote as shlex_quote
 
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves import shlex_quote
 from ansible_collections.community.postgresql.plugins.module_utils.database import (
     SQLParseError,
     check_input,


### PR DESCRIPTION
``ansible.module_utils.six`` is deprecated in ansible-core 2.21 and is scheduled for removal in 2.24. Every use of it in this collection has a direct Python 3 standard library equivalent, so this replaces them:

- ``shlex.quote``

No behaviour change on Python 3.

This intentionally drops Python 2 fallbacks from code that runs on the managed node. Python 2.7 targets were last supported by ansible-core 2.16 (EOL).

Assisted-by: Grok 4.5 (xAI)