### PR TITLE
[5.0.0] feat!: remove deprecated login, host, port, and unix_socket aliases

### DIFF
--- a/changelogs/fragments/847-remove-aliases.yml
+++ b/changelogs/fragments/847-remove-aliases.yml
@@ -1,0 +1,2 @@
+removed_features:
+- "postgresql modules - the ``login``, ``host`` and ``unix_socket`` aliases have been removed in ``community.postgresql 5.0.0``. Use the ``login_user``, ``login_host`` and ``login_unix_socket`` options instead (https://github.com/ansible-collections/community.postgresql/issues/847)."

--- a/changelogs/fragments/847-remove-aliases.yml
+++ b/changelogs/fragments/847-remove-aliases.yml
@@ -1,2 +1,2 @@
 removed_features:
-- "postgresql modules - the ``login``, ``host`` and ``unix_socket`` aliases have been removed in ``community.postgresql 5.0.0``. Use the ``login_user``, ``login_host`` and ``login_unix_socket`` options instead (https://github.com/ansible-collections/community.postgresql/issues/847)."
+- "postgresql modules - the ``login``, ``host``, ``unix_socket`` and ``port`` aliases have been removed in ``community.postgresql 5.0.0``. Use the ``login_user``, ``login_host``, ``login_unix_socket`` and ``login_port`` options instead (https://github.com/ansible-collections/community.postgresql/issues/847)."

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -35,10 +35,8 @@ options:
   login_port:
     description:
       - Database port to connect to.
-      - The C(port) alias is deprecated and will be removed in the next major release. Use C(login_port) instead.
     type: int
     default: 5432
-    aliases: [ port ]
   ssl_mode:
     description:
       - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.

--- a/plugins/doc_fragments/postgres.py
+++ b/plugins/doc_fragments/postgres.py
@@ -16,7 +16,6 @@ options:
       - The username this module should use to establish its PostgreSQL session.
     type: str
     default: postgres
-    aliases: [ login ]
   login_password:
     description:
       - The password this module should use to establish its PostgreSQL session.
@@ -28,13 +27,11 @@ options:
       - If you have connection issues when using C(localhost), try to use C(127.0.0.1) instead.
     default: ''
     type: str
-    aliases: [ host ]
   login_unix_socket:
     description:
       - Path to a Unix domain socket for local connections.
     type: str
     default: ''
-    aliases: [ unix_socket ]
   login_port:
     description:
       - Database port to connect to.

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -87,13 +87,6 @@ def postgres_common_argument_spec():
         login_port=dict(
             type='int',
             default=int(env_vars.get("PGPORT", 5432)),
-            aliases=['port'], deprecated_aliases=[
-                {
-                    'name': 'port',
-                    'version': '5.0.0',
-                    'collection_name': 'community.postgresql',
-                }
-            ],
         ),
         ssl_mode=dict(
             default='prefer',

--- a/plugins/module_utils/postgres.py
+++ b/plugins/module_utils/postgres.py
@@ -80,29 +80,10 @@ def postgres_common_argument_spec():
     return dict(
         login_user=dict(
             default='postgres' if not env_vars.get("PGUSER") else env_vars.get("PGUSER"),
-            aliases=['login'], deprecated_aliases=[
-                {
-                    'name': 'login',
-                    'version': '5.0.0',
-                    'collection_name': 'community.postgresql',
-                }
-            ],
         ),
         login_password=dict(default='', no_log=True),
-        login_host=dict(default='', aliases=['host'], deprecated_aliases=[
-            {
-                'name': 'host',
-                'version': '5.0.0',
-                'collection_name': 'community.postgresql',
-            }],
-        ),
-        login_unix_socket=dict(default='', aliases=['unix_socket'], deprecated_aliases=[
-            {
-                'name': 'unix_socket',
-                'version': '5.0.0',
-                'collection_name': 'community.postgresql',
-            }],
-        ),
+        login_host=dict(default=''),
+        login_unix_socket=dict(default=''),
         login_port=dict(
             type='int',
             default=int(env_vars.get("PGPORT", 5432)),

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -61,13 +61,7 @@ class TestPostgresCommonArgSpec():
             login_password=dict(default='', no_log=True),
             login_host=dict(default=''),
             login_unix_socket=dict(default=''),
-            login_port=dict(type='int', default=5432, aliases=['port'], deprecated_aliases=[
-                {
-                    'collection_name': 'community.postgresql',
-                    'name': 'port',
-                    'version': '5.0.0'
-                }
-            ]),
+            login_port=dict(type='int', default=5432),
             ssl_mode=dict(
                 default='prefer',
                 choices=['allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']

--- a/tests/unit/plugins/module_utils/test_postgres.py
+++ b/tests/unit/plugins/module_utils/test_postgres.py
@@ -57,28 +57,10 @@ class TestPostgresCommonArgSpec():
         The return and expected dictionaries must be compared.
         """
         expected_dict = dict(
-            login_user=dict(default='postgres', aliases=['login'], deprecated_aliases=[
-                {
-                    'name': 'login',
-                    'version': '5.0.0',
-                    'collection_name': 'community.postgresql',
-                }
-            ]),
+            login_user=dict(default='postgres'),
             login_password=dict(default='', no_log=True),
-            login_host=dict(default='', aliases=['host'], deprecated_aliases=[
-                {
-                    'name': 'host',
-                    'version': '5.0.0',
-                    'collection_name': 'community.postgresql',
-                }
-            ]),
-            login_unix_socket=dict(default='', aliases=['unix_socket'], deprecated_aliases=[
-                {
-                    'name': 'unix_socket',
-                    'version': '5.0.0',
-                    'collection_name': 'community.postgresql',
-                }
-            ]),
+            login_host=dict(default=''),
+            login_unix_socket=dict(default=''),
             login_port=dict(type='int', default=5432, aliases=['port'], deprecated_aliases=[
                 {
                     'collection_name': 'community.postgresql',


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/847

Assisted by AI