### PR TITLE
[5.0.0] remove!: remove deprecated keep_comments_at_rules option from postgresql_pg_hba

### DIFF
--- a/changelogs/fragments/810-remove_keep_comments_at_rules.yml
+++ b/changelogs/fragments/810-remove_keep_comments_at_rules.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - postgresql_pg_hba - the ``keep_comments_at_rules`` option has been removed.
+    It had no effect since it was deprecated
+    (https://github.com/ansible-collections/community.postgresql/issues/810).

--- a/plugins/modules/postgresql_pg_hba.py
+++ b/plugins/modules/postgresql_pg_hba.py
@@ -53,7 +53,7 @@ options:
     choices: [ local, host, hostnossl, hostssl, hostgssenc, hostnogssenc ]
   comment:
     description:
-      - A comment that will be placed in the same line behind the rule. See also the I(keep_comments_at_rules) parameter.
+      - A comment that will be placed in the same line behind the rule.
     type: str
     version_added: '1.5.0'
   databases:
@@ -86,12 +86,6 @@ options:
       - Ignores all errors in the existing file.
     type: bool
     default: false
-  keep_comments_at_rules:
-    description:
-      - This option has been deprecated and doesn't do anything. The module behaves as if this is C(true).
-    type: bool
-    default: true
-    version_added: '1.5.0'
   rules:
     description:
       - A list of objects, specifying rules for the pg_hba.conf. Use this to manage multiple rules at once.
@@ -199,7 +193,7 @@ EXAMPLES = '''
     databases: mydb
     state: absent
 
-- name: Grant some_user access to some_db, comment that and keep other rule-specific comments attached to their rules
+- name: Grant some_user access to some_db with a comment
   community.postgresql.postgresql_pg_hba:
     dest: /var/lib/postgres/data/pg_hba.conf
     contype: host
@@ -207,7 +201,6 @@ EXAMPLES = '''
     databases: some_db
     method: md5
     source: ::/0
-    keep_comments_at_rules: true
     comment: "this rule is an example"
 
 - name: Replace everything with a new set of rules
@@ -1282,11 +1275,6 @@ def main():
         netmask=dict(type='str'),
         # TODO this can probably be changed to dict without breaking
         options=dict(type='str'),
-        # DEPRECATED, does nothing
-        keep_comments_at_rules=dict(type='bool',
-                                    default=True,
-                                    removed_in_version="5.0.0",
-                                    removed_from_collection="community.postgresql"),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         users=dict(type='str', default='all'),
         rules=dict(type='list', elements='dict'),

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -229,7 +229,7 @@
     that:
       - '"host\tall\tall\t2001:db8::1/128\tmd5\t#comment1\nhost\tall\tall\t2001:db8::2/128\tmd5\t#comment2" == content'
 
-- name: Create a rule with the comment 'comment3' and keep_comments_at_rules
+- name: Create a rule with the comment 'comment3'
   postgresql_pg_hba:
     contype: host
     dest: /tmp/pg_hba2.conf
@@ -237,7 +237,6 @@
     address: "2001:db8::3/128"
     state: present
     comment: "comment3"
-    keep_comments_at_rules: true
 
 - name: Fetch the file
   fetch:


### PR DESCRIPTION


##### SUMMARY
Fixes https://github.com/ansible-collections/community.postgresql/issues/810

assisted by AI