### PR TITLE
ci: split Docker integration tests into two groups to prevent timeouts

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -129,7 +129,10 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}/1
+          testFormat: devel/linux/{0}
+          groups:
+            - 1
+            - 2
           targets:
             - name: Fedora 44
               test: fedora44
@@ -144,7 +147,10 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.21/linux/{0}/1
+          testFormat: 2.21/linux/{0}
+          groups:
+            - 1
+            - 2
           targets:
             - name: Fedora 43
               test: fedora43
@@ -159,7 +165,10 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.20/linux/{0}/1
+          testFormat: 2.20/linux/{0}
+          groups:
+            - 1
+            - 2
           targets:
             - name: Fedora 42
               test: fedora42
@@ -174,7 +183,10 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.19/linux/{0}/1
+          testFormat: 2.19/linux/{0}
+          groups:
+            - 1
+            - 2
           targets:
             - name: Fedora 41
               test: fedora41
@@ -189,7 +201,10 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.18/linux/{0}/1
+          testFormat: 2.18/linux/{0}
+          groups:
+            - 1
+            - 2
           targets:
             - name: Fedora 40
               test: fedora40

--- a/tests/integration/targets/postgresql_privs/aliases
+++ b/tests/integration/targets/postgresql_privs/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_publication/aliases
+++ b/tests/integration/targets/postgresql_publication/aliases
@@ -1,3 +1,3 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2
 skip/freebsd

--- a/tests/integration/targets/postgresql_query/aliases
+++ b/tests/integration/targets/postgresql_query/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_schema/aliases
+++ b/tests/integration/targets/postgresql_schema/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_script/aliases
+++ b/tests/integration/targets/postgresql_script/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_sequence/aliases
+++ b/tests/integration/targets/postgresql_sequence/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_slot/aliases
+++ b/tests/integration/targets/postgresql_slot/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_subscription/aliases
+++ b/tests/integration/targets/postgresql_subscription/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2
 skip/freebsd
 skip/rhel

--- a/tests/integration/targets/postgresql_tablespace/aliases
+++ b/tests/integration/targets/postgresql_tablespace/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_user/aliases
+++ b/tests/integration/targets/postgresql_user/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2

--- a/tests/integration/targets/postgresql_user_obj_stat_info/aliases
+++ b/tests/integration/targets/postgresql_user_obj_stat_info/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group1
+shippable/posix/group2
 skip/freebsd
 skip/rhel


### PR DESCRIPTION
## Summary
- With all 21 test targets in `shippable/posix/group1`, Ubuntu Docker CI jobs exceed the 50-minute time limit when many targets need to run (e.g., PRs touching multiple modules like #952)
- Split into group1 (10 targets) and group2 (11 targets) so each job stays under the limit
- Updated Azure Pipelines config to run both groups for each Docker target

## Test plan
- [ ] Verify CI pipeline generates jobs for both group1 and group2 per Docker target
- [ ] Verify Ubuntu Docker jobs complete within the 50-minute limit
- [ ] Verify Fedora and RHEL jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)